### PR TITLE
Fix broken local tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ COPY scripts/dev-entry.sh scripts/dev-entry.sh
 COPY static ./static/
 COPY templates ./templates/
 
+# Required in order to run tests against local dev
+COPY .env.test .
+RUN ln -s /app/thunderbird_accounts src/thunderbird_accounts
+
 # Add our source code
 ADD src/thunderbird_accounts ./src/thunderbird_accounts
 


### PR DESCRIPTION
This [previous PR](https://github.com/thunderbird/thunderbird-accounts/pull/19/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) made some Dockerfile changes which inadvertently broke running the tests against your local dev env. The `docker compose exec backend uv run python manage.py test` cmd fails with settings.SECRET_KEY is not set error.

Add back some of the Dockerfile commands to fix this.