### PR TITLE
Split allowed origins and allowed hosts, since origins needs url scheme.

### DIFF
--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -53,14 +53,15 @@ class ClientSetAllowedHostsMiddleware:
         start = time.perf_counter_ns()
 
         allowed_hosts = cache.get(settings.ALLOWED_HOSTS_CACHE_KEY)
-        if not allowed_hosts:
-            allowed_hosts = ClientEnvironment.cache_hostnames()
+        allowed_origins = cache.get(settings.ALLOWED_ORIGINS_CACHE_KEY)
+        if not allowed_hosts or not allowed_origins:
+            allowed_hosts, allowed_origins = ClientEnvironment.cache_hostnames()
         # Get the IP of whatever machine is running this code and allow it as a hostname
         allowed_hosts.append(gethostbyname(gethostname()))
 
         # Set both django allowed hosts and cors allowed origins
         settings.ALLOWED_HOSTS = allowed_hosts
-        settings.CORS_ALLOWED_ORIGINS = allowed_hosts
+        settings.CORS_ALLOWED_ORIGINS = allowed_origins
 
         end = time.perf_counter_ns()
 

--- a/src/thunderbird_accounts/authentication/tests.py
+++ b/src/thunderbird_accounts/authentication/tests.py
@@ -209,7 +209,7 @@ class ClientSetAllowedHostsMiddlewareTestCase(TestCase):
         """Test that middleware properly sets ALLOWED_HOSTS from ClientEnvironment"""
         self.middleware(self.request)
         self.assertIn('test.com', settings.ALLOWED_HOSTS)
-        self.assertIn('test.com', settings.CORS_ALLOWED_ORIGINS)
+        self.assertIn('http://test.com', settings.CORS_ALLOWED_ORIGINS)
 
     def test_allowed_hosts_uses_cached_hosts(self):
         """Test that middleware uses cached hosts when available"""

--- a/src/thunderbird_accounts/authentication/tests.py
+++ b/src/thunderbird_accounts/authentication/tests.py
@@ -253,7 +253,7 @@ class ClientSetAllowedHostsMiddlewareTestCase(TestCase):
         """Test that middleware uses cached hosts when available"""
 
         # Note: At this point there's no cache entry, so the allowed host cache is remade.
-        client_env = ClientEnvironment.objects.create(
+        ClientEnvironment.objects.create(
             environment='test',
             redirect_url='http://testserver2/really-long-url-holy-carp/whatever/',
             client_id=self.client.uuid,

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -321,6 +321,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AUTH_USER_MODEL = 'authentication.User'
 
 ALLOWED_HOSTS_CACHE_KEY = '__ALLOWED_HOSTS'
+ALLOWED_ORIGINS_CACHE_KEY = '__ALLOWED_ORIGINS'
 
 USE_X_FORWARDED_HOST = True
 
@@ -369,3 +370,11 @@ sentry_sdk.set_extra('CELERY_BROKER_URL', CELERY_BROKER_URL)
 sentry_sdk.set_extra('CELERY_RESULT_BACKEND', CELERY_RESULT_BACKEND)
 sentry_sdk.set_extra('CELERY_RESULT_EXPIRES', CELERY_RESULT_EXPIRES)
 sentry_sdk.set_extra('CELERY_TASK_ALWAYS_EAGER', CELERY_TASK_ALWAYS_EAGER)
+
+# Cors
+CORS_PREFLIGHT_MAX_AGE = 0  # For debugging purposes
+CORS_ALLOWED_ORIGINS = [host for host in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',') if host]
+
+# For local docker usage
+if DEBUG:
+    CORS_ALLOWED_ORIGINS += ['localhost', 'accounts']

--- a/uv.lock
+++ b/uv.lock
@@ -1135,7 +1135,7 @@ wheels = [
 
 [[package]]
 name = "thunderbird-accounts"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },


### PR DESCRIPTION
Should fix #134 

Allowed origins requires the url scheme, so we can't just put allowed hosts into the field. If this works I'll create a follow up ticket to add a "allowed origins" db field. For now we just use the scheme from the redirect url and allowed hosts to create allowed origins. 