### PR TITLE
Add an entry script that depending on an env, run kc in prod or dev mode.

### DIFF
--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -24,4 +24,6 @@ FROM quay.io/keycloak/keycloak:26.3
 COPY --chown=keycloak:keycloak keycloak/data/import /opt/keycloak/data/import
 COPY --from=build /app/keycloak/themes/tbpro /opt/keycloak/themes/tbpro
 
-ENTRYPOINT ["/bin/bash", "/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm"]
+COPY scripts/entry-keycloak.sh scripts/entry.sh
+
+ENTRYPOINT ["./scripts/entry.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,7 @@ services:
       KC_DB_URL_PORT: '5434'
       KC_DB_USERNAME: "kc"
       KC_DB_PASSWORD: "kc"
+      KC_DEV: yes  # Run the container with start-dev instead of start
     volumes:
       - "./keycloak/themes:/opt/keycloak/themes"
       - "./keycloak/data/export:/opt/keycloak/data/export"

--- a/scripts/entry-keycloak.sh
+++ b/scripts/entry-keycloak.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage:
+#   Running this script with the default options will launch the backend in an environment-ready
+#   mode. To run in development mode instead, run with KC_DEV=yes.
+
+# Run the app with the appropriate command
+if [[ "$KC_DEV" == "yes" ]]; then
+    CMD="/bin/bash /opt/keycloak/bin/kc.sh start-dev --import-realm"
+else
+    CMD="/bin/bash /opt/keycloak/bin/kc.sh start --http-enabled=true --proxy-headers forwarded"
+fi
+
+$CMD


### PR DESCRIPTION
Related #272 

We may have to do some tweaking for AWS, but this seemingly works locally.
https://www.keycloak.org/server/reverseproxy#_trusted_proxies