### PR TITLE
Pin tb_pulumi to v0.0.16

### DIFF
--- a/pulumi/requirements.txt
+++ b/pulumi/requirements.txt
@@ -1,2 +1,2 @@
-tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@main
+tb_pulumi @ git+https://github.com/thunderbird/pulumi.git@v0.0.16
 pulumi_cloudflare==5.48.0


### PR DESCRIPTION
We've stabilized things in the tb_pulumi library and we should pin to the latest version.