### PR TITLE
Fix CI bugs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -270,6 +270,7 @@ jobs:
       - name: Package Pulumi code
         shell: bash
         run:
+          rm -rf pulumi/venv
           tar -cvjf pulumi.tbz pulumi/
 
       - name: Archive the Pulumi artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
           pulumi login
           pulumi stack select thunderbird/prod
           TBPULUMI_DISABLE_PROTECTION=True \
-            pulumi up -y --diff --target \
+            pulumi up -y --diff \
             --target 'urn:pulumi:prod::accounts::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::accounts-prod-fargate-accounts-taskdef' \
             --target 'urn:pulumi:prod::accounts::tb:fargate:FargateClusterWithLogging$aws:ecs/taskDefinition:TaskDefinition::accounts-prod-fargate-accounts-celery-taskdef' \
             --target-dependents


### PR DESCRIPTION
This fixes two bugs:

1. Removes a bonus `--target` argument with no target listed from the prod Pulumi deploy command.
2. Removes the virtual environment before archiving the IaC, which was creating some problems with the Python executable.