### PR TITLE
Add the env `OIDC_FALLBACK_MATCH_BY_EMAIL` that when true matches incoming oidc claims by email if oidc_id fails.

### DIFF
--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -382,6 +382,8 @@ resources:
                 value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/certs"
               - name: OIDC_URL_LOGOUT
                 value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/logout"
+              - name: OIDC_FALLBACK_MATCH_BY_EMAIL
+                value: 'True'
 
     accounts-celery:
       assign_public_ip: True  # Necessary, or else it can't talk out through the IG

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -68,7 +68,14 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
         sub = claims.get('sub')
         if not sub:
             return self.UserModel.objects.none()
-        return self.UserModel.objects.filter(oidc_id__iexact=sub)
+
+        user_query = self.UserModel.objects.filter(oidc_id__iexact=sub)
+
+        # Fallback to matching by email if the env is set
+        if settings.OIDC_FALLBACK_MATCH_BY_EMAIL:
+            if user_query.count() == 0:
+                user_query = self.UserModel.objects.filter(email__iexact=claims.get('email'))
+        return user_query
 
 
 class SetHostIPInAllowedHostsMiddleware:

--- a/src/thunderbird_accounts/authentication/tests.py
+++ b/src/thunderbird_accounts/authentication/tests.py
@@ -2,8 +2,44 @@ from django.conf import settings
 from django.test import TestCase, Client as RequestClient
 from django.urls import reverse
 
-
+from thunderbird_accounts.authentication.middleware import AccountsOIDCBackend
 from thunderbird_accounts.authentication.models import User
+
+
+class AccountsOIDCBackendTestCase(TestCase):
+    def setUp(self):
+        self.claim_oidc_id = 'abc123'
+        self.claim_email = 'user@example.org'
+        self.user = User.objects.create(oidc_id=self.claim_oidc_id, email=self.claim_email)
+        self.backend = AccountsOIDCBackend()
+
+    def test_filter_users_by_claims_no_fallback(self):
+        _original_setting = settings.OIDC_FALLBACK_MATCH_BY_EMAIL
+        settings.OIDC_FALLBACK_MATCH_BY_EMAIL = False
+
+        query = self.backend.filter_users_by_claims({'sub': self.claim_oidc_id, 'email': self.claim_email})
+        assert query.count() == 1
+
+        query = self.backend.filter_users_by_claims(
+            {'sub': f'{self.claim_oidc_id}_not_the_actual_id_anymore', 'email': self.claim_email}
+        )
+        assert query.count() == 0
+
+        settings.OIDC_FALLBACK_MATCH_BY_EMAIL = _original_setting
+
+    def test_filter_users_by_claims_with_fallback(self):
+        _original_setting = settings.OIDC_FALLBACK_MATCH_BY_EMAIL
+        settings.OIDC_FALLBACK_MATCH_BY_EMAIL = True
+
+        query = self.backend.filter_users_by_claims({'sub': self.claim_oidc_id, 'email': self.claim_email})
+        assert query.count() == 1
+
+        query = self.backend.filter_users_by_claims(
+            {'sub': f'{self.claim_oidc_id}_not_the_actual_id_anymore', 'email': self.claim_email}
+        )
+        assert query.count() == 1
+
+        settings.OIDC_FALLBACK_MATCH_BY_EMAIL = _original_setting
 
 
 class LoginRequiredTestCase(TestCase):

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -328,6 +328,10 @@ if AUTH_SCHEME == 'oidc':
 
     OIDC_OP_LOGOUT_URL_METHOD = 'thunderbird_accounts.settings.oidc_logout'
 
+    # this should only be used to transition users from one oidc to another
+    # ideally you should turn this off when you're done.
+    OIDC_FALLBACK_MATCH_BY_EMAIL = os.getenv('OIDC_FALLBACK_MATCH_BY_EMAIL', '').lower() == 'True'
+
 
 STALWART_API_URL = os.getenv('STALWART_API_URL')
 STALWART_API_AUTH_STRING = os.getenv('STALWART_API_AUTH_STRING')

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -330,7 +330,7 @@ if AUTH_SCHEME == 'oidc':
 
     # this should only be used to transition users from one oidc to another
     # ideally you should turn this off when you're done.
-    OIDC_FALLBACK_MATCH_BY_EMAIL = os.getenv('OIDC_FALLBACK_MATCH_BY_EMAIL', '').lower() == 'True'
+    OIDC_FALLBACK_MATCH_BY_EMAIL = os.getenv('OIDC_FALLBACK_MATCH_BY_EMAIL', '').lower() == 'true'
 
 
 STALWART_API_URL = os.getenv('STALWART_API_URL')


### PR DESCRIPTION
Fixes #221 

I wasn't expecting us to not nuke stage with the oidc move. But with this option it doesn't matter. Once we're good we can disable it so incoming users from the oidc login flow will be matched only by oidc_id (or created if not matched.)
