### PR TITLE
Fix Zendesk Contact form fields reset

### DIFF
--- a/assets/app/vue/components/ContactSupportForm.vue
+++ b/assets/app/vue/components/ContactSupportForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { NoticeBar, TextInput, TextArea, SelectInput, PrimaryButton } from '@thunderbirdops/services-ui';
+import { NoticeBar, TextInput, TextArea, SelectInput, PrimaryButton, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import CsrfToken from '@/components/CsrfToken.vue';
 
 const TICKET_CUSTOM_FIELD_NAMES = {
@@ -22,6 +22,11 @@ const form = ref({
 });
 const formRef = ref(null);
 const fileInput = ref(null);
+
+// services-ui's TextInput and TextArea field references for resetting form state
+const emailInput = ref(null);
+const subjectInput = ref(null);
+const descriptionInput = ref(null);
 
 // Dynamic options from API
 const productOptions = ref([]);
@@ -118,6 +123,12 @@ const resetForm = () => {
   errorText.value = '';
   successText.value = '';
 
+  // services-ui's TextInput and TextArea components don't reset their internal state
+  // when the form is reset, so we need to reset them manually
+  emailInput.value.reset();
+  subjectInput.value.reset();
+  descriptionInput.value.reset();
+
   formRef.value.reset();
 };
 
@@ -182,21 +193,29 @@ onMounted(() => {
 </script>
 
 <template>
-  <notice-bar type="error" v-if="errorText" class="notice">{{ errorText }}</notice-bar>
-  <notice-bar type="success" v-if="successText" class="notice">{{ successText }}</notice-bar>
+  <notice-bar :type="NoticeBarTypes.Error" v-if="errorText" class="notice">{{ errorText }}</notice-bar>
+  <notice-bar :type="NoticeBarTypes.Success" v-if="successText" class="notice">{{ successText }}</notice-bar>
 
   <form @submit.prevent="handleSubmit" method="post" action="/contact/submit" ref="formRef">
     <!-- Email -->
-    <text-input name="email" type="email" v-model="form.email" required="required" data-testid="contact-email-input">
+    <text-input
+      ref="emailInput"
+      name="email"
+      type="email"
+      v-model="form.email"
+      :required="true"
+      data-testid="contact-email-input"
+    >
       Your email address
     </text-input>
 
     <!-- Subject -->
     <text-input
+      ref="subjectInput"
       name="subject"
       type="text"
       v-model="form.subject"
-      required="required"
+      :required="true"
       data-testid="contact-subject-input"
     >
       Subject
@@ -207,7 +226,7 @@ onMounted(() => {
       name="product"
       :options="productOptions"
       v-model="form.product"
-      required="required"
+      :required="true"
       data-testid="contact-product-input"
     >
       Product
@@ -218,7 +237,7 @@ onMounted(() => {
       name="type"
       :options="typeOptions"
       v-model="form.type"
-      required="required"
+      :required="true"
       data-testid="contact-type-input"
     >
       Type of Request
@@ -226,9 +245,10 @@ onMounted(() => {
 
     <!-- Description -->
     <text-area
+      ref="descriptionInput"
       name="description"
       v-model="form.description"
-      required="required"
+      :required="true"
       data-testid="contact-description-input"
     >
       Description

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@paddle/paddle-js": "^1.4.0",
-        "@thunderbirdops/services-ui": "^0.6.19",
+        "@thunderbirdops/services-ui": "^0.6.22",
         "vue": "^3.5.13",
         "vue-i18n": "^11.1.11",
         "vue-router": "^4.5.1"
@@ -1167,9 +1167,9 @@
       "license": "MIT"
     },
     "node_modules/@thunderbirdops/services-ui": {
-      "version": "0.6.20",
-      "resolved": "https://registry.npmjs.org/@thunderbirdops/services-ui/-/services-ui-0.6.20.tgz",
-      "integrity": "sha512-304qsfTP++FWxf+y8XpLnbGBTWj5YNB4JU6hkQsRzbPH6ya7VzLMG6U+y8yLUyEPJWnr/oG1bS8jTQBVnzW62Q==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@thunderbirdops/services-ui/-/services-ui-0.6.22.tgz",
+      "integrity": "sha512-EfrD/2OPstJPJlpdDwnuCJmw4LlwLzLrRum/85sqAKn7boK9E0FbMWIJt1Br8uoV06rJshBc6L0StriNtLHemw==",
       "license": "MPL-2.0",
       "dependencies": {
         "vue": "^3.4.29",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/thunderbird/thunderbird-accounts#readme",
   "dependencies": {
     "@paddle/paddle-js": "^1.4.0",
-    "@thunderbirdops/services-ui": "^0.6.19",
+    "@thunderbirdops/services-ui": "^0.6.22",
     "vue": "^3.5.13",
     "vue-i18n": "^11.1.11",
     "vue-router": "^4.5.1"


### PR DESCRIPTION
## Description of change
After submitting the contact form, we are resetting the form to its original state. However, `services-ui`'s TextInput and TextArea components have internal state that have to be manually / "imperatively" reset.

This PR updates:
- `services-ui` to 0.6.22
- some better types
- manual reset of the inputs so now it doesn't look broken upon successfully submitting


https://github.com/user-attachments/assets/07e059fe-3cdf-4e7b-b461-285ff18c3d8c



## Solves
https://github.com/thunderbird/thunderbird-accounts/issues/240