### PR TITLE
Add celery's container as a security group source

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -77,7 +77,7 @@ redis_opts = resources['tb:elasticache:ElastiCacheReplicaGroup']['accounts']
 redis = tb_pulumi.elasticache.ElastiCacheReplicationGroup(
     name=f'{project.name_prefix}-redis',
     project=project,
-    source_sgids=[container_sgs['accounts'].resources['sg'].id],
+    source_sgids=[container_sgs['accounts'].resources['sg'].id, container_sgs['accounts-celery'].resources['sg'].id],
     subnets=vpc.resources['subnets'],
     opts=pulumi.ResourceOptions(depends_on=[vpc, container_sgs['accounts']]),
     **redis_opts,


### PR DESCRIPTION
Fixes #215 

According to https://thunderbird.github.io/pulumi/elasticache.html this should be all I need? The pulumi preview shows that a new ingress rule would be added. 

