### PR TITLE
Fix paddle's cancel event on subscription update, and add a test case for it.

### DIFF
--- a/src/thunderbird_accounts/subscription/tasks.py
+++ b/src/thunderbird_accounts/subscription/tasks.py
@@ -185,14 +185,17 @@ def paddle_subscription_event(self, event_data: dict, occurred_at: datetime.date
         next_billed_at = datetime.datetime.fromisoformat(next_billed_at)
 
     current_billing_period = event_data.get('current_billing_period', {})
-    current_billing_period_starts_at = current_billing_period.get('starts_at')
-    current_billing_period_ends_at = current_billing_period.get('end_at')
+    current_billing_period_starts_at = None
+    current_billing_period_ends_at = None
+    if current_billing_period:
+        current_billing_period_starts_at = current_billing_period.get('starts_at')
+        current_billing_period_ends_at = current_billing_period.get('end_at')
 
-    if current_billing_period_starts_at:
-        current_billing_period_starts_at = datetime.datetime.fromisoformat(current_billing_period_starts_at)
+        if current_billing_period_starts_at:
+            current_billing_period_starts_at = datetime.datetime.fromisoformat(current_billing_period_starts_at)
 
-    if current_billing_period_ends_at:
-        current_billing_period_ends_at = datetime.datetime.fromisoformat(current_billing_period_ends_at)
+        if current_billing_period_ends_at:
+            current_billing_period_ends_at = datetime.datetime.fromisoformat(current_billing_period_ends_at)
 
     subscription, subscription_created = Subscription.objects.update_or_create(
         paddle_id=paddle_id,

--- a/src/thunderbird_accounts/subscription/tests/fixtures/webhook_paddle_subscription_cancelled.json
+++ b/src/thunderbird_accounts/subscription/tests/fixtures/webhook_paddle_subscription_cancelled.json
@@ -1,0 +1,85 @@
+{
+  "event_id": "evt_01k8xm1bep8tfym2q6v2qdxgkx",
+  "event_type": "subscription.updated",
+  "occurred_at": "2025-10-31T17:11:25.910326Z",
+  "notification_id": "ntf_01k8xm1c426xeyh7aj8gg1fbgr",
+  "data": {
+    "id": "sub_01k8xkm86pmvzv0md1v2hdzfsd",
+    "items": [
+      {
+        "price": {
+          "id": "pri_01jqexab9ah62cezgqckd9am0c",
+          "name": "Annual",
+          "type": "standard",
+          "status": "active",
+          "quantity": {
+            "maximum": 1,
+            "minimum": 1
+          },
+          "tax_mode": "internal",
+          "created_at": "2025-03-28T17:38:10.346619Z",
+          "product_id": "pro_01jqex8chw7se0zhk15hn5d6hs",
+          "unit_price": {
+            "amount": "1",
+            "currency_code": "USD"
+          },
+          "updated_at": "2025-09-25T16:21:56.977027Z",
+          "description": "Annual Plan",
+          "import_meta": null,
+          "trial_period": null,
+          "billing_cycle": {
+            "interval": "year",
+            "frequency": 1
+          },
+          "unit_price_overrides": []
+        },
+        "status": "active",
+        "product": {
+          "id": "pro_01jqex8chw7se0zhk15hn5d6hs",
+          "name": "Thunderbird Pro",
+          "type": "standard",
+          "status": "active",
+          "image_url": "",
+          "created_at": "2025-03-28T17:37:06.108Z",
+          "updated_at": "2025-10-31T16:13:16.374Z",
+          "custom_data": null,
+          "description": "",
+          "tax_category": "standard",
+          "consents_required": []
+        },
+        "quantity": 1,
+        "recurring": true,
+        "created_at": "2025-10-31T17:04:16.598Z",
+        "updated_at": "2025-10-31T17:04:16.598Z",
+        "trial_dates": null,
+        "next_billed_at": null,
+        "previously_billed_at": "2025-10-31T17:04:15.995497Z"
+      }
+    ],
+    "status": "canceled",
+    "discount": null,
+    "paused_at": null,
+    "address_id": "add_01k8xkm06pd1f2cnddf5s4a01a",
+    "created_at": "2025-10-31T17:04:16.598Z",
+    "started_at": "2025-10-31T17:04:15.995497Z",
+    "updated_at": "2025-10-31T17:11:25.28Z",
+    "business_id": null,
+    "canceled_at": "2025-10-31T17:11:25.276Z",
+    "custom_data": {
+      "signed_user_id": "e3820ee0ccec4b1f9922fdd003f9e825:tsGZSs3uUfabY2LqZ8qGc0Xw6Ps1gmCbSVWvo66UeKU"
+    },
+    "customer_id": "ctm_01jc6eq8p0gh00azhv6ypyj8jx",
+    "import_meta": null,
+    "billing_cycle": {
+      "interval": "year",
+      "frequency": 1
+    },
+    "currency_code": "CAD",
+    "next_billed_at": null,
+    "billing_details": null,
+    "collection_mode": "automatic",
+    "first_billed_at": "2025-10-31T17:04:15.995497Z",
+    "scheduled_change": null,
+    "current_billing_period": null
+  }
+}

--- a/src/thunderbird_accounts/subscription/tests/test_tasks.py
+++ b/src/thunderbird_accounts/subscription/tests/test_tasks.py
@@ -634,6 +634,91 @@ class SubscriptionUpdatedTaskTestCase(SubscriptionCreatedTaskTestCase):
         self.assertEqual(task_results.get('reason'), 'webhook is out of date')
 
 
+class SubscriptionUpdatedToCancelledTaskTestCase(SubscriptionCreatedTaskTestCase):
+    is_create_event: bool = False
+    paddle_fixture = 'fixtures/webhook_paddle_subscription_cancelled.json'
+
+    def test_success(self):
+        self.assertEqual(models.Subscription.objects.count(), 0)
+
+        # Retrieve the webhook sample
+        data = self.retrieve_webhook_fixture()
+
+        event_data: dict = data.get('data')
+        occurred_at: datetime.datetime = datetime.datetime.fromisoformat(data.get('occurred_at'))
+
+        subscription = models.Subscription.objects.create(
+            paddle_id=event_data.get('id'),
+            webhook_updated_at=occurred_at - datetime.timedelta(hours=1),
+        )
+
+        task_results: dict | None = tasks.paddle_subscription_event.delay(
+            event_data, occurred_at, self.is_create_event
+        ).get(timeout=10)
+
+        self.assertIsNotNone(task_results)
+        self.assertEqual(task_results.get('paddle_id'), subscription.paddle_id)
+
+        # Success results have model_created and model_uuid, so test this first
+        self.assertEqual(task_results.get('task_status'), 'success', msg=task_results)
+
+        # This should be a new model
+        self.assertFalse(task_results.get('model_created'))
+
+        # Check if the model actually exists
+        self.assertTrue(models.Subscription.objects.filter(pk=task_results.get('model_uuid')).exists())
+
+        subscription.refresh_from_db()
+
+        # Spot check some updated fields
+        self.assertEqual(event_data.get('status'), subscription.status)
+        self.assertEqual(event_data.get('customer_id'), subscription.paddle_customer_id)
+
+        # Check if the model is associated with the test user
+        self.assertIsNotNone(subscription.user_id)
+        self.assertIsNotNone(subscription.user)
+        self.assertEqual(subscription.user_id, self.test_user.uuid)
+        self.assertEqual(subscription.user.uuid, self.test_user.uuid)
+
+        # Update does not create transaction_id
+        self.assertTrue(models.Transaction.objects.count() == 0)
+
+        # Check for subscription items - Test data has 1!
+        self.assertTrue(subscription.subscriptionitem_set.count() == 1)
+
+        self.assertTrue(subscription.status == models.Subscription.StatusValues.CANCELED.value)
+
+    def test_subscription_already_exists(self):
+        """Not needed for update webhook"""
+        pass
+
+    def test_subscription_out_of_date(self):
+        """We're testing if the transaction is out of date here."""
+        self.assertEqual(models.Transaction.objects.count(), 0)
+
+        # Retrieve the webhook sample
+        data = self.retrieve_webhook_fixture()
+
+        event_data: dict = data.get('data')
+        occurred_at: datetime.datetime = datetime.datetime.fromisoformat(data.get('occurred_at'))
+
+        subscription = models.Subscription.objects.create(
+            paddle_id=event_data.get('id'),
+            webhook_updated_at=occurred_at + datetime.timedelta(hours=1),
+        )
+
+        self.assertIsNotNone(subscription)
+
+        task_results: dict | None = tasks.paddle_subscription_event.delay(
+            event_data, occurred_at, self.is_create_event
+        ).get(timeout=10)
+
+        self.assertIsNotNone(task_results)
+        self.assertEqual(task_results.get('paddle_id'), event_data.get('id'))
+        self.assertEqual(task_results.get('task_status'), 'failed')
+        self.assertEqual(task_results.get('reason'), 'webhook is out of date')
+
+
 class ProductCreatedTaskTestCase(PaddleTestCase):
     is_create_event: bool = True
     paddle_fixture = 'fixtures/webhook_paddle_product_created.json'


### PR DESCRIPTION
This is part of #348 

Subscription updates without billing times were breaking the update code. Make that optional and I've added a test with a slimmed down version of the webhook call.