### PR TITLE
Fix issue with non-raw jq output producing double-doublequotes

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -137,7 +137,7 @@ jobs:
           # to do with the GHA workflow "env" settings above.
           export PATH="/home/runner/.pulumi/bin:$PATH"
 
-          ECR_TAG=$(jq .ecr_tag < deployment.json)
+          ECR_TAG=$(jq -r .ecr_tag < deployment.json)
           cd $PULUMI_DIR
 
           # Create a YAML config stump containing only the nested tree leading to the image tag update
@@ -167,9 +167,6 @@ jobs:
             --target 'urn:pulumi:stage::accounts::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::accounts-stage-fargate-accounts-celery-taskdef' \
             --target-dependents
         
-        # TODO: Write up something that can monitor the deployments. We don't want to run the e2e tests until we know
-        #       the deployment has completed. Can we get the deployment ID from the pulumi run?
-
   e2e-tests-browserstack-stage:
     name: e2e-tests-browserstack-stage
     needs: accounts-deploy


### PR DESCRIPTION
The `-r` argument to `jq` means it produces the "raw" output as opposed to the thing you queried with double-quotes around it. Leaving it off here results in newimage.json having some bad output with double double-quotes. A mockup of how it looks:

`image: ""host/image:tag""`

Restoring the `-r` fixes this.