### PR TITLE
Adds beta wait-list signup page

### DIFF
--- a/assets/css/wait-list.css
+++ b/assets/css/wait-list.css
@@ -45,13 +45,13 @@ header {
 .container {
   margin: 0 auto;
   width: 100%;
-  max-width: 600px;
+  max-width: 40rem;
   padding-left: 1rem;
   padding-right: 1rem;
 }
 
 .callout {
-  border: 1px solid var(--border-color);
+  border: 0.063rem solid var(--border-color);
   border-radius: var(--border-radius);
   padding: 0.5rem;
   margin-top: 1.5rem;
@@ -97,7 +97,7 @@ input[type="email"] {
   font-size: 0.875rem;
   color: #9ba2ae;
   background-color: var(--background-color);
-  border: 1px solid var(--border-color);
+  border: 0.063rem solid var(--border-color);
   border-radius: var(--border-radius);
   padding: 0.15rem;
   padding-left: 0.5rem;

--- a/assets/css/wait-list.css
+++ b/assets/css/wait-list.css
@@ -1,0 +1,115 @@
+@import "fonts.css";
+
+:root {
+  --border-color: #273347;
+  --background-color: #0f172a;
+  --border-radius: 4px;
+  font-size: 16px;
+}
+
+*,
+*::after,
+*::before {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+html,
+body {
+  background-color: var(--background-color);
+  color: white;
+
+  height: 100%;
+  width: 100%;
+
+  font-family: "Inter", sans-serif;
+  font-size: 1rem;
+}
+
+header {
+  padding-top: 1.75rem;
+  margin-bottom: 3rem;
+  text-align: center;
+
+  h1 {
+    margin-top: 0.75rem;
+  }
+
+  h2 {
+    margin-top: 0.75rem;
+    color: #909fb4;
+    font-size: 1rem;
+    font-weight: 300;
+  }
+}
+.container {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 600px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.callout {
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+code {
+  color: #5695e1;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.output code {
+  color: #bbc7d3;
+  font-size: 0.7rem;
+}
+
+.form-container {
+  border-radius: var(--border-radius);
+  background-color: #1e293b;
+  padding: 1.25rem 1rem;
+  margin-top: 1.5rem;
+
+  h3 {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.form-inputs {
+  display: flex;
+  flex-direction: row;
+  gap: 0.75rem;
+
+  > :first-child {
+    flex: 1;
+  }
+
+  > :last-child {
+    flex: 0;
+  }
+}
+
+input[type="email"] {
+  font-size: 0.875rem;
+  color: #9ba2ae;
+  background-color: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: 0.15rem;
+  padding-left: 0.5rem;
+  line-height: 1.75rem;
+  max-width: 100%;
+}
+
+input[type="submit"] {
+  background-color: #0060df;
+  border-width: 0;
+  color: white;
+  padding: 0 1rem;
+  border-radius: var(--border-radius);
+  font-size: 0.875rem;
+}

--- a/templates/mail/wait-list.html
+++ b/templates/mail/wait-list.html
@@ -12,114 +12,96 @@
   <link rel="stylesheet" href="{% static 'css/wait-list.css' %}">
 </head>
 <body>
-  <header class="header">
-    <span>
-      <code>
-        <pre>$ thunderbird --version=pro</pre>
-      </code>
-    </span>
-    <h1>For Those Who Know</h1>
-    <h2>The power tool for digital communication</h2>
-  </header>
-  <section>
-    <span>
-      <code>
-        <pre>&gt; Features</pre>
-      </code>
-    </span>
-    <span class="output">
-      <code>
-        <pre>email-service + appointment + send + assist</pre>
-      </code>
-    </span>
-  </section>
-  <section>
-    <span>
-      <code>
-        <pre>&gt; Philosophy</pre>
-      </code>
-    </span>
-    <span class="output">
-      <code>
-        <pre>open-source && privacy-focused && user-controlled</pre>
-      </code>
-    </span>
-  </section>
-  <section>
-    <span>
-      <code>
-        <pre>&gt; Status</pre>
-      </code>
-    </span>
-    <span class="output">
-      <code>
-        <pre>beta-signup.accepting(true)</pre>
-      </code>
-    </span>
-  </section>
   <div class="container">
-    <h3>Initialize Beta Access</h3>
-    <div id="mc_embed_shell">
-      <div id="mc_embed_signup">
-        <form
-          action="{{form_action}}"
-          method="post"
-          id="mc-embedded-subscribe-form"
-          name="mc-embedded-subscribe-form"
-          class="validate"
-          target="_self"
-          novalidate=""
-        >
-          <div id="mc_embed_signup_scroll">
-            <div class="indicates-required">
-              <span class="asterisk">*</span> indicates required
+    <header class="header">
+      <span>
+        <pre><code>$ thunderbird --version=pro</code></pre>
+      </span>
+      <h1>For Those Who Know</h1>
+      <h2>The power tool for digital communication</h2>
+    </header>
+    <section class="callout">
+      <span>
+        <code><pre>&gt; features</pre></code>
+      </span>
+      <span class="output">
+        <pre><code>[email_service, appointment, send, assist]</code></pre>
+      </span>
+    </section>
+    <section class="callout">
+      <span>
+        <pre><code>&gt; philosophy</code></pre>
+      </span>
+      <span class="output">
+        <pre><code>open_source & privacy_focused & user_controlled</code></pre>
+      </span>
+    </section>
+    <section class="callout">
+      <span>
+        <pre><code>&gt; status</code></pre>
+      </span>
+      <span class="output">
+        <pre><code>beta_signup.is_open=true</code></pre>
+      </span>
+    </section>
+    <div class="form-container">
+      <h3>Initialize Beta Access</h3>
+      <div id="mc_embed_shell">
+        <div id="mc_embed_signup">
+          <form
+            action="{{form_action}}"
+            method="post"
+            id="mc-embedded-subscribe-form"
+            name="mc-embedded-subscribe-form"
+            class="validate"
+            target="_self"
+            novalidate=""
+          >
+            <div id="mc_embed_signup_scroll">
+              <div class="mc-field-group form-inputs">
+                <input
+                  type="email"
+                  name="EMAIL"
+                  class="required email"
+                  id="mce-EMAIL"
+                  required=""
+                  value=""
+                  placeholder="email@domain.com"
+                />
+                <input
+                  type="submit"
+                  name="subscribe"
+                  id="mc-embedded-subscribe"
+                  class="button"
+                  value="Submit &#8594;"
+                />
+              </div>
+              <div hidden="">
+                <input type="hidden" name="tags" value="10526643" />
+              </div>
+              <div id="mce-responses" class="clear">
+                <div
+                  class="response"
+                  id="mce-error-response"
+                  style="display: none"
+                ></div>
+                <div
+                  class="response"
+                  id="mce-success-response"
+                  style="display: none"
+                ></div>
+              </div>
+              <div style="position: absolute; left: -5000px" aria-hidden="true">
+                <input
+                  type="text"
+                  name="b_f8051cc8637cf3ff79661f382_a508104cf8"
+                  tabindex="-1"
+                  value=""
+                />
+              </div>
             </div>
-            <div class="mc-field-group">
-              <label for="mce-EMAIL"
-                >Email Address <span class="asterisk">*</span></label
-              ><input
-                type="email"
-                name="EMAIL"
-                class="required email"
-                id="mce-EMAIL"
-                required=""
-                value=""
-              />
-            </div>
-            <div hidden="">
-              <input type="hidden" name="tags" value="10526643" />
-            </div>
-            <div id="mce-responses" class="clear">
-              <div
-                class="response"
-                id="mce-error-response"
-                style="display: none"
-              ></div>
-              <div
-                class="response"
-                id="mce-success-response"
-                style="display: none"
-              ></div>
-            </div>
-            <div style="position: absolute; left: -5000px" aria-hidden="true">
-              <input
-                type="text"
-                name="b_f8051cc8637cf3ff79661f382_a508104cf8"
-                tabindex="-1"
-                value=""
-              />
-            </div>
-            <div class="clear">
-              <input
-                type="submit"
-                name="subscribe"
-                id="mc-embedded-subscribe"
-                class="button"
-                value="Submit &#8594;"
-              />
-            </div>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/mail/wait-list.html
+++ b/templates/mail/wait-list.html
@@ -1,71 +1,127 @@
-{% extends 'base.html' %}
-{% block body %}
-<h1>Join the waitlist</h1>
-<div id="mcWaitlistForm">
-  <!-- Begin Mailchimp Waitlist Form -->
-  <div id="mc_embed_shell">
-    <div id="mc_embed_signup">
-      <form
-        action="{{form_action}}"
-        method="post"
-        id="mc-embedded-subscribe-form"
-        name="mc-embedded-subscribe-form"
-        class="validate"
-        target="_self"
-        novalidate=""
-      >
-        <div id="mc_embed_signup_scroll">
-          <div class="indicates-required">
-            <span class="asterisk">*</span> indicates required
+{% load helpers %}
+{% load static %}
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title></title>
+  <link rel="stylesheet" href="{% static 'css/wait-list.css' %}">
+</head>
+<body>
+  <header class="header">
+    <span>
+      <code>
+        <pre>$ thunderbird --version=pro</pre>
+      </code>
+    </span>
+    <h1>For Those Who Know</h1>
+    <h2>The power tool for digital communication</h2>
+  </header>
+  <section>
+    <span>
+      <code>
+        <pre>&gt; Features</pre>
+      </code>
+    </span>
+    <span class="output">
+      <code>
+        <pre>email-service + appointment + send + assist</pre>
+      </code>
+    </span>
+  </section>
+  <section>
+    <span>
+      <code>
+        <pre>&gt; Philosophy</pre>
+      </code>
+    </span>
+    <span class="output">
+      <code>
+        <pre>open-source && privacy-focused && user-controlled</pre>
+      </code>
+    </span>
+  </section>
+  <section>
+    <span>
+      <code>
+        <pre>&gt; Status</pre>
+      </code>
+    </span>
+    <span class="output">
+      <code>
+        <pre>beta-signup.accepting(true)</pre>
+      </code>
+    </span>
+  </section>
+  <div class="container">
+    <h3>Initialize Beta Access</h3>
+    <div id="mc_embed_shell">
+      <div id="mc_embed_signup">
+        <form
+          action="{{form_action}}"
+          method="post"
+          id="mc-embedded-subscribe-form"
+          name="mc-embedded-subscribe-form"
+          class="validate"
+          target="_self"
+          novalidate=""
+        >
+          <div id="mc_embed_signup_scroll">
+            <div class="indicates-required">
+              <span class="asterisk">*</span> indicates required
+            </div>
+            <div class="mc-field-group">
+              <label for="mce-EMAIL"
+                >Email Address <span class="asterisk">*</span></label
+              ><input
+                type="email"
+                name="EMAIL"
+                class="required email"
+                id="mce-EMAIL"
+                required=""
+                value=""
+              />
+            </div>
+            <div hidden="">
+              <input type="hidden" name="tags" value="10526643" />
+            </div>
+            <div id="mce-responses" class="clear">
+              <div
+                class="response"
+                id="mce-error-response"
+                style="display: none"
+              ></div>
+              <div
+                class="response"
+                id="mce-success-response"
+                style="display: none"
+              ></div>
+            </div>
+            <div style="position: absolute; left: -5000px" aria-hidden="true">
+              <input
+                type="text"
+                name="b_f8051cc8637cf3ff79661f382_a508104cf8"
+                tabindex="-1"
+                value=""
+              />
+            </div>
+            <div class="clear">
+              <input
+                type="submit"
+                name="subscribe"
+                id="mc-embedded-subscribe"
+                class="button"
+                value="Submit &#8594;"
+              />
+            </div>
           </div>
-          <div class="mc-field-group">
-            <label for="mce-EMAIL"
-              >Email Address <span class="asterisk">*</span></label
-            ><input
-              type="email"
-              name="EMAIL"
-              class="required email"
-              id="mce-EMAIL"
-              required=""
-              value=""
-            />
-          </div>
-          <div hidden="">
-            <input type="hidden" name="tags" value="10526643" />
-          </div>
-          <div id="mce-responses" class="clear">
-            <div
-              class="response"
-              id="mce-error-response"
-              style="display: none"
-            ></div>
-            <div
-              class="response"
-              id="mce-success-response"
-              style="display: none"
-            ></div>
-          </div>
-          <div style="position: absolute; left: -5000px" aria-hidden="true">
-            <input
-              type="text"
-              name="b_f8051cc8637cf3ff79661f382_a508104cf8"
-              tabindex="-1"
-              value=""
-            />
-          </div>
-          <div class="clear">
-            <input
-              type="submit"
-              name="subscribe"
-              id="mc-embedded-subscribe"
-              class="button"
-              value="Subscribe"
-            />
-          </div>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
   </div>
-  <!--End mc_embed_waitlist-->
-</div>
-{% endblock %}
+</body>
+</html>

--- a/templates/mail/wait-list.html
+++ b/templates/mail/wait-list.html
@@ -22,7 +22,7 @@
     </header>
     <section class="callout">
       <span>
-        <code><pre>&gt; features</pre></code>
+        <code><pre>&gt;&gt; features</pre></code>
       </span>
       <span class="output">
         <pre><code>[email_service, appointment, send, assist]</code></pre>
@@ -30,7 +30,7 @@
     </section>
     <section class="callout">
       <span>
-        <pre><code>&gt; philosophy</code></pre>
+        <pre><code>&gt;&gt; philosophy</code></pre>
       </span>
       <span class="output">
         <pre><code>open_source & privacy_focused & user_controlled</code></pre>
@@ -38,7 +38,7 @@
     </section>
     <section class="callout">
       <span>
-        <pre><code>&gt; status</code></pre>
+        <pre><code>&gt;&gt; status</code></pre>
       </span>
       <span class="output">
         <pre><code>beta_signup.is_open=true</code></pre>


### PR DESCRIPTION
Closes #21 

Adds a mobile-friendly (and reasonably desktop-friendly) version of the beta wait-list signup page, per [the document from marcom](https://docs.google.com/document/d/1jhjCwujcY3ufh0rpD_NpJEsmfGlsC6JcyGOeDNbgMqk/edit?tab=t.72ouhlqs1g3n)

![Screenshot_20250228_201346](https://github.com/user-attachments/assets/480c503f-b10c-4b4d-bfaf-4ec74ea7f156)

