### PR TITLE
Fix contact support link in Keycloak screens

### DIFF
--- a/keycloak/themes/tbpro/login/login-username.ftl
+++ b/keycloak/themes/tbpro/login/login-username.ftl
@@ -5,7 +5,7 @@
     <script>
       window._page['currentView'] = {
         formAction: '${url.loginAction}',
-        supportUrl: '${client.baseUrl}contact',
+        supportUrl: '${client.baseUrl}contact/',
         clientUrl: '${client.baseUrl}',
         // <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
         registerUrl: '${url.registrationUrl}',

--- a/keycloak/themes/tbpro/login/login.ftl
+++ b/keycloak/themes/tbpro/login/login.ftl
@@ -5,7 +5,7 @@
     <script>
       window._page['currentView'] = {
         formAction: '${url.loginAction}',
-        supportUrl: '${client.baseUrl}contact',
+        supportUrl: '${client.baseUrl}contact/',
         clientUrl: '${client.baseUrl}',
         // <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
         registerUrl: '${url.registrationUrl}',


### PR DESCRIPTION
## Description of changes

The URL for the contact page needs the extra `/` at the end because it is currently a Django route.

This PR won't be necessary / needs to be reverted once https://github.com/thunderbird/thunderbird-accounts/pull/271 gets merged since it moves the Zendesk form within the Vue app (outside of Django), hence removing the extra `/` at the end.

## Known issues / Things to improve
- In terms of the `baseUrl` in prod containing the `self-serve/` part, it seems that this is controlled in Keycloak itself as I couldn't find references to it in the codebase 🤔 


## Related issues
Related PR https://github.com/thunderbird/thunderbird-accounts/pull/271
Solves https://github.com/thunderbird/thunderbird-accounts/issues/414