### PR TITLE
Fix E2E tests on stage

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -183,6 +183,7 @@ jobs:
       FXA_ENCRYPT_SECRET: ${{ secrets.E2E_ACCTS_FXA_ENCRYPT_SECRET }}
       THUNDERMAIL_USERNAME: ${{ secrets.E2E_THUNDERMAIL_USERNAME }}
       THUNDERMAIL_EMAIL_ADDRESS: ${{ secrets.E2E_THUNDERMAIL_EMAIL_ADDRESS }}
+      EMAIL_SIGN_UP_ADDRESS: ${{ secrets.E2E_ACCTS_PADDLE_EMAIL_SIGN_UP_ADDRESS }}
     steps:
       - uses: actions/checkout@v4
 

--- a/test/e2e/.env.stage.example
+++ b/test/e2e/.env.stage.example
@@ -6,7 +6,7 @@ ACCTS_SELF_SERVE_URL=https://accounts-stage.tb.pro/self-serve/
 ACCTS_EMAIL_SIGN_UP_URL=https://accounts-stage.tb.pro/sign-up/
 
 # Host / ports / domains
-ACCTS_HOST=stage-thundermail.com
+ACCTS_HOST=mail.stage-thundermail.com
 IMAP_PORT=993
 JMAP_PORT=7768
 SMTP_PORT=465


### PR DESCRIPTION
Fix the broken E2E tests on stage:

- Include the `EMAIL_SIGN_UP_ADDRESS` in the GHA workflow env
- Update the incorrect `ACCTS_HOST` value in the `test/e2e/.env.stage.example`