### PR TITLE
Update TB Pro Sign up with new form id, the slim appeal footer, and updated styling.

### DIFF
--- a/assets/css/wait-list.css
+++ b/assets/css/wait-list.css
@@ -2,7 +2,8 @@
 
 :root {
   --border-color: #273347;
-  --background-color: #0f172a;
+  /* --background-color: #0f172a; */
+  --background-color: #1a202c;
   --border-radius: 4px;
   font-size: 16px;
 }
@@ -21,6 +22,10 @@ body {
 
   height: 100%;
   width: 100%;
+  min-height: 100vh;
+
+  display: flex;
+  flex-direction: column;
 
   font-family: "Inter", sans-serif;
   font-size: 1rem;
@@ -53,7 +58,7 @@ header {
 .callout {
   border: 0.063rem solid var(--border-color);
   border-radius: var(--border-radius);
-  padding: 0.5rem;
+  padding: 1.5rem;
   margin-top: 1.5rem;
 }
 
@@ -112,4 +117,58 @@ input[type="submit"] {
   padding: 0 1rem;
   border-radius: var(--border-radius);
   font-size: 0.875rem;
+}
+
+
+#footer {
+  position: relative;
+  margin-top: auto;
+  margin-bottom: 0;
+  min-height: 10rem;
+  display: flex;
+  color: #e4e4e7;
+
+  a {
+    --legal-txt: #e4e4e7;
+    color: var(--legal-txt);
+    text-decoration-color: var(--legal-txt);
+    text-underline-offset: 0.25em;
+    text-decoration-thickness: 0.12em;
+    text-decoration-style: solid;
+    transition: font-size 0.2s, text-decoration-color 0.2s;
+  }
+
+  svg {
+    width: 100%;
+    height: 100%
+  }
+
+  .mzla {
+    display: grid;
+    place-items: center;
+    gap: 0.9375rem;
+    text-align: center;
+    max-inline-size: 75ch;
+
+    position: relative;
+    padding-inline: 1rem;
+    padding-block: clamp(1rem, 5.469vw, 2.375rem);
+    margin-inline: auto;
+    max-width: 1280px;
+    overflow: hidden;
+  }
+
+  .mozilla-logo {
+    --accent: white;
+    width: 7.6875rem;
+    max-width: 100%;
+  }
+
+  .legal-links {
+    font-size: 1rem;
+    display: flex;
+    gap: 1.875rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 }

--- a/docs/deploying-thundermail-waiting-list.rst
+++ b/docs/deploying-thundermail-waiting-list.rst
@@ -1,0 +1,24 @@
+==============================================
+Deploying Thundermail.com Waiting List
+==============================================
+
+The thundermail.com waiting list is hosted on directly on an S3 bucket named `tb-pro-frontend`.
+
+Once any edits or additional changes are ready for deployment, simply visit `http://localhost:8087/wait-list`,
+and copy the html output. Create a new folder, and place the html in a new index.html file.
+
+Copy the contents of `assets/` into the new folder as well, and inside your new folder delete the app folder.
+
+So you should see a folder structure like:
+
+.. code-block::
+
+  ./css
+  ./favicon.ico
+  ./fonts
+  ./index.html
+  ./svg
+
+Finally edit the css path inside index.html to be `"/css/wait-list.css"`.
+
+Once done that directory's contents to the s3 bucket.

--- a/templates/mail/wait-list.html
+++ b/templates/mail/wait-list.html
@@ -8,7 +8,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title></title>
+  <title>Thunderbird Pro Beta Access</title>
   <link rel="stylesheet" href="{% static 'css/wait-list.css' %}">
 </head>
 <body>
@@ -94,7 +94,7 @@
               <div style="position: absolute; left: -5000px" aria-hidden="true">
                 <input
                   type="text"
-                  name="b_f8051cc8637cf3ff79661f382_a508104cf8"
+                  name="b_b7a94f022286353777c825b60_8950d99234"
                   tabindex="-1"
                   value=""
                 />
@@ -105,5 +105,21 @@
       </div>
     </div>
   </div>
+<footer id="footer">
+  <div class="mzla container">
+    <a href="https://mozilla.org" class="mozilla-logo">
+      <!--?xml version="1.0" encoding="UTF-8"?-->
+      <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" id="Layer_1" x="0" y="0" version="1.1" viewBox="0 0 703.5 147" width="2400" height="501.13636363636" fill="currentColor"><path d="m54.6 0 18.7 92H80L98.7 0h54.6v144.9h-29.8V25.4h-6.7l-26 119.5H62.6l-26-119.5h-6.7v119.5H0V0zm171.1 30.7c34.4 0 54.4 20.6 54.4 58.2s-19.9 58.2-54.4 58.2-54.4-20.6-54.4-58.2c.1-37.7 20-58.2 54.4-58.2m0 93.2c15.5 0 22.9-8.4 22.9-26.9V80.6c0-18.5-7.3-26.9-22.9-26.9s-22.9 8.4-22.9 26.9V97c.1 18.5 7.4 26.9 22.9 26.9m66.6-.6 56.9-68.9h-56.1V32.8h91.6v21.6l-56.9 68.9h57.7v21.6h-93.2zm108.8-90.5h42v112.1h-29.8V54.4h-12.2zM413.3 0h29.8v21.6h-29.8zm49.5 0h42v144.9H475V21.6h-12.2zm61.8 0h42v144.9h-29.8V21.6h-12.2zm106 30.7c16.6 0 27.5 8.2 30.7 22.5h6.7V32.8h35.5v21.6h-12.2v68.9h12.2v21.6h-17c-12 0-18.5-6.5-18.5-18.5v-1.9h-6.7c-3.2 14.3-14.1 22.5-30.7 22.5-26.2 0-44.7-22.3-44.7-58.2s18.5-58.1 44.7-58.1m8.8 93.2c15.1 0 22-8.4 22-26.9V80.6c0-18.5-6.9-26.9-22-26.9s-22 8.4-22 26.9V97c0 18.5 6.9 26.9 22 26.9"></path></svg>
+    </a>
+    <div class="legal-links">
+      <a href="https://www.mozilla.org/privacy/websites/" data-link-type="footer" data-link-name="Privacy">Privacy</a>
+      <a href="https://www.mozilla.org/privacy/websites/#data-tools" data-link-type="footer" data-link-name="Cookies">Cookies</a>
+      <a href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/" data-link-type="footer" data-link-name="Legal">Legal</a>
+      <a href="https://www.mozilla.org/en-US/about/legal/report-infringement/" data-link-type="footer" data-link-name="infringement">Send DMCA Notice</a>
+      <a href="https://www.mozilla.org/about/legal/fraud-report/" data-link-type="footer" data-link-name="Report Trademark Misuse">Report Fraud</a>
+      <a href="https://www.mozilla.org/en-US/about/governance/policies/participation/" data-link-type="footer" data-link-name="guidelines">Participation Guidelines</a>
+    </div>
+  </div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
![Screen Shot 2025-03-31 at 12 12 30-fullpage](https://github.com/user-attachments/assets/3857f663-38f6-433d-aaa9-8c5a2dee48a4)

I've checked in the edits that were missing from this repo from https://thundermail.com/. 

The form id is actually an env file so it's not visible here. I've also added deployment instructions.



