### PR TITLE
Fix Delete Account and All Data Link

### DIFF
--- a/assets/app/vue/views/DashboardView/components/PrivacyAndDataCard.vue
+++ b/assets/app/vue/views/DashboardView/components/PrivacyAndDataCard.vue
@@ -28,9 +28,11 @@ const { t } = useI18n();
         <strong>{{ t('views.dashboard.privacyAndDataCard.deleteAccount') }}</strong>
         <p>{{ t('views.dashboard.privacyAndDataCard.deleteAccountText') }}</p>
 
-        <link-button href="/contact/" size="small" class="delete-account-button">
-          {{ t('views.dashboard.privacyAndDataCard.deleteAccountButtonLabel') }}
-        </link-button>
+        <a href="/contact/">
+          <link-button size="small" class="delete-account-button">
+            {{ t('views.dashboard.privacyAndDataCard.deleteAccountButtonLabel') }}
+          </link-button>
+        </a>
       </div>
     </div>
   </card-container>


### PR DESCRIPTION
## Description of changes
Currently, the `LinkButton` renders a `button` which shouldn't be used as a link to another page. Instead of using the click event of the button, I believe the better fix here is to wrap it in a normal anchor tag.
 
## Screenshot / Video
https://github.com/user-attachments/assets/0afff095-576c-43e2-9c14-19a042316258


## Known issues / Things to improve
- Opened up an issue in `services-ui` https://github.com/thunderbird/services-ui/issues/191 to remove the ambiguity of link vs button.


## Related Issues
Fixes https://github.com/thunderbird/thunderbird-accounts/issues/403