### PR TITLE
Adjust oidc email fallback to match only 1 (oldest), and delete the rest.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,4 +137,5 @@ pythonpath = "test"
 [dependency-groups]
 dev = [
     "faker>=33.1.0",
+    "freezegun>=1.5.5",
 ]

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -73,8 +73,20 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
 
         # Fallback to matching by email if the env is set
         if settings.OIDC_FALLBACK_MATCH_BY_EMAIL:
-            if user_query.count() == 0:
-                user_query = self.UserModel.objects.filter(email__iexact=claims.get('email'))
+            if len(user_query) == 0:
+                user_query = self.UserModel.objects.filter(email__iexact=claims.get('email')).order_by("created_at")
+
+                # Remove any weird duplicate accounts
+                # See issue #236 for context
+                if len(user_query) > 1:
+                    to_remove = user_query[1:]
+                    logging.warning(
+                        f'[AccountsOIDCBackend.filter_users_by_claims] Deleting {len(to_remove)} duplicate accounts!')
+                    for user in to_remove:
+                        user.delete()
+
+                # Select the first account
+                user_query = user_query[:1]
         return user_query
 
 

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -74,14 +74,15 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
         # Fallback to matching by email if the env is set
         if settings.OIDC_FALLBACK_MATCH_BY_EMAIL:
             if len(user_query) == 0:
-                user_query = self.UserModel.objects.filter(email__iexact=claims.get('email')).order_by("created_at")
+                user_query = self.UserModel.objects.filter(email__iexact=claims.get('email')).order_by('created_at')
 
                 # Remove any weird duplicate accounts
                 # See issue #236 for context
                 if len(user_query) > 1:
                     to_remove = user_query[1:]
                     logging.warning(
-                        f'[AccountsOIDCBackend.filter_users_by_claims] Deleting {len(to_remove)} duplicate accounts!')
+                        f'[AccountsOIDCBackend.filter_users_by_claims] Deleting {len(to_remove)} duplicate accounts!'
+                    )
                     for user in to_remove:
                         user.delete()
 

--- a/src/thunderbird_accounts/authentication/tests.py
+++ b/src/thunderbird_accounts/authentication/tests.py
@@ -12,7 +12,9 @@ class AccountsOIDCBackendTestCase(TestCase):
         self.claim_oidc_id = 'abc123'
         self.claim_email = 'user@example.org'
         with freezegun.freeze_time('Apr 4th, 2000'):
-            self.user = User.objects.create(oidc_id=self.claim_oidc_id, username='test@example.org', email=self.claim_email)
+            self.user = User.objects.create(
+                oidc_id=self.claim_oidc_id, username='test@example.org', email=self.claim_email
+            )
             self.user.save()
             self.user.refresh_from_db()
         self.backend = AccountsOIDCBackend()

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -23,7 +23,7 @@ def create_stalwart_account(self, user_uuid: str, username: str, email: str, app
                 f' Cannot create a Stalwart account with the username {username} for {email}.'
             ),
             level='error',
-            user=user_uuid,
+            user={'uuid': user_uuid},
         )
         return {
             'uuid': user_uuid,

--- a/uv.lock
+++ b/uv.lock
@@ -432,6 +432,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,6 +1196,9 @@ subscription = [
 ]
 
 [package.dev-dependencies]
+cli = [
+    { name = "freezegun" },
+]
 dev = [
     { name = "faker" },
 ]
@@ -1224,6 +1239,7 @@ requires-dist = [
 provides-extras = ["cli", "docs", "subscription"]
 
 [package.metadata.requires-dev]
+cli = [{ name = "freezegun", specifier = ">=1.5.5" }]
 dev = [{ name = "faker", specifier = ">=33.1.0" }]
 
 [[package]]


### PR DESCRIPTION
Also fix tests to ensure that I don't nuke everyone.

Fixes #236 

This occurs when the oidc_id field is empty (as we're migrating existing users over) with multiple accounts matching by email. (Not sure how that happened, but it exists on stage.) 

The OIDC middleware (that we extend) fails on multi-user match. So lets limit the matching by 1, and delete the newer accounts. 

This pathing only occurs if `OIDC_FALLBACK_MATCH_BY_EMAIL == true` which is not expected to be a default flag, but more of a migration period flag.  