### PR TITLE
Implement Delete Account functionality

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -285,7 +285,9 @@
       "deleteAccountCheckbox": "I understand my data will be permanently deleted",
       "enterPassword": "Enter your password to confirm",
       "deleteAccountButtonLabel": "Request to delete data",
-      "cancelButtonLabel": "Cancel"
+      "cancelButtonLabel": "Cancel",
+      "deleteAccountSuccess": "Your account has been deleted. You will be redirected to the home page in 3 seconds.",
+      "deleteAccountError": "An error occurred while deleting your account"
     },
     "subscribe": {
       "lineItems": {

--- a/assets/app/vue/router.ts
+++ b/assets/app/vue/router.ts
@@ -4,7 +4,7 @@ import {createRouter, createWebHistory} from 'vue-router';
 import HomeView from '@/views/HomeView.vue';
 import DashboardView from '@/views/DashboardView/index.vue';
 import ManageMfaView from '@/views/ManageMfaView/index.vue';
-import PrivacyAndDataView from '@/views/PrivacyAndDataView.vue';
+import PrivacyAndDataView from '@/views/PrivacyAndDataView/index.vue';
 import PrivacyView from '@/views/PrivacyView.vue';
 import SubscribeView from '@/views/SubscribeView/index.vue';
 import TermsView from '@/views/TermsView.vue';

--- a/assets/app/vue/views/DashboardView/components/PrivacyAndDataCard.vue
+++ b/assets/app/vue/views/DashboardView/components/PrivacyAndDataCard.vue
@@ -26,14 +26,24 @@ const { t } = useI18n();
       <div>
         <strong>{{ t('views.dashboard.privacyAndDataCard.deleteAccount') }}</strong>
         <p>{{ t('views.dashboard.privacyAndDataCard.deleteAccountText') }}</p>
-    
-        <danger-button variant="outline">{{ t('views.dashboard.privacyAndDataCard.deleteAccountButtonLabel') }}</danger-button>
+
+        <router-link to="/privacy-and-data">
+          <danger-button variant="outline">
+            {{ t('views.dashboard.privacyAndDataCard.deleteAccountButtonLabel') }}
+          </danger-button>
+        </router-link>
       </div>
     </div>
   </card-container>
 </template>
 
 <style scoped>
+a {
+  display: inline-block;
+  text-decoration: none;
+  width: auto;
+}
+
 .privacy-and-data-card {
   min-width: unset;
   color: var(--colour-ti-secondary);

--- a/assets/app/vue/views/PrivacyAndDataView/api.ts
+++ b/assets/app/vue/views/PrivacyAndDataView/api.ts
@@ -1,0 +1,12 @@
+export const deleteAccount = async (password: string) => {
+  const response = await fetch('/delete-account', {
+    method: 'DELETE',
+    headers: {
+      'X-CSRFToken': window._page.csrfToken,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ password }),
+  });
+
+  return await response.json();
+};

--- a/src/thunderbird_accounts/authentication/clients.py
+++ b/src/thunderbird_accounts/authentication/clients.py
@@ -92,6 +92,30 @@ class KeycloakClient:
         response = self.request(endpoint, RequestMethods.GET)
         return response.json()
 
+    def verify_password(self, username: str, password: str) -> bool:
+        """Verify a user's password by attempting to authenticate with Keycloak.
+        :param username: The user's username (email)
+        :param password: The password to verify
+        :return: True if password is correct, False otherwise
+        """
+
+        try:
+            response = requests.post(
+                settings.OIDC_OP_TOKEN_ENDPOINT,
+                data={
+                    'client_id': settings.OIDC_RP_CLIENT_ID,
+                    'client_secret': settings.OIDC_RP_CLIENT_SECRET,
+                    'grant_type': 'password',
+                    'username': username,
+                    'password': password,
+                },
+            )
+
+            # If authentication is successful, we get a 200 with tokens
+            return response.status_code == 200
+        except Exception:
+            return False
+
     def _shared_clean(self, username):
         if '@' not in username:
             raise ValueError('Username needs to be the Stalwart/Keycloak login email.')

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -52,6 +52,7 @@ urlpatterns = [
     path('custom-domains/add', mail_views.create_custom_domain, name='add_custom_domain'),
     path('custom-domains/verify', mail_views.verify_custom_domain, name='verify_custom_domain'),
     path('custom-domains/remove', mail_views.remove_custom_domain, name='remove_custom_domain'),
+    path('delete-account', mail_views.delete_account, name='delete_account'),
     # API
     path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),


### PR DESCRIPTION
## Description of changes
- Refactors Privacy & Data view into its own folder for better code maintainability
- Delete Account Data functionality

> [!NOTE]
> We need to allow for "Direct access grants" in the Keycloak client for the re-validation of the password to work during the delete account process

You can find it in Keycloak > Clients > [Choose the client that you are using] > Scroll down and check this:

<img width="693" height="214" alt="image" src="https://github.com/user-attachments/assets/87427d13-9782-4b78-b146-46d5a558f3b0" />


## Known issues / Things to improve
- We are still discussing whether or not we should auto-cancel the Paddle subscription
- The original issue discusses a mechanism of delaying the actual deletion of the account for X amount of time to allow for the user to "un-cancel" in a subsequent login. This is not covered in this PR yet.

## Related issues
Related https://github.com/thunderbird/thunderbird-accounts/issues/202