### PR TITLE
Use Math.floor for storage / bytes calculations

### DIFF
--- a/assets/app/vue/views/DashboardView/utils.ts
+++ b/assets/app/vue/views/DashboardView/utils.ts
@@ -22,8 +22,8 @@ export const formatBytes = (bytes: string | null): string | null => {
     if (bytesNum >= unit.threshold) {
       const value = bytesNum / unit.divisor;
 
-      // Format without unnecessary decimals
-      const formatted = value % 1 === 0 ? value.toFixed(0) : value.toFixed(2);
+      // Flooring the value as we don't need decimals for the UI
+      const formatted = Math.floor(value);
       return `${formatted} ${unit.label}`;
     }
   }


### PR DESCRIPTION
## Description of changes

- Changed the `formatBytes` function calculation to do a `Math.floor` instead since we don't want to display decimal values in the UI.

## Screenshots

In Django admin
<img width="486" height="71" alt="image" src="https://github.com/user-attachments/assets/26ed1930-5b8a-4af0-9ff9-bff8b3676645" />

Your Current Subscription
<img width="393" height="536" alt="image" src="https://github.com/user-attachments/assets/a3eb8dcc-b912-4d8d-b0a8-f19d29fd8a82" />

Mail Usage
<img width="520" height="86" alt="image" src="https://github.com/user-attachments/assets/f75af178-9839-40e9-9deb-8d1d66e2c72c" />


## How to test

- As `admin@example.org` go to Django Admin (`/admin/`)
- Update your `Plan` object to have `32212254721` bytes in the Mail / Send storage
- Check the Accounts Dashboard UI and Mail UI to see it shows `30 GB`
- Go back to Django Admin (`/admin/`)
- Update your `Plan` object to have `32212254720` bytes in the Mail / Send storage
- Check the Accounts Dashboard UI and Mail UI to see it still shows `30 GB`

## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/431