### PR TITLE
Fix where we get the keycloak image tag

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Produce an artifact containing the tag and version
         id: create-artifact
         run: |
-          echo '{"ecr_tag": "${{ steps.build-accounts.outputs.keycloak-image }}", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
+          echo '{"ecr_tag": "${{ steps.build-keycloak.outputs.keycloak-image }}", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
 
       - name: Archive the deployment artifact
         id: tag-archive


### PR DESCRIPTION
The reason the automation is breaking is that we are pulling the ECR tag from the wrong build step, one that doesn't really exist. Thus, this value is none/null, and we get a validation error.