### PR TITLE
Remove the is_email_reserved check on the admin panel (Fixes #418)

### DIFF
--- a/src/thunderbird_accounts/authentication/admin/forms.py
+++ b/src/thunderbird_accounts/authentication/admin/forms.py
@@ -13,7 +13,6 @@ from thunderbird_accounts.authentication.exceptions import (
     ImportUserError,
 )
 from thunderbird_accounts.authentication.models import User
-from thunderbird_accounts.authentication.utils import is_email_reserved
 from thunderbird_accounts.mail.clients import MailClient
 
 
@@ -77,10 +76,6 @@ class CustomUserFormBase(forms.ModelForm):
                 zoneinfo.ZoneInfo(self.data.get('timezone'))
             except (zoneinfo.ZoneInfoNotFoundError, ValueError) as ex:
                 self.add_error('timezone', str(ex))
-
-        if is_email_reserved(self.data.get('username').partition("@")[0]):
-            self.add_error('username', _('This username is taken.'))
-            return
 
         return super().clean()
 


### PR DESCRIPTION
Also added a test which is a copy of the success test but with admin in the username. It fails without the new code change. 