### PR TITLE
Add the celery worker to pulumi and the github deploy workflow

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -47,6 +47,7 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
       PULUMI_DIR: "pulumi"
+      CELERY_WORKER_TAG: '-celery-worker'
     steps:
       # Preparation for future steps
       - uses: actions/checkout@v4
@@ -107,11 +108,30 @@ jobs:
           name: ecr_tag
           path: ecr_tag.txt
 
+      - name: Build, tag, and push account's celery worker image to Amazon ECR
+        id: build-celery-worker
+        env:
+          ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}${{ env.CELERY_WORKER_TAG }}:${{ github.sha }}"
+        run: |
+          # Build a docker container and push it to ECR so that it can be deployed to ECS.
+          docker build -t $ECR_TAG -f ./Dockerfile.celery.stage --platform="linux/amd64" .          
+          docker push $ECR_TAG
+          echo "accounts-image=$ECR_TAG" >> $GITHUB_OUTPUT
+          echo -n "$ECR_TAG" > ecr_tag_celery_worker.txt
+
+      - name: Archive the ECR tag
+        id: tag-archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecr_tag
+          path: ecr_tag_celery_worker.txt
+
       # Deploy to stage
       - name: Deploy new image to stage
         shell: bash
         env:
           ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:${{ github.sha }}"
+          CELERY_WORKER_ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}${{ env.CELERY_WORKER_TAG }}:${{ github.sha }}"
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
           # Update the PATH to include the right version of Pulumi; this is non-trivial or impossible
@@ -127,8 +147,10 @@ jobs:
               accounts:
                 task_definition:
                   container_definitions:
-                    accounts:
+                    accounts: &accounts_def
                       image: "$ECR_TAG"
+                    celery_worker:
+                      image: "$CELERY_WORKER_ECR_TAG"
           EOF
 
           # Use yq to merge the stump into the main config

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -83,7 +83,7 @@ resources:
         - paddle-price-id-lo
         - paddle-price-id-md
         - paddle-price-id-hi
-  
+
   # Config to build a jumphost
   # tb:ec2:SshableInstance:
   #   jumphost:
@@ -125,6 +125,9 @@ resources:
             unhealthy_threshold: 5
             interval: 30
             path: /health
+        celery_worker:  # Doesn't require a listener, simply handles queued tasks
+          container_name: celery_worker
+          name: celery-worker-stage
       task_definition:
         network_mode: awsvpc
         cpu: 512
@@ -132,7 +135,7 @@ resources:
         requires_compatibilities:
           - FARGATE
         container_definitions:
-          accounts:
+          accounts: &accounts_def
             image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:melstagedeploy02
             portMappings:
               - name: accounts
@@ -227,6 +230,23 @@ resources:
                 value: 'True'
               - name: PADDLE_ENV
                 value: 'sandbox'
+              - name: REDIS_INTERNAL_DB
+                value: '0'
+              - name: REDIS_CELERY_DB
+                value: '5'
+              - name: REDIS_CELERY_RESULTS_DB
+                value: '6'
+              - name: REDIS_SHARED_DB
+                value: '10'
+              - name: CELERY_BROKER
+                value: rediss://master.accounts-stage-redis.7syyoy.euc1.cache.amazonaws.com:6379
+              - name: CELERY_BACKEND
+                value: rediss://master.accounts-stage-redis.7syyoy.euc1.cache.amazonaws.com:6379
+              - name: CELERY_EAGER
+                value: 'False'
+          celery_worker:
+            <<: *accounts_def
+            portMappings: null
 
   tb:ci:AwsAutomationUser:
     ci:


### PR DESCRIPTION
Part of #71 

This hopefully spins up a second task that just runs the celery worker. (Concurrency defaults to the number of cpus available, see https://github.com/thunderbird/thunderbird-accounts/blob/main/scripts/celery-entry.sh for more info.) We don't need any http listener, but I'm unsure how the health check will run otherwise. 🤔 

In the future we may need a second celery container task def to run a cron scheduler. So taking suggestions on optimizing this workflow/pulumi config.
https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#starting-the-scheduler