### PR TITLE
Create stalwart account on login under certain conditions

### DIFF
--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -82,7 +82,8 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
 
         # If we somehow have an accounts user but don't have a stalwart account associated, create one.
         # But make sure our username is within the allowed email domains!
-        if not user.stalwart_username and any([user.username.endswith(domain) for domain in settings.ALLOWED_EMAIL_DOMAINS]):
+        if not user.stalwart_username and any(
+                [user.username.endswith(domain) for domain in settings.ALLOWED_EMAIL_DOMAINS]):
             self.create_stalwart_account(user)
 
         return user

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -10,6 +10,9 @@ from .utils import is_email_in_allow_list
 
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
+from thunderbird_accounts.mail import tasks
+from thunderbird_accounts.mail.models import Account, Email
+
 
 class AccountsOIDCBackend(OIDCAuthenticationBackend):
     def _check_allow_list(self, claims: dict):
@@ -21,6 +24,20 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
             raise PermissionDenied()
 
         return True
+
+    def create_stalwart_account(self, user):
+        # Run this immediately for now, in the future we'll ship these to celery
+        tasks.create_stalwart_account.run(
+            user_uuid=user.uuid.hex, username=user.username, email=user.email
+        )
+
+        # Also create their account objects
+        account = Account.objects.create(
+            name=user.username,
+            active=True,
+            user=user,
+        )
+        Email.objects.create(address=user.username, type='primary', account=account)
 
     def _set_user_fields(self, user: User, claims: dict):
         print('User -> ', user)
@@ -48,6 +65,8 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
         user = self._set_user_fields(user, claims)
         user.save()
 
+        self.create_stalwart_account(user)
+
         return user
 
     def update_user(self, user, claims):
@@ -60,6 +79,11 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
         if claims.get('email') and user.email != claims.get('email'):
             user.email = claims.get('email')
         user.save()
+
+        # If we somehow have an accounts user but don't have a stalwart account associated, create one.
+        # But make sure our username is within the allowed email domains!
+        if not user.stalwart_username and any([user.username.endswith(domain) for domain in settings.ALLOWED_EMAIL_DOMAINS]):
+            self.create_stalwart_account(user)
 
         return user
 

--- a/src/thunderbird_accounts/mail/client.py
+++ b/src/thunderbird_accounts/mail/client.py
@@ -63,7 +63,7 @@ class MailClient:
         self._raise_for_error(response)
 
         # Reduce log spam
-        #logging.info(f'[MailClient._list_principals()]: {response.json()}')
+        # logging.info(f'[MailClient._list_principals()]: {response.json()}')
 
         return response
 
@@ -74,7 +74,8 @@ class MailClient:
 
         Important: Don't use this directly!
         """
-        response = requests.get(f'{self.api_url}/principal/{principal_id}', verify=False, headers=self.authorized_headers)
+        response = requests.get(f'{self.api_url}/principal/{principal_id}', verify=False,
+                                headers=self.authorized_headers)
         response.raise_for_status()
         self._raise_for_error(response)
 

--- a/src/thunderbird_accounts/mail/client.py
+++ b/src/thunderbird_accounts/mail/client.py
@@ -238,6 +238,20 @@ class MailClient:
             logging.error(f'[save_app_password] err: {data}')
             raise RuntimeError(data)
 
+    def save_email_address(self, username, email):
+        """Adds a new email address to a stalwart's individual principal by stalwart username."""
+        response = self._update_principal(
+            username,
+            [{'action': 'addItem', 'field': 'emails', 'value': email}],
+        )
+        # Returns data: null on success...
+        data = response.json()
+        error = data.get('error')
+        # I have no idea what the error is yet
+        if error:
+            logging.error(f'[save_email_address] err: {data}')
+            raise RuntimeError(data)
+
     def make_api_key(self, username, password):
         if not settings.IS_DEV:
             raise RuntimeError('You can only make api keys in dev.')


### PR DESCRIPTION
Accounts stage and prod are a bit of mess, so if we don't have an accounts object then either create or partially create one. 

Since this is cross-service it's not easily testable, still thinking about how we can test this but for now this will do.