### PR TITLE
Update secrets & work-around VPC peering ssl issue on prod

### DIFF
--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -61,3 +61,11 @@ config:
     secure: AAABAHmGNAUpB5Cn2v3+E0BRX6IzJa9Z1xPc4hlOJUU7Ze77JIK/AA8M6WEHBx1HJOk2Pmo=
   accounts:oidc-sign-algo:
     secure: AAABAJII4yJIQGxGc07VLQJqqxDKszZ+RWg7fVvVzPLK5NeKqw==
+  accounts:keycloak-admin-client-id:
+    secure: AAABALR7duQEQUXxGG1gnbN0YKjGUDW4rQgO2AUUXc/p6tuQUnWPS9J9fFCJAzCsFg==
+  accounts:keycloak-admin-client-secret:
+    secure: AAABAAdWkOjtE/Wu2kfRA+1keOz3Goc9LTSofyRvMV8vRdH8GI7iwMBcAKu/Or8B4KUFr6ET9bquylETyBzrLA==
+  accounts:stalwart-api-auth-key:
+    secure: AAABAL+jwS313yLJ4lPdw7sTUnDWz7JFxCdK7m3Ynexb9x15SZFRD6AzxUTrQTipTBoC1g5oM7j7aUNdnBMTtr7LbX0bYrYpcICG8syBMFbnHZWQg6j0983XbRc8ccGO5xQrFhOodpI=
+  accounts:stalwart-api-auth-method:
+    secure: AAABAIesea0SHkKIagR9AyMAr7sJPucCFdafKHZqGA25AXy/32Y=

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -155,6 +155,11 @@ resources:
         - oidc-client-secret
         - oidc-client-id
         - oidc-sign-algo
+        - stalwart-api-auth-method
+        - stalwart-api-auth-key
+        - keycloak-admin-client-id
+        - keycloak-admin-client-secret
+
 
   tb:ec2:SshableInstance: {}
   # Fill out this template to build an SSH bastion
@@ -201,7 +206,7 @@ resources:
           - FARGATE
         container_definitions:
           keycloak:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-d7efc69b5dc4b9d925f3d61a798213b6dc24db81
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-1a25562dde49115f3461c5e77ad85e6d470a3bbc
             command:
               - start
             portMappings:
@@ -277,7 +282,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:feff24ea6ef90b11fa40fbc40c6cab35d1bbf006
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:1a25562dde49115f3461c5e77ad85e6d470a3bbc
             portMappings:
               - name: accounts
                 containerPort: 8087
@@ -335,6 +340,14 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/paddle-webhook-key-vX5JHE
               - name: PADDLE_API_KEY
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/paddle-api-key-yz3XNN
+              - name: KEYCLOAK_ADMIN_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/keycloak-admin-client-id-DOpTIZ
+              - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/keycloak-admin-client-secret-3CMuUp
+              - name: STALWART_API_AUTH_STRING
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-key-cnGrUN
+              - name: STALWART_API_AUTH_METHOD
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-method-ErlvTR
             environment:
               - name: ADMIN_CONTACT
                 value: dummy@example.org
@@ -395,21 +408,25 @@ resources:
               - name: SUPPORT_CONTACT
                 value: dummy@example.org
               - name: OIDC_URL_AUTH
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth/"
               - name: OIDC_URL_TOKEN
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token/"
               - name: OIDC_URL_USER
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/userinfo"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/userinfo/"
               - name: OIDC_URL_JWKS
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/certs"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/certs/"
               - name: OIDC_URL_LOGOUT
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/logout"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/logout/"
               - name: OIDC_FALLBACK_MATCH_BY_EMAIL
                 value: 'True'
               - name: STALWART_BASE_JMAP_URL
                 value: 'https://mail.thundermail.com'
               - name: STALWART_BASE_API_URL
-                value: 'https://mailstrom-management-i.thundermail.com:8080'
+                value: 'https://mailstrom-prod-management-i.thundermail.com:8080'
+              - name: KEYCLOAK_URL_API
+                value: 'https://auth.tb.pro/admin/realms/tbpro/'
+              - name: KEYCLOAK_ADMIN_URL_TOKEN
+                value: 'https://auth.tb.pro/realms/master/protocol/openid-connect/token/'
 
     accounts-celery:
       assign_public_ip: True  # Necessary, or else it can't talk out through the IG
@@ -427,7 +444,7 @@ resources:
           - FARGATE
         container_definitions:
           accounts:
-            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:feff24ea6ef90b11fa40fbc40c6cab35d1bbf006
+            image: 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:1a25562dde49115f3461c5e77ad85e6d470a3bbc
             linuxParameters:
               initProcessEnabled: True
             secrets:
@@ -468,7 +485,7 @@ resources:
               - name: OIDC_CLIENT_ID
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/oidc-client-id-HjOG4R
               - name: OIDC_SIGN_ALGO
-                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/oidc-sign-algo-N6vK9
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/oidc-sign-algo-N6vK9L
               - name: ZENDESK_SUBDOMAIN
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/zendesk-subdomain-C2G7He
               - name: ZENDESK_USER_EMAIL
@@ -479,6 +496,14 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/paddle-webhook-key-vX5JHE
               - name: PADDLE_API_KEY
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/paddle-api-key-yz3XNN
+              - name: KEYCLOAK_ADMIN_CLIENT_ID
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/keycloak-admin-client-id-DOpTIZ
+              - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/keycloak-admin-client-secret-3CMuUp
+              - name: STALWART_API_AUTH_STRING
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-key-cnGrUN
+              - name: STALWART_API_AUTH_METHOD
+                valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-method-ErlvTR
             environment:
               - name: ADMIN_CONTACT
                 value: dummy@example.org
@@ -539,21 +564,25 @@ resources:
               - name: TBA_CELERY
                 value: "yes"
               - name: OIDC_URL_AUTH
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth/"
               - name: OIDC_URL_TOKEN
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/token/"
               - name: OIDC_URL_USER
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/userinfo"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/userinfo/"
               - name: OIDC_URL_JWKS
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/certs"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/certs/"
               - name: OIDC_URL_LOGOUT
-                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/logout"
+                value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/logout/"
               - name: OIDC_FALLBACK_MATCH_BY_EMAIL
                 value: 'True'
               - name: STALWART_BASE_JMAP_URL
                 value: 'https://mail.thundermail.com'
               - name: STALWART_BASE_API_URL
-                value: 'https://mailstrom-management-i.thundermail.com:8080'
+                value: 'https://mailstrom-prod-management-i.thundermail.com:8080'
+              - name: KEYCLOAK_URL_API
+                value: 'https://auth.tb.pro/admin/realms/tbpro/'
+              - name: KEYCLOAK_ADMIN_URL_TOKEN
+                value: 'https://auth.tb.pro/realms/master/protocol/openid-connect/token/'
 
   tb:autoscale:EcsServiceAutoscaler:
     accounts:

--- a/src/thunderbird_accounts/mail/clients.py
+++ b/src/thunderbird_accounts/mail/clients.py
@@ -64,7 +64,9 @@ class MailClient:
         if type:
             params['type'] = type
 
-        response = requests.get(f'{self.api_url}/principal', params=params, headers=self.authorized_headers)
+        response = requests.get(
+            f'{self.api_url}/principal', params=params, headers=self.authorized_headers, verify=False
+        )
         response.raise_for_status()
         self._raise_for_error(response)
 
@@ -80,7 +82,9 @@ class MailClient:
 
         Important: Don't use this directly!
         """
-        response = requests.get(f'{self.api_url}/principal/{principal_id}', headers=self.authorized_headers)
+        response = requests.get(
+            f'{self.api_url}/principal/{principal_id}', headers=self.authorized_headers, verify=False
+        )
         response.raise_for_status()
         self._raise_for_error(response)
 
@@ -95,7 +99,9 @@ class MailClient:
 
         Important: Don't use this directly!
         """
-        response = requests.delete(f'{self.api_url}/principal/{principal_id}', headers=self.authorized_headers)
+        response = requests.delete(
+            f'{self.api_url}/principal/{principal_id}', headers=self.authorized_headers, verify=False
+        )
         response.raise_for_status()
         self._raise_for_error(response)
 
@@ -129,8 +135,9 @@ class MailClient:
         }
 
         response = requests.post(
-            f'{self.api_url}/principal/deploy', json=principal_data, headers=self.authorized_headers
+            f'{self.api_url}/principal/deploy', json=principal_data, headers=self.authorized_headers, verify=False
         )
+
         response.raise_for_status()
         self._raise_for_error(response)
 
@@ -163,7 +170,7 @@ class MailClient:
                 raise TypeError(f'{data.get("action")} is not allowed in')
 
         response = requests.patch(
-            f'{self.api_url}/principal/{principal_id}', json=update_data, headers=self.authorized_headers
+            f'{self.api_url}/principal/{principal_id}', json=update_data, headers=self.authorized_headers, verify=False
         )
         response.raise_for_status()
         self._raise_for_error(response)
@@ -189,7 +196,7 @@ class MailClient:
 
     def create_dkim(self, domain):
         data = {'id': None, 'algorithm': settings.STALWART_DKIM_ALGO, 'domain': domain, 'selector': None}
-        response = requests.post(f'{self.api_url}/dkim', json=data, headers=self.authorized_headers)
+        response = requests.post(f'{self.api_url}/dkim', json=data, headers=self.authorized_headers, verify=False)
         response.raise_for_status()
         data = response.json()
         logging.info(f'[MailClient.create_dkim({domain}]: {data}')


### PR DESCRIPTION
This updates a bunch of secrets (which are already deployed) and re-introduces #248's verify=False until we get SSL certs working on the production private mailstrom instance.  