### PR TITLE
Update the E2E checkout test to mock paddle plan subscription payment error

### DIFF
--- a/test/e2e/const/mocks/paddle.ts
+++ b/test/e2e/const/mocks/paddle.ts
@@ -5,3 +5,7 @@ export const MOCK_PRICING_RESPONSE_BAD = {
     fake_data: 'fake response data',
   }),
 };
+
+export const MOCK_SUBSCRIPTION_PAY_RESPONSE_BAD = {
+  status: 500,
+};

--- a/test/e2e/pages/paddle-frame.ts
+++ b/test/e2e/pages/paddle-frame.ts
@@ -14,6 +14,7 @@ export class PaddleFrame {
   readonly cardExpiryField: Locator;
   readonly cardVerificationField: Locator;
   readonly finalCheckoutButton: Locator;
+  readonly checkoutErrText: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -29,5 +30,6 @@ export class PaddleFrame {
     this.cardExpiryField = this.modal.getByTestId('expiryDateField');
     this.cardVerificationField = this.modal.getByTestId('cardVerificationValueInput');
     this.finalCheckoutButton = this.modal.getByTestId('cardPaymentFormSubmitButton');
+    this.checkoutErrText = this.modal.getByText('We are unable to take payment at this time. Please try again, or use a different payment method.');
   }
 }


### PR DESCRIPTION
Currently the E2E checkout test actually signs up the test account for a TB pro subscription. This modifies the E2E test to mock the paddle payment to return a payment error, so that the test won't actually sign up (which would require us to delete the subscription data after each test run).