### PR TITLE
Better responsiveness on CheckoutStep

### DIFF
--- a/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
@@ -153,7 +153,7 @@ const setupPaddle = async () => {
         displayMode: 'inline',
         frameTarget: 'checkout-container',
         frameInitialHeight: 992,
-        frameStyle: 'width: 100%; min-width: 312px; background-color: transparent; border: none;',
+        frameStyle: 'width: 100%; background-color: transparent; border: none;',
         variant: 'one-page',
       },
     },
@@ -279,7 +279,6 @@ export default {
     gap: 1rem;
     display: flex;
     flex-direction: column;
-    align-items: center;
   }
 
   h2 {
@@ -293,12 +292,10 @@ export default {
 
   .checkout-container {
     width: 100%;
-    max-width: 60%;
   }
 
   .summary-card {
     width: 100%;
-    max-width: 60%;
     min-height: 340px;
   }
 
@@ -373,6 +370,14 @@ export default {
       align-items: flex-start;
       flex-direction: row;
       gap: 2rem;
+    }
+
+    .checkout-container {
+      max-width: 60%;
+    }
+
+    .summary-card {
+      max-width: 60%;
     }
   }
 }


### PR DESCRIPTION
## Description of changes

- Updates a couple of container styles in the `CheckoutStep` component and the inline styles in the Paddle iframe to be more responsive-friendly.

## Screenshots

Desktop (still the same)
<img width="3046" height="3260" alt="image" src="https://github.com/user-attachments/assets/7f1ae23f-a419-4716-9354-4e4d7247f2fe" />

Mobile

<img width="385" height="820" alt="image" src="https://github.com/user-attachments/assets/33244f0e-3d92-4d4c-9ad6-a1984e8ebd67" />

<img width="382" height="819" alt="image" src="https://github.com/user-attachments/assets/324d8fde-a22d-4696-aaee-86e0f06619ec" />





## Related Issues

Solves https://github.com/thunderbird/thunderbird-accounts/issues/392