### PR TITLE
Hook up some CSRF settings to env (Fixes #47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ ADMIN_WEBSITE=https://www.thunderbird.net
 ADMIN_CONTACT=dummy@example.org
 SUPPORT_CONTACT=dummy@example.org
 
+CSRF_SECURE=False
+CSRF_HTTPONLY=False
+# None value for this field
+CSRF_TRUSTED_ORIGINS
+
 # From Appointment
 FXA_OPEN_ID_CONFIG=https://accounts.stage.mozaws.net/.well-known/openid-configuration
 FXA_OAUTH_SERVER_URL=https://oauth.stage.mozaws.net/v1

--- a/.env.test
+++ b/.env.test
@@ -9,6 +9,11 @@ ADMIN_WEBSITE=https://www.thunderbird.net
 ADMIN_CONTACT=dummy@example.org
 SUPPORT_CONTACT=dummy@example.org
 
+CSRF_SECURE=False
+CSRF_HTTPONLY=False
+# None value for this field
+CSRF_TRUSTED_ORIGINS
+
 # From Appointment
 FXA_OPEN_ID_CONFIG=https://accounts.stage.mozaws.net/.well-known/openid-configuration
 FXA_OAUTH_SERVER_URL=https://oauth.stage.mozaws.net/v1

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -187,6 +187,12 @@ resources:
                 value: rediss://master.accounts-stage-redis.7syyoy.euc1.cache.amazonaws.com:6379
               - name: SUPPORT_CONTACT
                 value: dummy@example.org
+              - name: CSRF_SECURE
+                value: 'True'
+              - name: CSRF_HTTPONLY
+                value: 'True'
+              - name: CSRF_TRUSTED_ORIGINS
+                value: 'https://accounts-stage.tb.pro'
 
   # tb:ec2:SshableInstance:
   #   jumphost:

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -77,6 +77,12 @@ WAIT_LIST_FORM_ACTION: str = os.getenv('WAIT_LIST_FORM_ACTION')
 
 ALLOWED_HOSTS = [host for host in os.getenv('ALLOWED_HOSTS', '').split(',') if host]
 
+# Settings for CSRF cookie.
+CSRF_COOKIE_SECURE = os.getenv('CSRF_SECURE')
+CSRF_COOKIE_HTTPONLY = os.getenv('CSRF_HTTPONLY')
+if os.getenv('CSRF_TRUSTED_ORIGINS', ''):
+    CSRF_TRUSTED_ORIGINS = [host for host in os.getenv('CSRF_TRUSTED_ORIGINS', '').split(',') if host]
+
 # For local docker usage
 if DEBUG:
     ALLOWED_HOSTS += ['localhost', 'accounts']

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -78,8 +78,8 @@ WAIT_LIST_FORM_ACTION: str = os.getenv('WAIT_LIST_FORM_ACTION')
 ALLOWED_HOSTS = [host for host in os.getenv('ALLOWED_HOSTS', '').split(',') if host]
 
 # Settings for CSRF cookie.
-CSRF_COOKIE_SECURE = os.getenv('CSRF_SECURE')
-CSRF_COOKIE_HTTPONLY = os.getenv('CSRF_HTTPONLY')
+CSRF_COOKIE_SECURE: bool = os.getenv('CSRF_SECURE') == 'True'
+CSRF_COOKIE_HTTPONLY: bool = os.getenv('CSRF_HTTPONLY') == 'True'
 if os.getenv('CSRF_TRUSTED_ORIGINS', ''):
     CSRF_TRUSTED_ORIGINS = [host for host in os.getenv('CSRF_TRUSTED_ORIGINS', '').split(',') if host]
 


### PR DESCRIPTION
I think we'll only need the one value. I'd make these the same as allowed_hosts but this requires https:// (or http://) in the value. 