### PR TITLE
Enable scaling for keycloak

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -52,7 +52,8 @@ for service, sg in resources['tb:network:SecurityGroupWithRules']['containers'].
         raise ValueError(f'{MSG_LB_MATCHING_CONTAINER} Create a matching load_balancers entry for "{service}".')
     # Allow access from each load balancer to its respective container
     for rule in sg['rules']['ingress']:
-        rule['source_security_group_id'] = lb_sgs[service].resources['sg'].id
+        if 'self' not in rule or not rule['self']:
+            rule['source_security_group_id'] = lb_sgs[service].resources['sg'].id
     depends_on = [lb_sgs[service].resources['sg'], vpc] if lb_sgs[service] else []
 
     container_sgs[service] = tb_pulumi.network.SecurityGroupWithRules(

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -54,6 +54,7 @@ for service, sg in resources['tb:network:SecurityGroupWithRules']['containers'].
     for rule in sg['rules']['ingress']:
         rule['source_security_group_id'] = lb_sgs[service].resources['sg'].id
     depends_on = [lb_sgs[service].resources['sg'], vpc] if lb_sgs[service] else []
+
     container_sgs[service] = tb_pulumi.network.SecurityGroupWithRules(
         name=f'{project.name_prefix}-sg-cont-{service}',
         project=project,

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -114,10 +114,7 @@ resources:
               protocol: tcp
               from_port: 7800
               to_port: 7800
-              # The following security group is self-referential. If you have to rebuild this env from scratch,
-              # you will have to uncomment this rule to do the initial build, then uncomment it and update this
-              # rule ID with the security group created by this config.
-              source_security_group_id: sg-0f703e22b05e6f0c3
+              self: True
           egress:
             - description: Allow traffic from the container out to the Internet
               cidr_blocks:

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -109,6 +109,15 @@ resources:
               protocol: tcp
               from_port: 9000
               to_port: 9000
+            # KeyCloak clustered nodes speak to each other on port 7800
+            - description: Allow clustered nodes to communicate
+              protocol: tcp
+              from_port: 7800
+              to_port: 7800
+              # The following security group is self-referential. If you have to rebuild this env from scratch,
+              # you will have to uncomment this rule to do the initial build, then uncomment it and update this
+              # rule ID with the security group created by this config.
+              source_security_group_id: sg-0f703e22b05e6f0c3
           egress:
             - description: Allow traffic from the container out to the Internet
               cidr_blocks:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -109,6 +109,15 @@ resources:
               protocol: tcp
               from_port: 9000
               to_port: 9000
+            # KeyCloak clustered nodes speak to each other on port 7800
+            - description: Allow clustered nodes to communicate
+              protocol: tcp
+              from_port: 7800
+              to_port: 7800
+              # The following security group is self-referential. If you have to rebuild this env from scratch,
+              # you will have to uncomment this rule to do the initial build, then uncomment it and update this
+              # rule ID with the security group created by this config.
+              source_security_group_id: sg-0cf2676258c552f8c
           egress:
             - description: Allow traffic from the container out to the Internet
               cidr_blocks:
@@ -199,7 +208,7 @@ resources:
           - FARGATE
         container_definitions:
           keycloak:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-6f807fa7427fdccd1757b65f4b53f106f51b94fe
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-7af48fff73c4f5f29ec56b0b3e6b29079353bab0
             command:
               - start
             portMappings:
@@ -271,7 +280,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:da25c40236dbfd2096624e8baff26aee21ad88e7
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:7af48fff73c4f5f29ec56b0b3e6b29079353bab0
             portMappings:
               - name: accounts
                 containerPort: 8087
@@ -433,7 +442,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:da25c40236dbfd2096624e8baff26aee21ad88e7
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:7af48fff73c4f5f29ec56b0b3e6b29079353bab0
             linuxParameters:
               initProcessEnabled: True
             secrets:
@@ -587,14 +596,14 @@ resources:
 
     # NOTE: Uncomment below when keycloak session sync is fixed
     # Ref: https://github.com/thunderbird/thunderbird-accounts/issues/272
-    # keycloak:
-    #   cpu_threshold: 80
-    #   ram_threshold: 80
-    #   cooldown: 180
-    #   disable_scale_in: False
-    #   min_capacity: 2
-    #   max_capacity: 4
-    #   suspend: False
+    keycloak:
+      cpu_threshold: 80
+      ram_threshold: 80
+      cooldown: 180
+      disable_scale_in: False
+      min_capacity: 2
+      max_capacity: 4
+      suspend: False
 
   tb:ci:AwsAutomationUser:
     ci:

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -114,10 +114,7 @@ resources:
               protocol: tcp
               from_port: 7800
               to_port: 7800
-              # The following security group is self-referential. If you have to rebuild this env from scratch,
-              # you will have to uncomment this rule to do the initial build, then uncomment it and update this
-              # rule ID with the security group created by this config.
-              source_security_group_id: sg-0cf2676258c552f8c
+              self: True
           egress:
             - description: Allow traffic from the container out to the Internet
               cidr_blocks:


### PR DESCRIPTION
This is a self-referential rule. That is, we allow any entity the SG gets attached to to speak on port 7800 with any other entity the SG is attached to. This allows our Keycloak containers to speak their cluster protocol with each other.