### PR TITLE
Set the default timezone to UTC

### DIFF
--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -30,7 +30,7 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
         user.oidc_id = claims.get('sub')
         user.first_name = claims.get('given_name', '')
         user.last_name = claims.get('family_name', '')
-        user.timezone = claims.get('zoneinfo')
+        user.timezone = claims.get('zoneinfo', 'UTC')
         user.avatar_url = claims.get('picture')
         user.display_name = claims.get('preferred_username')
         user.username = claims.get('preferred_username')


### PR DESCRIPTION
Fixes #218 

Keycloak doesn't have a "use user's timezone" option as a profile attribute. On the custom theme we have some javascript to set the value and hide or disable (can't remember which) the timezone field on user registration.

We don't have that custom theme setup on keycloak (and possibly other OIDCs won't have this option), so to avoid crashing accounts we should just fallback to UTC.