### PR TITLE
Install autoscalers for accounts (but not Keycloak)

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -121,7 +121,7 @@ for service, opts in resources['tb:fargate:FargateClusterWithLogging'].items():
             opts=pulumi.ResourceOptions(depends_on=[fargate_clusters[service]]),
             **autoscaler_opts,
         )
-        
+
 
 cloudflare_backend_record = cloudflare.Record(
     f'{project.name_prefix}-dns-backend',

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -554,14 +554,24 @@ resources:
       min_capacity: 2
       max_capacity: 4
       suspend: False
-    keycloak:
+    accounts-celery:
       cpu_threshold: 80
       ram_threshold: 80
       cooldown: 180
       disable_scale_in: False
       min_capacity: 2
       max_capacity: 4
-      suspend: False
+
+    # NOTE: Uncomment below when keycloak session sync is fixed
+    # Ref: https://github.com/thunderbird/thunderbird-accounts/issues/272
+    # keycloak:
+    #   cpu_threshold: 80
+    #   ram_threshold: 80
+    #   cooldown: 180
+    #   disable_scale_in: False
+    #   min_capacity: 2
+    #   max_capacity: 4
+    #   suspend: False
 
   tb:ci:AwsAutomationUser:
     ci:

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -545,6 +545,24 @@ resources:
               - name: STALWART_BASE_API_URL
                 value: 'https://mailstrom-management-i.thundermail.com:8080'
 
+  tb:autoscale:EcsServiceAutoscaler:
+    accounts:
+      cpu_threshold: 80
+      ram_threshold: 80
+      cooldown: 180
+      disable_scale_in: False
+      min_capacity: 2
+      max_capacity: 4
+      suspend: False
+    keycloak:
+      cpu_threshold: 80
+      ram_threshold: 80
+      cooldown: 180
+      disable_scale_in: False
+      min_capacity: 2
+      max_capacity: 4
+      suspend: False
+
   tb:ci:AwsAutomationUser:
     ci:
       enable_ecr_image_push: true

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -199,7 +199,7 @@ resources:
           - FARGATE
         container_definitions:
           keycloak:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-fc05641eaffe2b2b2e876f71d78f2b4aff44df97
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-6f807fa7427fdccd1757b65f4b53f106f51b94fe
             command:
               - start
             portMappings:
@@ -271,7 +271,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:d31bf9141e11c7474ca820538fbb64af3f678931
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:da25c40236dbfd2096624e8baff26aee21ad88e7
             portMappings:
               - name: accounts
                 containerPort: 8087
@@ -433,7 +433,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:d31bf9141e11c7474ca820538fbb64af3f678931
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:da25c40236dbfd2096624e8baff26aee21ad88e7
             linuxParameters:
               initProcessEnabled: True
             secrets:
@@ -566,6 +566,24 @@ resources:
                 value: 'https://auth-stage.tb.pro/admin/realms/tbpro/'
               - name: KEYCLOAK_ADMIN_URL_TOKEN
                 value: 'https://auth-stage.tb.pro/realms/master/protocol/openid-connect/token/'
+
+  tb:autoscale:EcsServiceAutoscaler:
+    accounts:
+      cpu_threshold: 80
+      ram_threshold: 80
+      cooldown: 180
+      disable_scale_in: False
+      min_capacity: 2
+      max_capacity: 4
+      suspend: False
+    keycloak:
+      cpu_threshold: 80
+      ram_threshold: 80
+      cooldown: 180
+      disable_scale_in: False
+      min_capacity: 2
+      max_capacity: 4
+      suspend: False
 
   tb:ci:AwsAutomationUser:
     ci:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -576,7 +576,7 @@ resources:
       min_capacity: 2
       max_capacity: 4
       suspend: False
-    keycloak:
+    accounts-celery:
       cpu_threshold: 80
       ram_threshold: 80
       cooldown: 180
@@ -584,6 +584,17 @@ resources:
       min_capacity: 2
       max_capacity: 4
       suspend: False
+
+    # NOTE: Uncomment below when keycloak session sync is fixed
+    # Ref: https://github.com/thunderbird/thunderbird-accounts/issues/272
+    # keycloak:
+    #   cpu_threshold: 80
+    #   ram_threshold: 80
+    #   cooldown: 180
+    #   disable_scale_in: False
+    #   min_capacity: 2
+    #   max_capacity: 4
+    #   suspend: False
 
   tb:ci:AwsAutomationUser:
     ci:


### PR DESCRIPTION
What it says on the tin.

This places basic CPU and RAM-driven autoscaling for the backend API and the Celery containers. I did briefly enable this for Keycloak, but it broke. Seems it [tracks sessions on the container](https://github.com/thunderbird/thunderbird-accounts/issues/272) and otherwise requires the use of an obscure (to me?) cache system. So just the accounts services for now.