### PR TITLE
Fix stage E2E test BrowserStack job

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -170,7 +170,6 @@ jobs:
         run: |
           cd ./test/e2e
           npm install
-          npx playwright install
 
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@master

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
     // Maximum time (ms) each action such as `click()` can take. Defaults to 0 (no limit)
     actionTimeout: 10_000,
     // Maximum time given for browser page navigation
-    navigationTimeout: 15_000,
+    navigationTimeout: 30_000,
   },
   expect: {
     // set default timeout for all expects that have a {timeout} option i.e. if locators are not found,


### PR DESCRIPTION
The E2E tests BrowserStack job on stage is failing with:

```
Running 8 tests using 2 workers

Timed out waiting 300s for the test suite to run
```

See #105  for more info.

The only thing I can see is that the playwright browsers are being installed, but we don't need them as the tests are running in BrowserStack. Not sure if that is the exact issue but perhaps the installation of the playwright browsers is causing the tests to fail to connnect / start in the BrowserStack browsers. The playwright browsers aren't required either way so good to remove and hopefully this will fix the issue. 🤞 