### PR TITLE
Make Zendesk form loginless

### DIFF
--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -101,7 +101,6 @@ def self_serve_common_options(is_account_settings: bool, user: User, account: Ac
     }
 
 
-@login_required
 def contact(request: HttpRequest):
     """Contact page for support requests (uses ZenDesk's API)
     A user can always access this page even if they don't have a mail account setup
@@ -109,7 +108,6 @@ def contact(request: HttpRequest):
     return TemplateResponse(request, 'mail/contact.html')
 
 
-@login_required
 @require_http_methods(['GET'])
 def contact_fields(request: HttpRequest):
     """Get ticket fields from Zendesk API and filter for fields with custom options."""
@@ -150,7 +148,6 @@ def contact_fields(request: HttpRequest):
     })
 
 
-@login_required
 @require_http_methods(['POST'])
 def contact_submit(request: HttpRequest):
     """ Uses Zendesk's Requests API to create a ticket

--- a/test/e2e/tests/contact.spec.ts
+++ b/test/e2e/tests/contact.spec.ts
@@ -72,6 +72,28 @@ test.describe('contact support form', {
     await expect(contactPage.emailInput).toHaveValue(ACCTS_FXA_EMAIL);
   });
 
+  test('contact form displayed correctly without logging in', async ({ page }) => {
+    // clear authentication state for this test
+    await page.context().clearCookies();
+
+    await contactPage.navigateToContactPage();
+    await contactPage.waitForFormFieldsToLoad();
+
+    // check that the contact form is visible
+    await expect(contactPage.contactHeader).toBeVisible();
+    await expect(contactPage.requiredFieldsText).toBeVisible();
+    await expect(contactPage.emailInput).toBeVisible();
+    await expect(contactPage.subjectInput).toBeVisible();
+    await expect(contactPage.productSelect).toBeVisible();
+    await expect(contactPage.typeSelect).toBeVisible();
+    await expect(contactPage.descriptionInput).toBeVisible();
+    await expect(contactPage.fileDropzone).toBeVisible();
+    await expect(contactPage.submitButton).toBeVisible();
+
+    // check that email is not pre-filled with user's email
+    expect(contactPage.emailInput).toBeEmpty;
+  });
+
   test('able to submit contact form successfully', async ({ page }) => {
     // capture the POST /contact/submit and mock the response
     await page.route('*/**/contact/submit', async (route, request) => {


### PR DESCRIPTION
Remove the login requirements for the Zendesk related endpoints to enable a loginless form submission + tests

PS: Currently all the e2e test suites are tied up with the `auth.setup.ts` as a prerequisite but perhaps in the future it would be nice IMHO to decouple that for test suites that rely on non-logged in behavior. I am using `clearCookies` for now as doing a full logout interfere with other test suites.

Solves https://github.com/thunderbird/thunderbird-accounts/issues/185