### PR TITLE
Cors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "thunderbird_accounts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
     "django>=5.1",
     "django-filter>=24.3",
@@ -26,6 +26,7 @@ dependencies = [
     "sentry-sdk[django]>=2.22.0",
     "requests>=2.32.3",
     "celery[redis]>=5.5.0",
+    "django-cors-headers>=4.7.0",
 ]
 description = "Accounts hub for Thunderbird Pro Services."
 readme = "README.md"

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -58,7 +58,9 @@ class ClientSetAllowedHostsMiddleware:
         # Get the IP of whatever machine is running this code and allow it as a hostname
         allowed_hosts.append(gethostbyname(gethostname()))
 
+        # Set both django allowed hosts and cors allowed origins
         settings.ALLOWED_HOSTS = allowed_hosts
+        settings.CORS_ALLOWED_ORIGINS = allowed_hosts
 
         end = time.perf_counter_ns()
 

--- a/src/thunderbird_accounts/authentication/tests.py
+++ b/src/thunderbird_accounts/authentication/tests.py
@@ -202,15 +202,19 @@ class ClientSetAllowedHostsMiddlewareTestCase(TestCase):
         """Test that middleware properly sets ALLOWED_HOSTS from ClientEnvironment"""
         self.middleware(self.request)
         self.assertIn('test.com', settings.ALLOWED_HOSTS)
+        self.assertIn('test.com', settings.CORS_ALLOWED_ORIGINS)
 
     def test_allowed_uses_cached_hosts(self):
         """Test that middleware uses cached hosts when available"""
+
+        # Note: At this point there's no cache entry, so the allowed host cache is remade.
         cached_hosts = 'cached.com'
         settings.ALLOWED_HOSTS += [cached_hosts]
 
         self.middleware(self.request)
 
         self.assertIn(cached_hosts, settings.ALLOWED_HOSTS)
+        self.assertIn(cached_hosts, settings.CORS_ALLOWED_ORIGINS)
 
 
 class FXAWebhooksTestCase(DRF_APITestCase):

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -130,7 +130,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    # This needs to be first, as we're setting up our allowed hosts
+    # Cors first!
+    'corsheaders.middleware.CorsMiddleware',
+    # This needs to be second, as we're setting up our allowed hosts
     'thunderbird_accounts.authentication.middleware.ClientSetAllowedHostsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'servestatic.middleware.ServeStaticMiddleware',

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -130,10 +130,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    # Cors first!
-    'corsheaders.middleware.CorsMiddleware',
-    # This needs to be second, as we're setting up our allowed hosts
+    # This needs to be first, as we're setting up our allowed hosts
     'thunderbird_accounts.authentication.middleware.ClientSetAllowedHostsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'servestatic.middleware.ServeStaticMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/uv.lock
+++ b/uv.lock
@@ -349,6 +349,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/6c/16f6cb6064c63074fd5b2bd494eb319afd846236d9c1a6c765946df2c289/django_cors_headers-4.7.0.tar.gz", hash = "sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b", size = 21037 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/a2/7bcfff86314bd9dd698180e31ba00604001606efb518a06cca6833a54285/django_cors_headers-4.7.0-py3-none-any.whl", hash = "sha256:f1c125dcd58479fe7a67fe2499c16ee38b81b397463cf025f0e2c42937421070", size = 12794 },
+]
+
+[[package]]
 name = "django-filter"
 version = "25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,6 +1142,7 @@ dependencies = [
     { name = "celery", extra = ["redis"] },
     { name = "cryptography" },
     { name = "django" },
+    { name = "django-cors-headers" },
     { name = "django-filter" },
     { name = "django-vite" },
     { name = "djangorestframework" },
@@ -1173,6 +1187,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'cli'" },
     { name = "cryptography", specifier = ">=43.0.3" },
     { name = "django", specifier = ">=5.1" },
+    { name = "django-cors-headers", specifier = ">=4.7.0" },
     { name = "django-filter", specifier = ">=24.3" },
     { name = "django-vite", specifier = ">=3.0.6" },
     { name = "djangorestframework", specifier = ">=3.15.2" },


### PR DESCRIPTION
Fixes #132 

...hopefully.

I figured django's internal [allowed hosts](https://docs.djangoproject.com/en/5.1/ref/settings/#allowed-hosts) setting would handle this. But it doesn't. 🤔 

I've hooked it up to our middleware which dynamically sets the allowed_hosts based on our list of clients. So it should work, I just can't test it easily locally. 