### PR TITLE
Build CI users with SAPS

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -124,7 +124,18 @@ if 'tb:ci:AwsAutomationUser' in resources and 'ci' in resources['tb:ci:AwsAutoma
     ci_opts = resources['tb:ci:AwsAutomationUser']['ci']
     ci_iam = tb_pulumi.ci.AwsAutomationUser(name=f'{project.project}-ci', project=project, **ci_opts)
 
+def __sap_on_apply(resources):
+    ci_user_name = f'{project.name_prefix}-ci'
+    ci_user = tb_pulumi.iam.UserWithAccessKey(
+        ci_user_name,
+        project=project,
+        user_name=ci_user_name,
+        groups=[resources['admin_group']],
+        opts=pulumi.ResourceOptions(depends_on=[sap])
+    )
+
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',
     project=project,
+    on_apply=__sap_on_apply,
 )

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -124,6 +124,7 @@ if 'tb:ci:AwsAutomationUser' in resources and 'ci' in resources['tb:ci:AwsAutoma
     ci_opts = resources['tb:ci:AwsAutomationUser']['ci']
     ci_iam = tb_pulumi.ci.AwsAutomationUser(name=f'{project.project}-ci', project=project, **ci_opts)
 
+
 def __sap_on_apply(resources):
     ci_user_name = f'{project.name_prefix}-ci'
     tb_pulumi.iam.UserWithAccessKey(
@@ -131,8 +132,9 @@ def __sap_on_apply(resources):
         project=project,
         user_name=ci_user_name,
         groups=[resources['admin_group']],
-        opts=pulumi.ResourceOptions(depends_on=[sap])
+        opts=pulumi.ResourceOptions(depends_on=[sap]),
     )
+
 
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -126,7 +126,7 @@ if 'tb:ci:AwsAutomationUser' in resources and 'ci' in resources['tb:ci:AwsAutoma
 
 def __sap_on_apply(resources):
     ci_user_name = f'{project.name_prefix}-ci'
-    ci_user = tb_pulumi.iam.UserWithAccessKey(
+    tb_pulumi.iam.UserWithAccessKey(
         ci_user_name,
         project=project,
         user_name=ci_user_name,

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -197,7 +197,7 @@ resources:
           - FARGATE
         container_definitions:
           keycloak:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-9097225846a7fbaa214dff96abdf38bcc1feeccc
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-fd67515839b2570189b98f10c0375b87fbc62af5
             command:
               - start
             portMappings:
@@ -269,7 +269,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:6f75df9a3475b6a6106022c3662501963346df66
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:fd67515839b2570189b98f10c0375b87fbc62af5
             portMappings:
               - name: accounts
                 containerPort: 8087
@@ -424,7 +424,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:6f75df9a3475b6a6106022c3662501963346df66
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:fd67515839b2570189b98f10c0375b87fbc62af5
             linuxParameters:
               initProcessEnabled: True
             secrets:


### PR DESCRIPTION
This depends upon [this PR](https://github.com/thunderbird/pulumi/pull/211).

This waits until our stack access polices (and the user groups they create) are done building, and then it builds a CI user and sticks it in the admin group. This user has full access to the single environment it's been created in.