### PR TITLE
Add cancel button to email sign up

### DIFF
--- a/assets/app/vue/components/SignUpFlowForm.vue
+++ b/assets/app/vue/components/SignUpFlowForm.vue
@@ -82,6 +82,6 @@ const onCancel = () => {
 .button-container {
   display: flex;
   flex-direction: row;
-  gap: 0.25rem;
+  gap: 1rem;
 }
 </style>

--- a/assets/app/vue/components/SignUpFlowForm.vue
+++ b/assets/app/vue/components/SignUpFlowForm.vue
@@ -1,12 +1,13 @@
 <script setup>
 
-import {NoticeBar, PrimaryButton, SelectInput, TextInput} from "@thunderbirdops/services-ui";
+import {NoticeBar, PrimaryButton, SecondaryButton, SelectInput, TextInput} from "@thunderbirdops/services-ui";
 import {ref} from "vue";
 import CsrfToken from "@/components/CsrfToken.vue";
 
 const signUpFlow = ref();
 const errorText = ref(window._page.formError);
 const userLoginEmail = ref(window._page.userEmail);
+const cancelRedirect = window._page.cancelRedirect;
 
 const availableDomains = window._page.allowedDomains.map((val) => {
   return {
@@ -20,6 +21,10 @@ const onSubmit = () => {
   signUpFlow.value.submit();
 }
 
+// This should be an anchor tag, but we don't have a button anchor in services-ui yet.
+const onCancel = () => {
+  window.location = cancelRedirect;
+};
 </script>
 
 <template>
@@ -35,7 +40,14 @@ const onSubmit = () => {
         <text-input :model-value="userLoginEmail" disabled="disabled" help="You'll use this email to login via Mozilla Accounts to our self-serve page and to your mail client" data-testid="sign-up-login-username-input">Login Username / Email</text-input>
         <text-input name="app_password" required="required" type="password" help="You'll use this password sign-in to your mail client" data-testid="sign-up-app-password-input">App Password</text-input>
         <br/>
-        <primary-button @click.capture="onSubmit" id="sign-up-btn" data-testid="sign-up-sign-up-btn">Sign Up</primary-button>
+        <div class="button-container">
+          <primary-button @click.capture="onSubmit" id="sign-up-btn" data-testid="sign-up-sign-up-btn"
+            >Sign Up</primary-button
+          >
+          <secondary-button @click.capture="onCancel" id="cancel-btn" data-testid="sign-up-cancel-btn"
+            >Cancel</secondary-button
+          >
+        </div>
         <csrf-token></csrf-token>
       </form>
     </div>
@@ -65,5 +77,11 @@ const onSubmit = () => {
 /* Bug fix for tbpro inputs */
 :deep(.tbpro-input) {
   box-sizing: border-box;
+}
+
+.button-container {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
 }
 </style>

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -37,6 +37,7 @@ def sign_up(request: HttpRequest):
         'mail/sign-up/index.html',
         {
             'allowed_domains': settings.ALLOWED_EMAIL_DOMAINS,
+            'cancel_redirect': reverse('self_serve_account_info'),
         },
     )
 

--- a/templates/mail/sign-up/index.html
+++ b/templates/mail/sign-up/index.html
@@ -17,6 +17,7 @@
   <div id="signUpFlowForm"></div>
   {% endif %}
   <script>
-  window._page.allowedDomains = {{ allowed_domains|safe }}
+  window._page.allowedDomains = {{ allowed_domains|safe }};
+  window._page.cancelRedirect="{{ cancel_redirect }}";
   </script>
 {% endblock %}

--- a/test/e2e/pages/email-sign-up-page.ts
+++ b/test/e2e/pages/email-sign-up-page.ts
@@ -8,6 +8,7 @@ export class EmailSignUpPage {
   readonly loginUserNameEmail: Locator;
   readonly appPassword: Locator;
   readonly signUpBtn: Locator;
+  readonly cancelBtn: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -16,6 +17,7 @@ export class EmailSignUpPage {
     this.loginUserNameEmail = this.page.getByTestId('sign-up-login-username-input');
     this.appPassword = this.page.getByTestId('sign-up-app-password-input');
     this.signUpBtn = this.page.getByRole('button', { 'name': 'Sign Up' });
+    this.cancelBtn = this.page.getByRole('button', { 'name': 'Cancel' });
   }
 
   async navigateToEmailSignUpPage() {

--- a/test/e2e/tests/email-sign-up.spec.ts
+++ b/test/e2e/tests/email-sign-up.spec.ts
@@ -54,3 +54,17 @@ test.describe('email sign-up', {
     await emailSignUpPage.signUpBtn.click();
   });
 });
+
+test.describe('cancel sign-up', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test('able to cancel sign up flow', async ({ page }) => {
+    await page.route('*/**/self-serve/account-settings', async (route, request) => {
+      console.log('captured GET /self-serve/account-settings and mocking the response');
+
+      // now send a fake response to the sign-up request
+      await route.fulfill(MOCK_RESPONSE_OK);
+    });
+    await emailSignUpPage.cancelBtn.click();
+  })
+})


### PR DESCRIPTION
Closes #64 

* Adds cancel button to email signup page (`/sign-up/`)
  * Clicking cancel button redirects to account info page (`/self-serve/account-settings`)
* Adds e2e test for cancel button (in `test/e2e/tests/email-sign-up.spec.ts`)

[Screencast_20250521_180906.webm](https://github.com/user-attachments/assets/b024b5b0-946f-4a26-97ad-e93850806c12)
