### PR TITLE
Fix browserstack jobs by updating playwright version

### DIFF
--- a/test/e2e/browserstack.yml
+++ b/test/e2e/browserstack.yml
@@ -80,6 +80,7 @@ debug: false # <boolean> # Set to true if you need screenshots for every seleniu
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
 consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
+browserstack.playwrightVersion: 1.55.0 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "1.55.0",
         "@types/node": "^22.10.1",
         "browserstack-node-sdk": "^1.34.34",
         "dotenv": "^16.3.1",
@@ -234,13 +234,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.1"
+        "playwright": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.40.8",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.40.8.tgz",
-      "integrity": "sha512-6XPXltfmRqjB3yGS9i/UZwHIRXqy1F4ufEMUvqZ+819e4q8F+URcTSwOYELqcdO/DNyCZH0MClZk0k3Pt9FfHQ==",
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.42.2.tgz",
+      "integrity": "sha512-w0NNgfPY8NQNOesWUlqdDfS3PMNel1W3UIG5M5zp2zWWZlDSXj7wRnOk71UrWqSb62hjh27H6bZCpQEU87cobQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -4233,13 +4233,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4252,9 +4252,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "1.55.0",
     "@types/node": "^22.10.1",
     "browserstack-node-sdk": "^1.34.34",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
BrowserStack test jobs starting failing out of the blue (see #256) however updating the Playwright version locally and in BrowserStack appears to fix the issue