### PR TITLE
Actually update the account quota with the plan when activating sub features. (Fixes #388)

### DIFF
--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -122,9 +122,14 @@ def delete_email_addresses_from_stalwart_account(self, username: str, emails: li
 
 
 @shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
-def update_quota_on_stalwart_account(self, username: str, quota: int):
+def update_quota_on_stalwart_account(self, username: str, quota: Optional[int]):
     """Updates the quota value on a stalwart account.
     This will cause the account's storage to be tracked by stalwart."""
+
+    # Small fix for db defaulting to None
+    if quota is None:
+        quota = 0
+
     try:
         stalwart = MailClient()
         stalwart.update_quota(username, quota)

--- a/src/thunderbird_accounts/subscription/utils.py
+++ b/src/thunderbird_accounts/subscription/utils.py
@@ -17,6 +17,10 @@ def activate_subscription_features(user: User, plan: Plan):
 
     account = user.account_set.first()
     if account and account.stalwart_id:
+        # Update the mail storage quota
+        account.quota = plan.mail_storage_bytes
+        account.save()
+
         update_quota_on_stalwart_account(user, account.quota)
         return
 


### PR DESCRIPTION
A minor overlook when activating subscription features is we're not actually updating the account's quota. Oops.

Also a small fix for if None is passed to update_quota.