### PR TITLE
Expand the E2E test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,6 @@ To run tests for a specific module:
 ```shell
 docker compose exec backend uv run manage.py test thunderbird_accounts.client.tests
 ```
+
+## Running the E2E tests
+Please see the [E2E tests README](./test/e2e/README.md).

--- a/assets/app/vue/components/AccountInfoForm.vue
+++ b/assets/app/vue/components/AccountInfoForm.vue
@@ -30,8 +30,8 @@ const onDeleteAccount = () => {
     </div>
     <div>
       <h3>Delete Account</h3>
-      <p>You can delete your account and all associated information (including your email address, and emails!)</p>
-      <secondary-button @click.capture="onDeleteAccount">Delete Account</secondary-button>
+      <p data-testid="account-info-delete-account-description">You can delete your account and all associated information (including your email address, and emails!)</p>
+      <secondary-button data-testid="account-info-delete-account-btn" @click.capture="onDeleteAccount">Delete Account</secondary-button>
     </div>
   </div>
 </template>

--- a/assets/app/vue/components/AccountInfoForm.vue
+++ b/assets/app/vue/components/AccountInfoForm.vue
@@ -25,8 +25,8 @@ const onDeleteAccount = () => {
     <notice-bar type="error" v-if="errorText">{{ errorText }}</notice-bar>
     <div v-if="!hasAccount">
       <h3>Email</h3>
-      <p>You have not setup your email address. Click below to get started!</p>
-      <primary-button @click.capture="onSetUp">Set Up</primary-button>
+      <p data-testid="account-info-no-email-setup-text">You have not setup your email address. Click below to get started!</p>
+      <primary-button data-testid="account-info-email-setup-btn" @click.capture="onSetUp">Set Up</primary-button>
     </div>
     <div>
       <h3>Delete Account</h3>

--- a/assets/app/vue/components/SelfServeForm.vue
+++ b/assets/app/vue/components/SelfServeForm.vue
@@ -68,8 +68,8 @@ const onDeleteAppPassword = async (evt) => {
         <h3>Existing App Passwords</h3>
         <form id="delete-app-password-form" ref="deleteAppPasswordFormRef" method="post" action="/self-serve/app-passwords/remove">
           <ul class="app-passwords" v-if="appPasswords?.length > 0">
-            <li class="app-password" v-for="password in appPasswords" :key="password" :data-testid="'app-passwords-existing-password-' + t(password)">{{ password }}
-              <secondary-button size="small" :value="password" @click.capture="onDeleteAppPassword" :data-testid="'app-passwords-delete-password-btn-' + t(password)" :aria-label="`Delete ${password} app password.`">Delete</secondary-button>
+            <li class="app-password" v-for="password in appPasswords" :key="password" :data-testid="'app-passwords-existing-password-' + password">{{ password }}
+              <secondary-button size="small" :value="password" @click.capture="onDeleteAppPassword" :data-testid="'app-passwords-delete-app-password-btn-' + password" :aria-label="`Delete ${password} app password.`">Delete</secondary-button>
             </li>
           </ul>
           <p v-else>You don't have any App Passwords.</p>

--- a/assets/app/vue/components/SelfServeForm.vue
+++ b/assets/app/vue/components/SelfServeForm.vue
@@ -62,14 +62,14 @@ const onDeleteAppPassword = async (evt) => {
 <template>
   <div class="form-container">
     <notice-bar type="error" v-if="errorText">{{ errorText }}</notice-bar>
-    <p>Create App Passwords to login to mail clients like Thunderbird! You cannot view the password after creating it, so make sure to save it.</p>
+    <p data-testid="app-passwords-create-description">Create App Passwords to login to mail clients like Thunderbird! You cannot view the password after creating it, so make sure to save it.</p>
     <div class="container">
       <div>
         <h3>Existing App Passwords</h3>
         <form id="delete-app-password-form" ref="deleteAppPasswordFormRef" method="post" action="/self-serve/app-passwords/remove">
           <ul class="app-passwords" v-if="appPasswords?.length > 0">
-            <li class="app-password" v-for="password in appPasswords" :key="password">{{ password }}
-              <secondary-button size="small" :value="password" @click.capture="onDeleteAppPassword" :aria-label="`Delete ${password} app password.`">Delete</secondary-button>
+            <li class="app-password" v-for="password in appPasswords" :key="password" :data-testid="'app-passwords-existing-password-' + t(password)">{{ password }}
+              <secondary-button size="small" :value="password" @click.capture="onDeleteAppPassword" :data-testid="'app-passwords-delete-password-btn-' + t(password)" :aria-label="`Delete ${password} app password.`">Delete</secondary-button>
             </li>
           </ul>
           <p v-else>You don't have any App Passwords.</p>
@@ -78,9 +78,9 @@ const onDeleteAppPassword = async (evt) => {
       <div>
         <h3>Add a new App Password</h3>
         <form id="new-app-password-form" ref="newAppPasswordFormRef" name="addForm" method="post" action="/self-serve/app-passwords/add" v-if="appPasswords?.length === 0">
-          <text-input name="name">Name</text-input>
-          <text-input name="password" type="password">Password</text-input>
-          <primary-button @click.capture="onAddAppPassword">Add</primary-button>
+          <text-input name="name" data-testid="app-passwords-add-name-input">Name</text-input>
+          <text-input name="password" data-testid="app-passwords-add-password-input" type="password">Password</text-input>
+          <primary-button data-testid="app-passwords-add-btn" @click.capture="onAddAppPassword">Add</primary-button>
           <csrf-token></csrf-token>
         </form>
         <p v-else>You have reached the maximum number of App Passwords you can create.</p>

--- a/assets/app/vue/components/SignUpFlowForm.vue
+++ b/assets/app/vue/components/SignUpFlowForm.vue
@@ -26,17 +26,16 @@ const onSubmit = () => {
   <div class="form-container">
     <notice-bar type="error" v-if="errorText">{{ errorText }}</notice-bar>
     <div class="container">
-      <p>Thank you for your interest in signing up. Please enter a desired email address, and select a domain below.</p>
+      <p data-testid="sign-up-description-text">Thank you for your interest in signing up. Please enter a desired email address, and select a domain below.</p>
       <form id="sign-up-flow-form" ref="signUpFlow" method="POST" action="/sign-up/submit">
         <div class="split-input">
-          <text-input name="email_address" required="required">Email Address</text-input>
-          @
-          <select-input name="email_domain" :options="availableDomains" :model-value="selectedDomain" required="required">Domain</select-input>
+          <text-input name="email_address" required="required" data-testid="sign-up-email-address-input">Email Address</text-input>
+          <select-input name="email_domain" :options="availableDomains" :model-value="selectedDomain" required="required" data-testid="sign-up-domain-input">Domain</select-input>
         </div>
-        <text-input :model-value="userLoginEmail" disabled="disabled" help="You'll use this email to login via Mozilla Accounts to our self-serve page and to your mail client">Login Username / Email</text-input>
-        <text-input name="app_password" required="required" type="password" help="You'll use this password sign-in to your mail client">App Password</text-input>
+        <text-input :model-value="userLoginEmail" disabled="disabled" help="You'll use this email to login via Mozilla Accounts to our self-serve page and to your mail client" data-testid="sign-up-login-username-input">Login Username / Email</text-input>
+        <text-input name="app_password" required="required" type="password" help="You'll use this password sign-in to your mail client" data-testid="sign-up-app-password-input">App Password</text-input>
         <br/>
-        <primary-button @click.capture="onSubmit" id="sign-up-btn">Sign Up</primary-button>
+        <primary-button @click.capture="onSubmit" id="sign-up-btn" data-testid="sign-up-sign-up-btn">Sign Up</primary-button>
         <csrf-token></csrf-token>
       </form>
     </div>

--- a/templates/mail/self-serve/connection-info.html
+++ b/templates/mail/self-serve/connection-info.html
@@ -8,30 +8,30 @@
       <h3>Receiving Email</h3>
       <div>
         <h4 id="imap">IMAP</h4>
-        <p><b>Server Name:</b> {{ IMAP.HOST }}</p>
-        <p><b>Server Port:</b> {{ IMAP.PORT }}</p>
-        <p><b>Security:</b> {% if IMAP.TLS %}SSL/TLS{% else %}None{% endif %}</p>
-        <p><b>Username:</b> {{ mail_username }}</p>
-        <p><b>Password:</b> Your App Password</p>
+        <p data-testid="connection-info-imap-server"><b>Server Name:</b> {{ IMAP.HOST }}</p>
+        <p data-testid="connection-info-imap-port"><b>Server Port:</b> {{ IMAP.PORT }}</p>
+        <p data-testid="connection-info-imap-security"><b>Security:</b> {% if IMAP.TLS %}SSL/TLS{% else %}None{% endif %}</p>
+        <p data-testid="connection-info-imap-username"><b>Username:</b> {{ mail_username }}</p>
+        <p data-testid="connection-info-imap-password"><b>Password:</b> Your App Password</p>
       </div>
       <div>
         <h4 id="jmap">JMAP</h4>
-        <p><b>Server Name:</b> {{ JMAP.HOST }}</p>
-        <p><b>Server Port:</b> {{ JMAP.PORT }}</p>
-        <p><b>Security:</b> {% if JMAP.TLS %}SSL/TLS{% else %}None{% endif %}</p>
-        <p><b>Username:</b> {{ mail_username }}</p>
-        <p><b>Password:</b> Your App Password</p>
+        <p data-testid="connection-info-jmap-server"><b>Server Name:</b> {{ JMAP.HOST }}</p>
+        <p data-testid="connection-info-jmap-port"><b>Server Port:</b> {{ JMAP.PORT }}</p>
+        <p data-testid="connection-info-jmap-security"><b>Security:</b> {% if JMAP.TLS %}SSL/TLS{% else %}None{% endif %}</p>
+        <p data-testid="connection-info-jmap-username"><b>Username:</b> {{ mail_username }}</p>
+        <p data-testid="connection-info-jmap-password"><b>Password:</b> Your App Password</p>
       </div>
     </div>
     <div class="sending-email">
       <h3>Sending Email</h3>
       <div>
         <h4 id="smtp">SMTP</h4>
-        <p><b>Server Name:</b> {{ SMTP.HOST }}</p>
-        <p><b>Server Port:</b> {{ SMTP.PORT }}</p>
-        <p><b>Security:</b> {% if SMTP.TLS %}SSL/TLS{% else %}None{% endif %}</p>
-        <p><b>Username:</b> {{ mail_username }}</p>
-        <p><b>Password:</b> Your App Password</p>
+        <p data-testid="connection-info-smtp-server"><b>Server Name:</b> {{ SMTP.HOST }}</p>
+        <p data-testid="connection-info-smtp-port"><b>Server Port:</b> {{ SMTP.PORT }}</p>
+        <p data-testid="connection-info-smtp-security"><b>Security:</b> {% if SMTP.TLS %}SSL/TLS{% else %}None{% endif %}</p>
+        <p data-testid="connection-info-smtp-username"><b>Username:</b> {{ mail_username }}</p>
+        <p data-testid="connection-info-smtp-password"><b>Password:</b> Your App Password</p>
       </div>
     </div>
   </div>

--- a/test/e2e/.env.dev.example
+++ b/test/e2e/.env.dev.example
@@ -3,6 +3,7 @@ ACCTS_TARGET_ENV=dev
 
 # URLs
 ACCTS_SELF_SERVE_URL=http://localhost:8087/self-serve/
+ACCTS_EMAIL_SIGN_UP_URL=http://localhost:8087/sign-up/
 
 # Sign-in (FxA) credentials
 ACCTS_FXA_EMAIL=

--- a/test/e2e/.env.stage.example
+++ b/test/e2e/.env.stage.example
@@ -3,6 +3,7 @@ ACCTS_TARGET_ENV=stage
 
 # URLs
 ACCTS_SELF_SERVE_URL=https://accounts-stage.tb.pro/self-serve/
+ACCTS_EMAIL_SIGN_UP_URL=https://accounts-stage.tb.pro/sign-up/
 
 # Sign-in (FxA) credentials
 ACCTS_FXA_EMAIL=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -126,6 +126,7 @@ Here is some advice for how to investigate E2E test failures.
 
 ### E2E Tests Failing on your Local Dev Environment
 If you are running the E2E tests on your local machine against your local development environment and the tests are failing, you can:
+- Look at the playwright HTML report by running `npx playwright show-report` in test/e2e/
 - Run the tests again this time in debug (UI) mode (see above)
     - In the debug mode browser expand each test that was ran, and review each test step to trace the test progress and failure
     - Look at the corresponding screenshots to get a visual of where and when the tests actually failed

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -3,6 +3,8 @@ export const ACCTS_TARGET_ENV = String(process.env.ACCTS_TARGET_ENV);
 
 // tb accounts urls
 export const ACCTS_SELF_SERVE_URL = String(process.env.ACCTS_SELF_SERVE_URL);
+export const ACCTS_SELF_SERVE_ACCT_INFO_URL = `${ACCTS_SELF_SERVE_URL}account-settings`;
+export const ACCTS_EMAIL_SIGN_UP_URL = String(process.env.ACCTS_EMAIL_SIGN_UP_URL);
 
 // sign-in credentials and corresponding account display name
 export const ACCTS_FXA_EMAIL = String(process.env.ACCTS_FXA_EMAIL);
@@ -15,13 +17,26 @@ export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
 export const TIMEOUT_2_SECONDS = 2000;
 
 // connection info
-export const CONNECTION_LOCALHOST = 'localhost';
-export const IMAP_SERVER_PORT = 993;
-export const JMAP_SERVER_PORT = 7768;
-export const SMTP_SERVER_PORT = 7768;
+export const IMAP_SERVER_HOST = String(process.env.IMAP_HOST || 'localhost');
+export const IMAP_SERVER_PORT = Number(process.env.IMAP_PORT || 993);
+export const JMAP_SERVER_HOST = String(process.env.JMAP_HOST || 'localhost');
+export const JMAP_SERVER_PORT = Number(process.env.JMAP_PORT || 7768);
+export const SMTP_SERVER_HOST = String(process.env.SMTP_HOST || 'localhost');
+export const SMTP_SERVER_PORT = Number(process.env.SMTP_PORT || 7768);
 export const SECURITY_SSL_TLS = 'SSL/TLS';
 export const USERNAME_NONE = 'None';
 export const APP_PASSWORD_NONE = 'Your App Password';
 
-// URLs
-export const ACCTS_SELF_SERVE_ACCT_INFO_URL = `${ACCTS_SELF_SERVE_URL}account-settings`;
+// email sign-up
+export const EMAIL_SIGN_UP_EMAIL_ADDRESS = 'my-new-email-address';
+export const EMAIL_SIGN_UP_DOMAIN = 'tb.pro';
+export const EMAIL_SIGN_UP_APP_PWORD = 'password';
+
+// mock responses
+export const MOCK_RESPONSE_OK = {
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify({
+      fake_data: 'fake response data',
+  })
+};

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -13,3 +13,15 @@ export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
 
 // timeouts
 export const TIMEOUT_2_SECONDS = 2000;
+
+// connection info
+export const CONNECTION_LOCALHOST = 'localhost';
+export const IMAP_SERVER_PORT = 993;
+export const JMAP_SERVER_PORT = 7768;
+export const SMTP_SERVER_PORT = 7768;
+export const SECURITY_SSL_TLS = 'SSL/TLS';
+export const USERNAME_NONE = 'None';
+export const APP_PASSWORD_NONE = 'Your App Password';
+
+// URLs
+export const ACCTS_SELF_SERVE_ACCT_INFO_URL = `${ACCTS_SELF_SERVE_URL}account-settings`;

--- a/test/e2e/const/types.ts
+++ b/test/e2e/const/types.ts
@@ -1,0 +1,10 @@
+// our custom types
+
+export interface connectionInfo {
+    serverName: string;
+    serverPort: number;
+    securityType: string;
+    userName: string;
+    appPassword: string;
+  };
+

--- a/test/e2e/pages/email-sign-up-page.ts
+++ b/test/e2e/pages/email-sign-up-page.ts
@@ -1,0 +1,24 @@
+import { expect, type Page, type Locator } from '@playwright/test';
+import { ACCTS_EMAIL_SIGN_UP_URL } from '../const/constants';
+
+export class EmailSignUpPage {
+  readonly page: Page;
+  readonly emailAddressInput: Locator;
+  readonly domainSelect: Locator;
+  readonly loginUserNameEmail: Locator;
+  readonly appPassword: Locator;
+  readonly signUpBtn: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailAddressInput = this.page.getByTestId('sign-up-email-address-input');
+    this.domainSelect = this.page.getByTestId('sign-up-domain-input');
+    this.loginUserNameEmail = this.page.getByTestId('sign-up-login-username-input');
+    this.appPassword = this.page.getByTestId('sign-up-app-password-input');
+    this.signUpBtn = this.page.getByRole('button', { 'name': 'Sign Up' });
+  }
+
+  async navigateToEmailSignUpPage() {
+    await this.page.goto(ACCTS_EMAIL_SIGN_UP_URL);
+  }
+}

--- a/test/e2e/pages/self-serve-page.ts
+++ b/test/e2e/pages/self-serve-page.ts
@@ -1,24 +1,105 @@
-import { type Page, type Locator } from '@playwright/test';
+import { expect, type Page, type Locator } from '@playwright/test';
 import { ACCTS_SELF_SERVE_URL, ACCTS_FXA_EMAIL } from '../const/constants';
+import { connectionInfo } from '../const/types';
 
 export class SelfServePage {
   readonly page: Page;
   readonly pageHeader: Locator;
-  readonly selfServeHeader: Locator;
+  readonly selfServeConnectionInfoHeader: Locator;
+  readonly selfServeAccountInfoHeader: Locator;
   readonly welcomeBackHeader: Locator;
   readonly logoutLink: Locator;
   readonly userDisplayName: string;
+  readonly accountInfoLink: Locator;
+  readonly imapServerName: Locator;
+  readonly imapServerPort: Locator;
+  readonly imapSecurityType: Locator;
+  readonly imapUsername: Locator;
+  readonly imapPassword: Locator;
+  readonly jmapServerName: Locator;
+  readonly jmapServerPort: Locator;
+  readonly jmapSecurityType: Locator;
+  readonly jmapUsername: Locator;
+  readonly jmapPassword: Locator;
+  readonly smtpServerName: Locator;
+  readonly smtpServerPort: Locator;
+  readonly smtpSecurityType: Locator;
+  readonly smtpUsername: Locator;
+  readonly smtpPassword: Locator;
+  readonly emailHeader: Locator;
+  readonly noEmailSetupText: Locator;
+  readonly emailSetupBtn: Locator;
+  readonly deleteAccountHeader: Locator;
+  readonly deleteAcctText: Locator;
+  readonly deleteAcctBtn: Locator;
 
   constructor(page: Page) {
     this.page = page;
+
+    // headers and links
     this.pageHeader = this.page.getByRole('heading', { name: 'Accounts Hub'});
-    this.selfServeHeader = this.page.getByRole('heading', { name: 'Self Serve - Connection Information'});
+    this.selfServeConnectionInfoHeader = this.page.getByRole('heading', { name: 'Self Serve - Connection Information'});
+    this.selfServeAccountInfoHeader = this.page.getByRole('heading', { name: 'Self Serve - Account Information'});
     this.userDisplayName = ACCTS_FXA_EMAIL.split('@')[0];
     this.welcomeBackHeader = this.page.getByText(`Welcome back ${this.userDisplayName}.`, { exact: true });
     this.logoutLink = this.page.getByRole('link', { name: 'Logout'});
+    this.accountInfoLink = this.page.getByRole('link', { name: 'Account Info'});
+    
+    // imap details
+    this.imapServerName = this.page.getByTestId('connection-info-imap-server');
+    this.imapServerPort = this.page.getByTestId('connection-info-imap-port');
+    this.imapSecurityType = this.page.getByTestId('connection-info-imap-security');
+    this.imapUsername = this.page.getByTestId('connection-info-imap-username');
+    this.imapPassword = this.page.getByTestId('connection-info-imap-password');
+
+    // jmap details
+    this.jmapServerName = this.page.getByTestId('connection-info-jmap-server');
+    this.jmapServerPort = this.page.getByTestId('connection-info-jmap-port');
+    this.jmapSecurityType = this.page.getByTestId('connection-info-jmap-security');
+    this.jmapUsername = this.page.getByTestId('connection-info-jmap-username');
+    this.jmapPassword = this.page.getByTestId('connection-info-jmap-password');
+
+    // smtp details
+    this.smtpServerName = this.page.getByTestId('connection-info-smtp-server');
+    this.smtpServerPort = this.page.getByTestId('connection-info-smtp-port');
+    this.smtpSecurityType = this.page.getByTestId('connection-info-smtp-security');
+    this.smtpUsername = this.page.getByTestId('connection-info-smtp-username');
+    this.smtpPassword = this.page.getByTestId('connection-info-smtp-password');
+  
+    // account info
+    this.emailHeader = this.page.getByRole('heading', { name: 'Email' });
+    this.noEmailSetupText = this.page.getByTestId('account-info-no-email-setup-text');
+    this.emailSetupBtn = this.page.getByRole('button', { name: 'Set Up' });
+    this.deleteAccountHeader = this.page.getByRole('heading', { name: 'Delete Account' });
+    this.deleteAcctText = this.page.getByTestId('account-info-delete-account-description');
+    this.deleteAcctBtn = this.page.getByRole('button', { name: 'Delete Account' });
   }
 
   async navigateToSelfServeHub() {
     await this.page.goto(ACCTS_SELF_SERVE_URL);
+  }
+
+  async checkIMAPInfo(expectedInfo: connectionInfo) {
+    expect(await this.imapServerName.innerText()).toBe(`Server Name: ${expectedInfo['serverName']}`);
+    expect(await this.imapServerPort.innerText()).toBe(`Server Port: ${expectedInfo['serverPort']}`);
+    expect(await this.imapSecurityType.innerText()).toBe(`Security: ${expectedInfo['securityType']}`);
+    expect(await this.imapUsername.innerText()).toBe(`Username: ${expectedInfo['userName']}`);
+    expect(await this.imapPassword.innerText()).toBe(`Password: ${expectedInfo['appPassword']}`);
+  }
+
+  async checkJMAPInfo(expectedInfo: connectionInfo) {
+    expect(await this.jmapServerName.innerText()).toBe(`Server Name: ${expectedInfo['serverName']}`);
+    expect(await this.jmapServerPort.innerText()).toBe(`Server Port: ${expectedInfo['serverPort']}`);
+    expect(await this.jmapSecurityType.innerText()).toBe(`Security: ${expectedInfo['securityType']}`);
+    expect(await this.jmapUsername.innerText()).toBe(`Username: ${expectedInfo['userName']}`);
+    expect(await this.jmapPassword.innerText()).toBe(`Password: ${expectedInfo['appPassword']}`);
+  }
+
+  async checkSMTPInfo(expectedInfo: connectionInfo) {
+    expect(await this.smtpServerName.innerText()).toBe(`Server Name: ${expectedInfo['serverName']}`);
+    expect(await this.smtpServerPort.innerText()).toBe(`Server Port: ${expectedInfo['serverPort']}`);
+    expect(await this.smtpSecurityType.innerText()).toBe(`Security: ${expectedInfo['securityType']}`);
+    expect(await this.smtpUsername.innerText()).toBe(`Username: ${expectedInfo['userName']}`);
+    expect(await this.smtpPassword.innerText()).toBe(`Password: ${expectedInfo['appPassword']}`);
   }
 }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -30,12 +30,8 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'off',
-
-    // Capture screenshots on failure
-    screenshot: 'on',
+    screenshot: 'only-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/tests/email-sign-up.spec.ts
+++ b/test/e2e/tests/email-sign-up.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { FxAPage } from '../pages/fxa-page';
+import { navigateToAccountsSelfServeHubAndSignIn } from '../utils/utils';
+
+import {
+  PLAYWRIGHT_TAG_E2E_SUITE,
+  EMAIL_SIGN_UP_EMAIL_ADDRESS,
+  ACCTS_FXA_EMAIL,
+  EMAIL_SIGN_UP_DOMAIN,
+  EMAIL_SIGN_UP_APP_PWORD,
+  MOCK_RESPONSE_OK,
+ } from '../const/constants';
+import { EmailSignUpPage } from '../pages/email-sign-up-page';
+
+let fxaPage: FxAPage;
+let emailSignUpPage: EmailSignUpPage;
+
+test.beforeEach(async ({ page }) => {
+  fxaPage = new FxAPage(page);
+  await navigateToAccountsSelfServeHubAndSignIn(page);
+  emailSignUpPage = new EmailSignUpPage(page);
+  await emailSignUpPage.navigateToEmailSignUpPage();
+});
+
+test.describe('email sign-up', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test('able to sign up for a thundermail email address', async ({ page }) => {
+    // capture the POST /sign-up/submit and mock the response so that we don't
+    // actually create a new email account
+    await page.route('*/**/sign-up/submit', async (route, request) => {
+      console.log('captured POST /sign-up/submit and mocking the response');
+
+      // verify the captured request body is as expected
+      var capturedBody = request.postDataJSON();
+      expect(capturedBody['email_address']).toBe(EMAIL_SIGN_UP_EMAIL_ADDRESS);
+      expect(capturedBody['email_domain']).toBe(EMAIL_SIGN_UP_DOMAIN);
+      expect(capturedBody['app_password']).toBe(EMAIL_SIGN_UP_APP_PWORD);
+
+      // now send a fake response to the sign-up request
+      await route.fulfill(MOCK_RESPONSE_OK);
+    });
+
+    // now fill out the email sign up fields
+    await emailSignUpPage.emailAddressInput.fill(EMAIL_SIGN_UP_EMAIL_ADDRESS);
+    await emailSignUpPage.domainSelect.selectOption(EMAIL_SIGN_UP_DOMAIN);
+
+    // the login username/email field should already be filled with your tb accounts login email
+    await expect(emailSignUpPage.loginUserNameEmail).not.toBeEditable();
+    await expect(emailSignUpPage.loginUserNameEmail).toHaveValue(ACCTS_FXA_EMAIL);
+
+    // fill in app password then click sign up
+    await emailSignUpPage.appPassword.fill(EMAIL_SIGN_UP_APP_PWORD);
+    await emailSignUpPage.signUpBtn.click();
+  });
+});

--- a/test/e2e/tests/self-serve-account-info.spec.ts
+++ b/test/e2e/tests/self-serve-account-info.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { SelfServePage } from '../pages/self-serve-page';
+import { FxAPage } from '../pages/fxa-page';
+import { navigateToAccountsSelfServeHubAndSignIn } from '../utils/utils';
+
+import {
+  PLAYWRIGHT_TAG_E2E_SUITE,
+  ACCTS_SELF_SERVE_ACCT_INFO_URL,
+ } from '../const/constants';
+
+let selfServePage: SelfServePage;
+let fxaPage: FxAPage;
+
+test.beforeEach(async ({ page }) => {
+  selfServePage = new SelfServePage(page);
+  fxaPage = new FxAPage(page);
+  await navigateToAccountsSelfServeHubAndSignIn(page);
+  await page.goto(ACCTS_SELF_SERVE_ACCT_INFO_URL);
+});
+
+test.describe('self-serve hub accounts info', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test('displayed correctly with no email set up', async ({ page }) => {
+    // headers and link
+    await expect(selfServePage.selfServeAccountInfoHeader).toBeVisible();
+    await expect(selfServePage.welcomeBackHeader).toBeVisible();
+    await expect(selfServePage.accountInfoLink).toBeEnabled();
+    await expect(selfServePage.logoutLink).toBeVisible();
+
+    // no email setup text and button
+    await expect(selfServePage.emailHeader).toBeVisible();
+    await expect(selfServePage.noEmailSetupText).toBeVisible();
+    await expect(selfServePage.emailSetupBtn).toBeEnabled();
+
+    // delete account text and button
+    await expect(selfServePage.deleteAccountHeader).toBeVisible();
+    await expect(selfServePage.deleteAcctText).toBeVisible();
+    await expect(selfServePage.deleteAcctBtn).toBeEnabled();
+  });
+});

--- a/test/e2e/tests/self-serve-connection-info.spec.ts
+++ b/test/e2e/tests/self-serve-connection-info.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { SelfServePage } from '../pages/self-serve-page';
+import { FxAPage } from '../pages/fxa-page';
+import { navigateToAccountsSelfServeHubAndSignIn } from '../utils/utils';
+import { connectionInfo } from '../const/types';
+
+import {
+  PLAYWRIGHT_TAG_E2E_SUITE,
+  CONNECTION_LOCALHOST,
+  IMAP_SERVER_PORT,
+  JMAP_SERVER_PORT,
+  SMTP_SERVER_PORT,
+  SECURITY_SSL_TLS,
+  USERNAME_NONE,
+  APP_PASSWORD_NONE,
+ } from '../const/constants';
+
+let selfServePage: SelfServePage;
+let fxaPage: FxAPage;
+
+test.beforeEach(async ({ page }) => {
+  selfServePage = new SelfServePage(page);
+  fxaPage = new FxAPage(page);
+  await navigateToAccountsSelfServeHubAndSignIn(page);
+});
+
+test.describe('self-serve hub connection info', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test('displayed correctly with no email set up', async ({ page }) => {
+    // headers and link
+    await expect(selfServePage.selfServeConnectionInfoHeader).toBeVisible();
+    await expect(selfServePage.welcomeBackHeader).toBeVisible();
+    await expect(selfServePage.accountInfoLink).toBeEnabled();
+
+    // imap details
+    var expectedInfo: connectionInfo = {
+      'serverName': CONNECTION_LOCALHOST,
+      'serverPort': IMAP_SERVER_PORT,
+      'securityType': SECURITY_SSL_TLS,
+      'userName': USERNAME_NONE,
+      'appPassword': APP_PASSWORD_NONE,
+    };
+
+    // imap details
+    await selfServePage.checkIMAPInfo(expectedInfo);
+
+    // jmap details
+    expectedInfo['serverPort'] = JMAP_SERVER_PORT;
+    await selfServePage.checkJMAPInfo(expectedInfo);
+
+    // smtp details
+    expectedInfo['serverPort'] = SMTP_SERVER_PORT;
+    await selfServePage.checkSMTPInfo(expectedInfo);
+  });
+});

--- a/test/e2e/tests/self-serve-connection-info.spec.ts
+++ b/test/e2e/tests/self-serve-connection-info.spec.ts
@@ -6,10 +6,12 @@ import { connectionInfo } from '../const/types';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE,
-  CONNECTION_LOCALHOST,
   IMAP_SERVER_PORT,
   JMAP_SERVER_PORT,
   SMTP_SERVER_PORT,
+  IMAP_SERVER_HOST,
+  JMAP_SERVER_HOST,
+  SMTP_SERVER_HOST,
   SECURITY_SSL_TLS,
   USERNAME_NONE,
   APP_PASSWORD_NONE,
@@ -35,7 +37,7 @@ test.describe('self-serve hub connection info', {
 
     // imap details
     var expectedInfo: connectionInfo = {
-      'serverName': CONNECTION_LOCALHOST,
+      'serverName': IMAP_SERVER_HOST,
       'serverPort': IMAP_SERVER_PORT,
       'securityType': SECURITY_SSL_TLS,
       'userName': USERNAME_NONE,
@@ -46,10 +48,12 @@ test.describe('self-serve hub connection info', {
     await selfServePage.checkIMAPInfo(expectedInfo);
 
     // jmap details
+    expectedInfo['serverName'] = JMAP_SERVER_HOST;
     expectedInfo['serverPort'] = JMAP_SERVER_PORT;
     await selfServePage.checkJMAPInfo(expectedInfo);
 
     // smtp details
+    expectedInfo['serverName'] = SMTP_SERVER_HOST;
     expectedInfo['serverPort'] = SMTP_SERVER_PORT;
     await selfServePage.checkSMTPInfo(expectedInfo);
   });

--- a/test/e2e/tests/sign-in-self-serve.spec.ts
+++ b/test/e2e/tests/sign-in-self-serve.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { SelfServePage } from '../pages/self-serve-page';
 import { FxAPage } from '../pages/fxa-page';
-import { PLAYWRIGHT_TAG_E2E_SUITE, TIMEOUT_2_SECONDS,  } from '../const/constants';
-
+import { PLAYWRIGHT_TAG_E2E_SUITE, TIMEOUT_2_SECONDS  } from '../const/constants';
 
 let selfServePage: SelfServePage;
 let fxaPage: FxAPage;
@@ -19,7 +18,7 @@ test.describe('tb accounts self-serve hub', {
     await selfServePage.navigateToSelfServeHub();
     await fxaPage.signIn();
     await expect(selfServePage.pageHeader).toBeVisible({ timeout: 30_000 }); // generous time
-    await expect(selfServePage.selfServeHeader).toBeVisible();
+    await expect(selfServePage.selfServeConnectionInfoHeader).toBeVisible();
     await expect(selfServePage.welcomeBackHeader).toBeVisible();
     await expect(selfServePage.logoutLink).toBeVisible();
 
@@ -27,7 +26,7 @@ test.describe('tb accounts self-serve hub', {
     await page.waitForTimeout(TIMEOUT_2_SECONDS);
     await selfServePage.logoutLink.click();
     await page.waitForTimeout(TIMEOUT_2_SECONDS);
-    await expect(selfServePage.selfServeHeader).not.toBeVisible();
+    await expect(selfServePage.selfServeConnectionInfoHeader).not.toBeVisible();
     await expect(selfServePage.welcomeBackHeader).not.toBeVisible();
   });
 });

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -1,0 +1,21 @@
+// utility functions that may be used by any tests
+import { expect, type Page } from '@playwright/test';
+import { ACCTS_SELF_SERVE_URL, TIMEOUT_2_SECONDS } from '../const/constants';
+import { SelfServePage } from '../pages/self-serve-page';
+import { FxAPage } from '../pages/fxa-page';
+
+/**
+ * Navigate to and sign into the TB Accounts Self-Serve Hub target environment, using the URL and
+ * credentials provided in the .env file. Real FxA stage accounts are used when signing into both
+ * the local dev stack and stage environments.
+ */
+export const navigateToAccountsSelfServeHubAndSignIn = async (page: Page) => {
+    console.log(`navigating to the tb accounts self-serve hub (${ACCTS_SELF_SERVE_URL}) and signing in`);
+    const selfServePage = new SelfServePage(page);
+    const fxaPage = new FxAPage(page);
+    await selfServePage.navigateToSelfServeHub();
+    await fxaPage.signIn();
+    await page.waitForTimeout(TIMEOUT_2_SECONDS);
+    await expect(selfServePage.pageHeader).toBeVisible({ timeout: 30_000 }); // generous time
+    await expect(selfServePage.logoutLink).toBeVisible();
+}


### PR DESCRIPTION
Add some more E2E tests, more specifically to exercise the default states of the:
- self-serve connection info page
- self-serve accounts info page

And add a test for email sign-up (capturing the actual sign-up request and returning a mock response, so that we don't actually add a new email account every time the test runs).

Also adding some `data-testid` attribute to the frontend to help the tests locate elements easier.

For info on how to run the E2E tests please see the [E2E tests README](https://github.com/thunderbird/thunderbird-accounts/blob/main/test/e2e/README.md).