### PR TITLE
Add `UserCacheSerializer` and use that before placing user data in shared cache. (Fixes #29)

### DIFF
--- a/src/thunderbird_accounts/authentication/serializers.py
+++ b/src/thunderbird_accounts/authentication/serializers.py
@@ -16,3 +16,60 @@ class UserProfileSerializer(serializers.ModelSerializer):
             'created_at',
             'updated_at',
         ]
+
+
+class UserCacheSerializer(serializers.ModelSerializer):
+    """
+    Version 1
+    Formats a user model to the json format below:
+    {
+        "_version": "1",
+        "uuid": "7baaf446-d747-4b7c-ae87-1aab58a9fcd9",
+        "username": "My Username",
+        "display_name": "My Display Name",
+        "full_name": "my full name",
+        "email": "my@email.address",
+        "fxa_id": "123abc",
+        "language": "en",
+        "avatar_url": "https://coolcatpics.local/cat.png",
+        "timezone": "America/Vancouver",
+        "date_joined": "2024-11-13T16:57:11.968Z",
+        "last_login": "2024-11-13T16:57:11.968Z",
+        "created_at": "2024-11-13T16:57:11.968Z",
+        "updated_at": "2024-11-13T16:57:11.968Z",
+        "access": ["apmt", "send", "assist"]
+    }"""
+
+    # Schema version
+    _version = serializers.IntegerField(default=1, read_only=True)
+    # This is hard-coded for now but it should be a user-level permission
+    access = serializers.ListField(default=['appointment', 'assist', 'send'], read_only=True)
+    full_name = serializers.SerializerMethodField(method_name='get_full_name', read_only=True)
+
+    def get_full_name(self, instance: User):
+        return ' '.join([instance.first_name, instance.last_name]).strip()
+
+    class Meta:
+        model = User
+        fields = [
+            # Schema-specific
+            '_version',
+            # General
+            'uuid',
+            'username',
+            'display_name',
+            'full_name',
+            'email',
+            'fxa_id',
+            # Pref fields
+            'language',
+            'avatar_url',
+            'timezone',
+            # ACL
+            'access',
+            # Date fields
+            'date_joined',
+            'last_login',
+            'created_at',
+            'updated_at',
+        ]

--- a/src/thunderbird_accounts/authentication/views.py
+++ b/src/thunderbird_accounts/authentication/views.py
@@ -34,12 +34,7 @@ def _set_user_session(request: AccountsHttpRequest, user: User):
     # Save the current session key so we can remove it later if they log out.
     UserSession.objects.update_or_create(user_id=user.uuid, session_key=session_key)
 
-    user_obj = serialize(
-        'json',
-        [
-            user,
-        ],
-    )
+    user_obj = UserCacheSerializer(user).data
     caches['shared'].set(f'{USER_SESSION_CACHE_KEY}.{session_key}', user_obj)
 
 


### PR DESCRIPTION
I had to reduce the underscores for meta data to just one, as two induces a django relationship lookup? Weird.

Access is hardcoded until I figure out a good way to store it in the db.