### PR TITLE
Make Zendesk form produce tickets with correct triggers

### DIFF
--- a/src/thunderbird_accounts/mail/zendesk.py
+++ b/src/thunderbird_accounts/mail/zendesk.py
@@ -57,7 +57,9 @@ class ZendeskClient(object):
         response = requests.post(
             url,
             headers={"Content-Type": "application/json"},
-            auth=(f'{self.email}/token', self.token),
+            # This needs to be the end user's email for the ticket to be tracked correctly
+            # within Zendesk, NOT the ZENDESK_USER_EMAIL
+            auth=(f'{ticket_fields.get("email")}/token', self.token),
             json=payload
         )
 


### PR DESCRIPTION
## Description of change
If we send a request to the Requests API to create a ticket using the `ZENDESK_USER_EMAIL`, it will produce a `proactive ticket` which means a ticket created by an agent on the users behalf.

However, this endpoint should be called using the end users' email + API key combo for auth.

Note that the `GET` requests to the dynamically get the `custom_fields` still needs to be done with the `ZENDESK_USER_EMAIL` + API key combo otherwise it fails auth.

## Solves
https://github.com/thunderbird/thunderbird-accounts/issues/200