### PR TITLE
Fix AppPasswords and Display Name APIs

### DIFF
--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -30,7 +30,7 @@ const onSetPasswordSubmit = async () => {
   isSubmitting.value = true;
 
   try {
-    const response = await fetch('/self-serve/app-passwords/set', {
+    const response = await fetch('/app-passwords/set', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -83,7 +83,7 @@ const onCancelSetPassword = () => {
       <form
         ref="appPasswordFormRef"
         method="post"
-        action="/self-serve/app-passwords/set"
+        action="/app-passwords/set"
       >
         <input type="hidden" name="name" :value="userEmail" />
 

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/UserInfoSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/UserInfoSide.vue
@@ -33,7 +33,7 @@ const onSetDisplayNameSubmit = async () => {
   isSubmittingDisplayName.value = true;
 
   try {
-    const response = await fetch('/self-serve/display-name/set', {
+    const response = await fetch('/display-name/set', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -82,7 +82,7 @@ const onCancelSetDisplayName = () => {
       <template v-if="showDisplayNameForm">
         <form
           method="post"
-          action="/self-serve/display-name/set"
+          action="/display-name/set"
         >
           <text-input v-model="displayName" name="display-name" data-testid="display-name-input">
             {{ t('views.mail.sections.emailSettings.newDisplayName') }}:

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -398,6 +398,91 @@ def self_serve_app_password_remove(request: HttpRequest):
 @login_required
 @require_http_methods(['POST'])
 @sensitive_post_parameters('password')
+def app_password_set(request: HttpRequest):
+    """Sets an app password for a remote Stalwart account"""
+
+    try:
+        data = json.loads(request.body)
+        new_password = data.get('password')
+        label = data.get('name')
+
+        if not new_password or not label:
+            return JsonResponse({
+                'success': False,
+                'error': str(_('Label and password are required'))
+            }, status=400)
+
+        stalwart_client = MailClient()
+
+        email_user = stalwart_client.get_account(request.user.stalwart_primary_email)
+
+        # Find and delete all previously existing app passwords
+        for secret in email_user.get('secrets', []):
+            stalwart_client.delete_app_password(request.user.stalwart_primary_email, secret)
+
+        # Create and save the new app password
+        new_secret = utils.save_app_password(label, new_password)
+        stalwart_client.save_app_password(request.user.stalwart_primary_email, new_secret)
+
+        return JsonResponse({
+            'success': True,
+            'message': str(_('Password set successfully'))
+        })
+
+    except AccountNotFoundError:
+        return JsonResponse({
+            'success': False,
+            'error': str(_('Could not connect to Thundermail, please try again later.'))
+        }, status=500)
+    except json.JSONDecodeError:
+        return JsonResponse({
+            'success': False,
+            'error': str(_('Invalid request data'))
+        }, status=400)
+    except Exception as e:
+        logging.error(f'Error setting app password: {e}')
+        return JsonResponse({
+            'success': False,
+            'error': str(_('An error occurred while setting the password. Please try again.'))
+        }, status=500)
+
+
+@login_required
+@require_http_methods(['POST'])
+@sensitive_post_parameters('display-name')
+def display_name_set(request: HttpRequest):
+    """Sets a display name for a remote Stalwart account"""
+
+    try:
+        data = json.loads(request.body)
+        display_name = data.get('display-name')
+    except json.JSONDecodeError:
+        return JsonResponse({
+            'success': False,
+            'error': str(_('Invalid request data'))
+        }, status=400)
+
+    if not display_name:
+        return JsonResponse({
+            'success': False,
+            'error': str(_('Display name is required'))
+        }, status=400)
+
+    stalwart_client = MailClient()
+    try:
+        stalwart_client.update_individual(request.user.stalwart_primary_email, full_name=display_name)
+    except AccountNotFoundError:
+        messages.error(request, _('Could not connect to Thundermail, please try again later.'))
+
+    return JsonResponse({
+        'success': True,
+        'message': str(_('Display name set successfully'))
+    })
+
+
+@login_required
+@require_http_methods(['POST'])
+@sensitive_post_parameters('password')
 def self_serve_app_password_add(request: HttpRequest):
     """Add an app password to the remote Stalwart account"""
     label = request.POST['name']

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -47,6 +47,8 @@ urlpatterns = [
     path('contact/submit', mail_views.contact_submit, name='contact_submit'),
     path('self-serve/app-passwords/add', mail_views.self_serve_app_password_add, name='app_password_add'),
     path('self-serve/app-passwords/remove', mail_views.self_serve_app_password_remove, name='app_password_remove'),
+    path('app-passwords/set', mail_views.app_password_set, name='app_password_set'),
+    path('display-name/set', mail_views.display_name_set, name='display_name_set'),
     # API
     path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),


### PR DESCRIPTION
## Description of changes
The App Password and Display name related endpoints [have been removed in a recent PR](https://github.com/thunderbird/thunderbird-accounts/commit/2ff6e862b1dc38b112d7b052109d936c633fff48#diff-f9a2b1bfd2b55e873305640e2c285d3e3ff850edece24ab036e94001a2c61312L396-L480) and have to be reinstated to make it work again.

- Re-instated the code that handled the app password and display name settings
- Updated the route naming not to confuse with the self-serve actions

## Related issues
Solves https://github.com/thunderbird/thunderbird-accounts/issues/356