### PR TITLE
Add E2E tests to CI for local branches/PRs

### DIFF
--- a/.github/workflows/e2e-test-local.yml
+++ b/.github/workflows/e2e-test-local.yml
@@ -1,0 +1,71 @@
+name: e2e-test-local
+
+concurrency:
+  group: e2e-test-local
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  run-e2e-tests-local:
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      ACCTS_FXA_EMAIL: ${{ secrets.E2E_ACCTS_FXA_EMAIL }}
+      ACCTS_FXA_PWORD: ${{ secrets.E2E_ACCTS_FXA_PWORD }}
+      FXA_CLIENT_ID: ${{ secrets.E2E_ACCTS_FXA_CLIENT_ID }}
+      FXA_SECRET: ${{ secrets.E2E_ACCTS_FXA_SECRET }}
+      SECRET_KEY: ${{ secrets.E2E_ACCTS_SECRET_KEY }}
+      LOGIN_CODE_SECRET: ${{ secrets.E2E_ACCTS_LOGIN_CODE_SECRET }}
+      FXA_ENCRYPT_SECRET: ${{ secrets.E2E_ACCTS_FXA_ENCRYPT_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up local environment
+        run: |
+          cp .env.example .env
+          mkdir -p mail/etc && cp config.toml.example mail/etc/config.toml
+          echo -e "\nFXA_CLIENT_ID=$FXA_CLIENT_ID" >> .env
+          echo "FXA_SECRET=$FXA_SECRET" >> .env
+          echo "SECRET_KEY=$SECRET_KEY" >> .env
+          echo "LOGIN_CODE_SECRET=$LOGIN_CODE_SECRET" >> .env
+          echo "FXA_ENCRYPT_SECRET=$FXA_ENCRYPT_SECRET" >> .env
+
+      - name: Start appointment stack via docker
+        run: docker compose up -d --build -V postgres redis backend frontend
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install E2E test dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+          npx playwright install
+
+      - name: Run E2E tests against local stack
+        id: e2e
+        run: |
+          cd ./test/e2e
+          cp .env.dev.example .env
+          npm run e2e-test
+
+      - uses: actions/upload-artifact@v4
+        if: always() && ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: test/e2e/playwright-report/
+          retention-days: 7

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -119,3 +119,24 @@ npm run e2e-test-browserstack
 ```
 
 After the tests finish in your local console you'll see a link to the BrowserStack test session; when signed into your BrowserStack account you'll be able to use that link to see the test session results including video playback.
+
+## Debugging E2E Test Failures
+
+Here is some advice for how to investigate E2E test failures.
+
+### E2E Tests Failing on your Local Dev Environment
+If you are running the E2E tests on your local machine against your local development environment and the tests are failing, you can:
+- Run the tests again this time in debug (UI) mode (see above)
+    - In the debug mode browser expand each test that was ran, and review each test step to trace the test progress and failure
+    - Look at the corresponding screenshots to get a visual of where and when the tests actually failed
+    - Try to correlate the test failure with any local code changes
+
+### E2E Tests Failing in CI on your PR Check
+If you pushed to a branch or PR and the resulting Github pull request E2E test job check is failing, you can:
+
+- In your PR scroll down to the 'Checks' section and click on the failed E2E test job
+- In the console view, expand the E2E tests step and read the test failure details
+- Check if a playwright report artifact exists:
+    - In the console view click on `Summary` (top left)
+    - This shows the GHA summary, at the bottom of the page look for an `Artifacts` section and click on `playwright-report` and download the ZIP
+    - Open the ZIP file, expand it, and open the `index.html` file in your browser

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.34.41",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.41.tgz",
-      "integrity": "sha512-DojBMEYz9PwMPFzLAuKUUyGxSLItNqZdMVH3tnqGOnOOOs5LRxYQBTdnj9ovyjhj4LPlpmUR9ucml79drDjVYg==",
+      "version": "1.34.49",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.34.49.tgz",
+      "integrity": "sha512-Dhi/vO70+gTXHAFx9IcZIYpnRYcfH6/YhdBATH04+J8BEv5qUz2CawEp5Bu0IWumiaG8ZMb7veZYoh50wZmq7g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -24,14 +24,18 @@ export default defineConfig({
   // Tests will timeout if still running after this time (ms)
   timeout: 2 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['list']],
+  reporter: [['html']],
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'off',
+
+    // Capture screenshots on failure
+    screenshot: 'on',
   },
 
   /* Configure projects for major browsers */

--- a/test/e2e/tests/sign-in-self-serve.spec.ts
+++ b/test/e2e/tests/sign-in-self-serve.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { SelfServePage } from '../pages/self-serve-page';
 import { FxAPage } from '../pages/fxa-page';
-import { PLAYWRIGHT_TAG_E2E_SUITE, TIMEOUT_2_SECONDS } from '../const/constants';
-import exp from 'constants';
+import { PLAYWRIGHT_TAG_E2E_SUITE, TIMEOUT_2_SECONDS,  } from '../const/constants';
+
 
 let selfServePage: SelfServePage;
 let fxaPage: FxAPage;


### PR DESCRIPTION
Add a GHA workflow to run the E2E tests against local branches/PRs. The tests will run against the local stack on the GHA instance (but will use FxA stage for auth).

The playwright test results report is uploaded as an artifact after the test run (and it can be downloaded in the actions job page). For an example of the E2E test running as part of a PR just see the checks associated with this very PR :)