### PR TITLE
Add performance data to health check responses

### DIFF
--- a/src/thunderbird_accounts/infra/views.py
+++ b/src/thunderbird_accounts/infra/views.py
@@ -23,7 +23,7 @@ class PerformanceMonitored:
         finish = time.perf_counter()
         duration = finish - start
         logging.debug(f'Performance monitoring -- Function {self.func} ran in {duration} seconds')
-        return (result, duration)
+        return result, duration
 
 
 def health_check(request: HttpRequest):


### PR DESCRIPTION
I did a bunch of playing around with this locally today. There are a few things to note:

1. These checks are run serially, so they do add up instead of overlap. I took a stab at making the calls asyncronous, but didn't succeed.
2. The performance locally is extremely fast, way faster than production, which we expect because we're the only request in queue over a local network.
3. The first time we do a health check against a fresh Keycloak container, it runs really quite long for a local request (nearly a full second, pushing the total request time up the the 1.3 - 1.5 second range). Every subsequent health check runs crazy fast, though. If you just restart the Keycloak docker container, this makes the next request take a long time again. This makes me think there's something at play here in Keycloak's internal memory cache.
4. I suspect data transfer is probably a factor here, though there are confounding points of data. I ran the same health check call to the prod server from my local machine in the US and from a server running in AWS's Frankfurt region where this app is hosted. The Frankfurt requests are faster, but still longer than I would expect (still nearly a second, which is better than the two seconds I see on the US requests).
5. Health check calls to stage also take a full second or more every time, so there's something to it being in the app even if some of it is attributable to data transfer.
6. Site24x7 breaks down the timing of these requests, but the history does not go back far enough for me to see the effect of this deploy. I can see the current trends, which strangely sometimes attribute most of the request time to DNS lookup. That seems like either a fluke or mismeasurement to me. I'm not sure how we would measure that internally, though. They do break down request times by source location, but all of the regions report similar request times, which does **not** confirm the timing differences I noticed between local and Frankfurt timings. Perhaps that's because the instance was inside the network, on the same VPC? I should repeat this test with a server in Frankfurt that is outside the VPC.

This PR breaks our various checks out into several sub-functions, each of which is wrapped with a new `PerformanceMonitored` decorator. The health and runtimes of each check are aggregated into the response. The "accounts" duration is the combined duration of all the other calls. This will let me get that detailed info from stage and prod to see if it's helpful in further diagnosis. Comparing this info to the output of a `time`d `curl` should help determine how much of the total time is spent in data transfer. It also slightly expands the redis check to do what the comment describes and to avoid the (admittedly remote) possibility of a race condition.

Here a sample call:

```bash
curl http://localhost:8087/health 2> /dev/null | jq .
```

```json
{
  "keycloak": {
    "healthy": true,
    "duration": 0.032906853997701546
  },
  "stalwart": {
    "healthy": true,
    "duration": 0.003108187000179896
  },
  "redis": {
    "healthy": true,
    "duration": 0.0023673110008530784
  },
  "database": {
    "healthy": true,
    "duration": 0.017381506997480756
  },
  "accounts": {
    "healthy": true,
    "duration": 0.055763858996215276
  }
}
```