### PR TITLE
Only retrieve the email settings if the user has an active subscription.

### DIFF
--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -54,7 +54,7 @@ def home(request: HttpRequest):
     max_custom_domains = None
     max_email_aliases = None
 
-    if request.user.is_authenticated:
+    if request.user.is_authenticated and request.user.has_active_subscription:
         try:
             account = request.user.account_set.first()
             if not account:


### PR DESCRIPTION
Fixes #410 

It simply hides the error as it's not a real problem for the checkout form. 