### PR TITLE
Add TB_PRO_APPOINTMENT_URL and TB_PRO_SEND_URL env vars

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -425,6 +425,10 @@ resources:
                 value: 'https://mail.thundermail.com'
               - name: STALWART_BASE_API_URL
                 value: 'https://mailstrom-prod-management-i.thundermail.com:8080'
+              - name: TB_PRO_APPOINTMENT_URL
+                value: 'https://appointment.tb.pro/'
+              - name: TB_PRO_SEND_URL
+                value: 'https://send.tb.pro/'
               - name: KEYCLOAK_URL_API
                 value: 'https://auth.tb.pro/admin/realms/tbpro/'
               - name: KEYCLOAK_ADMIN_URL_TOKEN
@@ -581,6 +585,10 @@ resources:
                 value: 'https://mail.thundermail.com'
               - name: STALWART_BASE_API_URL
                 value: 'https://mailstrom-prod-management-i.thundermail.com:8080'
+              - name: TB_PRO_APPOINTMENT_URL
+                value: 'https://appointment.tb.pro/'
+              - name: TB_PRO_SEND_URL
+                value: 'https://send.tb.pro/'
               - name: KEYCLOAK_URL_API
                 value: 'https://auth.tb.pro/admin/realms/tbpro/'
               - name: KEYCLOAK_ADMIN_URL_TOKEN

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -421,6 +421,10 @@ resources:
                 value: 'https://mail.stage-thundermail.com'
               - name: STALWART_BASE_API_URL
                 value: 'https://mailstrom-stage-management-i.stage-thundermail.com:8080'
+              - name: TB_PRO_APPOINTMENT_URL
+                value: 'https://appointment-stage.tb.pro/'
+              - name: TB_PRO_SEND_URL
+                value: 'https://send-stage.tb.pro/'
               - name: KEYCLOAK_URL_API
                 value: 'https://auth-stage.tb.pro/admin/realms/tbpro/'
               - name: KEYCLOAK_ADMIN_URL_TOKEN
@@ -571,6 +575,10 @@ resources:
                 value: 'https://mail.stage-thundermail.com'
               - name: STALWART_BASE_API_URL
                 value: 'https://mailstrom-stage-management-i.stage-thundermail.com:8080'
+              - name: TB_PRO_APPOINTMENT_URL
+                value: 'https://appointment-stage.tb.pro/'
+              - name: TB_PRO_SEND_URL
+                value: 'https://send-stage.tb.pro/'
               - name: KEYCLOAK_URL_API
                 value: 'https://auth-stage.tb.pro/admin/realms/tbpro/'
               - name: KEYCLOAK_ADMIN_URL_TOKEN


### PR DESCRIPTION
## Description of changes

Adds env vars to pulumi configs for stage / prod so that the links in the Dashboard for the respective services actually work.


## Solves
https://github.com/thunderbird/thunderbird-accounts/issues/393