### PR TITLE
Differentiate docker vs local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,32 +10,53 @@ This project uses [uv](https://github.com/astral-sh/uv).
 
 Thunderbird Accounts is a Django 5.1 application. Please read up on Django before diving in.
 
-## Setup / Running
+Docker is the recommended way to run the server, though you have the option to run it locally.
 
-### Installing
 
-Ensure that uv is installed, and then run:
+## Shared setup
+
+Whether you're running the server via Docker or locally, you'll need to set up your `.env` file and copy the example Stalwart config.
+
+### Create the .env file
+
+Start from the `.env.example` file to create your dev and test `.env` files:
+
 ```shell
-uv sync
+cp .env.example .env
+cp .env.example .env.test
 ```
 
-### Using the example config for Stalwart
+In `.env.test`, set `APP_ENV=test`
+
+#### Get the `FXA_CLIENT_ID` and `FXA_SECRET`
+
+These can be found in the Services 1password vault in the item named "FXA stage application keys for TB Accounts".
+
+#### Generate `SECRET` keys
+
+Generate a different, random secrets for `SECRET_KEY` and `LOGIN_CODE_SECRET` using this command:
+
+```shell
+openssl rand -hex 16
+```
+
+### Use the example config for Stalwart
 
 Note: Do not use this for production environments.
 
 Copy config.toml.example to `mail/etc/config.toml` before first run.
 
-The default admin password should be `accounts`. 
-
-### Creating a local SuperUser
-
-Run the following and follow the terminal prompts:
-
 ```shell
-./manage.py createsuperuser
+mkdir -p mail/etc && cp config.toml.example mail/etc/config.toml
 ```
 
-### Running in docker (recommended)
+The default admin password should be `accounts`.
+
+
+## Running the server in Docker (recommended)
+
+
+### Start the Docker containers
 
 ```shell
 docker-compose up --build -V
@@ -43,13 +64,39 @@ docker-compose up --build -V
 
 A server will be available at [http://localhost:8087/](http://localhost:8087/)
 
-### Running local dev server
+### Generate an FXA Encryption Secret
+
+
+Generate one with this command:
 
 ```shell
-./manage.py runserver 0.0.0.0:8087
+docker compose exec backend uv run manage.py generate_key
 ```
 
-## Exposed dev ports
+Use this value for the `FXA_ENCRYPT_SECRET` variable in your `.env`.
+
+Then, restart your docker containers
+
+
+### Create a superuser
+
+Run the this command and follow the terminal prompts:
+
+```shell
+docker compose exec backend uv run manage.py createsuperuser
+```
+
+When asked, enter your FXA email address.
+
+### Make an existing user a superuser
+
+If you have already attempted to login to the admin via FXA and gotten a `401 Unauthorized`, run this command:
+
+```shell
+docker compose exec backend uv run manage.py make_superuser <fxa_email_address>
+```
+
+### Exposed dev ports
 
 For development the following ports are exposed:
 
@@ -63,6 +110,45 @@ For development the following ports are exposed:
 | Mailpit (SMTP)   | 1026                   | 1024                   |
 
 (Note: You're the host computer. So connect to postgres via port 5433!)
+
+
+## Running the server locally
+
+### Installation
+
+Ensure that uv is installed, and then run:
+```shell
+uv sync
+```
+
+The default admin password should be `accounts`.
+
+### Create a superuser
+
+Run the following and follow the terminal prompts:
+
+```shell
+./manage.py createsuperuser
+```
+
+When asked, enter your FXA email address.
+
+### Start the local dev server
+
+```shell
+./manage.py runserver 0.0.0.0:8087
+```
+
+
+### Make an existing user a superuser
+
+If you have already attempted to login to the admin via FXA and gotten a `401 Unauthorized`, run this command:
+
+```shell
+./manage.py make_superuser <fxa_email_address>
+```
+
+
 
 ## Creating additional apps
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ After making this change, restart your docker containers.
 Run the this command and follow the terminal prompts:
 
 ```shell
-docker compose exec backend uv run manage.py createsuperuser
+docker compose exec backend uv run manage.py createsuperuser --email <fxa_email_address>
 ```
 
 When asked, enter your FXA email address.
@@ -126,7 +126,7 @@ The default admin password should be `accounts`.
 Run the following and follow the terminal prompts:
 
 ```shell
-./manage.py createsuperuser
+./manage.py createsuperuser --email <fxa_email_address>
 ```
 
 When asked, enter your FXA email address.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ Run the following and follow the terminal prompts:
 
 When asked, enter your FXA email address.
 
+### Generate an FXA Encryption Secret
+
+
+Generate one with this command:
+
+```shell
+./manage.py generate_key
+```
+
+Use this value for the `FXA_ENCRYPT_SECRET` variable in your `.env`.
+
+
 ### Start the local dev server
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ In `.env.test`, set `APP_ENV=test`
 
 These can be found in the Services 1password vault in the item named "FXA stage application keys for TB Accounts".
 
-#### Generate `SECRET` keys
-
-Generate a different, random secrets for `SECRET_KEY` and `LOGIN_CODE_SECRET` using this command:
-
-```shell
-openssl rand -hex 16
-```
-
 ### Use the example config for Stalwart
 
 Note: Do not use this for production environments.
@@ -64,18 +56,24 @@ docker-compose up --build -V
 
 A server will be available at [http://localhost:8087/](http://localhost:8087/)
 
-### Generate an FXA Encryption Secret
+### Generate `SECRET` keys
 
 
-Generate one with this command:
+Generate a random secret with this command:
 
 ```shell
 docker compose exec backend uv run manage.py generate_key
 ```
 
-Use this value for the `FXA_ENCRYPT_SECRET` variable in your `.env`.
+Use this value for the following variables in your `.env` file:
 
-Then, restart your docker containers
+- `FXA_ENCRYPT_SECRET`
+- `SECRET_KEY`
+- `LOGIN_CODE_SECRET`
+
+It's fine to use the same key for all three; this is only for development.
+
+After making this change, restart your docker containers.
 
 
 ### Create a superuser
@@ -133,17 +131,22 @@ Run the following and follow the terminal prompts:
 
 When asked, enter your FXA email address.
 
-### Generate an FXA Encryption Secret
+### Generate `SECRET` keys
 
 
-Generate one with this command:
+Generate a random secret with this command:
 
 ```shell
 ./manage.py generate_key
 ```
 
-Use this value for the `FXA_ENCRYPT_SECRET` variable in your `.env`.
+Use this value for the following variables in your `.env` file:
 
+- `FXA_ENCRYPT_SECRET`
+- `SECRET_KEY`
+- `LOGIN_CODE_SECRET`
+
+It's fine to use the same key for all three; this is only for development.
 
 ### Start the local dev server
 

--- a/src/thunderbird_accounts/authentication/management/commands/generate_key.py
+++ b/src/thunderbird_accounts/authentication/management/commands/generate_key.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand, CommandError
+from cryptography.fernet import Fernet
+
+
+class Command(BaseCommand):
+    help = 'Generate a key of 32 url-safe base64-encoded bytes.'
+
+    def handle(self, *args, **options):
+        key = Fernet.generate_key()
+        self.stdout.write(self.style.SUCCESS(key.decode("utf-8")))

--- a/src/thunderbird_accounts/authentication/management/commands/make_superuser.py
+++ b/src/thunderbird_accounts/authentication/management/commands/make_superuser.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand, CommandError
+from thunderbird_accounts.authentication.models import User
+
+
+class Command(BaseCommand):
+    help = 'For each email address provided, make user a superuser'
+
+    def add_arguments(self, parser):
+        parser.add_argument('emails', nargs='+', type=str)
+
+    def handle(self, *args, **options):
+        emails = options['emails']
+        for email in emails:
+            u = None
+            try:
+                u = User.objects.get(email=email)
+            except User.DoesNotExist:
+                raise CommandError(f'User {email} does not exist')
+            if u:
+                u.is_superuser = True
+                u.is_staff = True
+                u.save()
+
+            self.stdout.write(self.style.SUCCESS(f'User {email} is now a superuser'))


### PR DESCRIPTION
Closes #8 

* adds management command for generating Fernet key
* adds management command for making an existing user a superuser
* README divides setup instructions into three sections:
  * shared/common steps
  * docker-specific steps
  * steps for running the server locally
* where applicable, README shows usage of new management commands