### PR TITLE
Tasks/117 ignore disallowed host error for sentry

### DIFF
--- a/src/thunderbird_accounts/authentication/apps.py
+++ b/src/thunderbird_accounts/authentication/apps.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.cache import cache
@@ -16,4 +18,8 @@ class AuthenticationConfig(AppConfig):
         # We don't do this on dev environments because this might restart
         # each time a python file is updated.
         if settings.APP_ENV != 'dev':
-            cache.clear()
+            try:
+                cache.clear()
+            except Exception as ex:  # noqa
+                # This shouldn't cause an application crash if we don't have caching setup correctly
+                logging.warning(f'Could not clear cache on application restart. Error: {ex}')

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 import os
 import sys
 from pathlib import Path
+
+from django.core.exceptions import DisallowedHost
 from dotenv import load_dotenv
 import sentry_sdk
 
@@ -45,6 +47,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
     profiles_sample_rate=1.0,
     environment=APP_ENV,
+    ignore_errors=[DisallowedHost],
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
One crashy error, and one spammy error fixed.

`#noqa` line is just to make ruff ignore it. 