### PR TITLE
Fix E2E tests: Update header locator to be more specific

### DIFF
--- a/test/e2e/pages/fxa-page.ts
+++ b/test/e2e/pages/fxa-page.ts
@@ -12,7 +12,7 @@ export class FxAPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.emailHeaderText = this.page.getByText('Enter your email');
+    this.emailHeaderText = this.page.getByRole('heading', { name: 'Enter your email' });
     this.passwordHeaderText = this.page.getByText('Enter your password');
     this.userAvatar = this.page.getByTestId('avatar-default');
     this.emailInput = this.page.getByRole('textbox', { name: 'Enter your email' });


### PR DESCRIPTION
The E2E tests started failing when locating the `Enter your email` heading on the FxA sign-in page. Unsure as to why this worked fine in the past and just started failing now, but regardless making the heading locator more specific does fix the E2E tests.