### PR TITLE
Create a new env var for keycloak that links to account's contact form (Fixes #447)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       KC_SPI_THEME_WELCOME_THEME: "tbpro"
       KC_TBPRO_HOME: "http://localhost:8087/"
       KC_TBPRO_SIGN_UP: "http://localhost:8087/sign-up"
+      KC_TBPRO_CONTACT: "http://localhost:8087/contact"
       KC_TBPRO_PRIMARY_DOMAIN: "example.org"
     volumes:
       - "./keycloak/themes:/opt/keycloak/themes"

--- a/keycloak/themes/tbpro/login/login-username.ftl
+++ b/keycloak/themes/tbpro/login/login-username.ftl
@@ -5,7 +5,7 @@
     <script>
       window._page['currentView'] = {
         formAction: '${url.loginAction}',
-        supportUrl: '${client.baseUrl}contact',
+        supportUrl: '${properties.tbproContactUrl}',
         clientUrl: '${client.baseUrl}',
         // <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
         registerUrl: '${url.registrationUrl}',

--- a/keycloak/themes/tbpro/login/login.ftl
+++ b/keycloak/themes/tbpro/login/login.ftl
@@ -5,7 +5,7 @@
     <script>
       window._page['currentView'] = {
         formAction: '${url.loginAction}',
-        supportUrl: '${client.baseUrl}contact',
+        supportUrl: '${properties.tbproContactUrl}',
         clientUrl: '${client.baseUrl}',
         // <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
         registerUrl: '${url.registrationUrl}',

--- a/keycloak/themes/tbpro/login/theme.properties
+++ b/keycloak/themes/tbpro/login/theme.properties
@@ -5,3 +5,4 @@ scripts=static/app.js
 
 tbproPrimaryDomain=${env.KC_TBPRO_PRIMARY_DOMAIN}
 tbproSignupUrl=${env.KC_TBPRO_SIGN_UP}
+tbproContactUrl=${env.KC_TBPRO_CONTACT}

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -254,6 +254,8 @@ resources:
                 value: "https://accounts.tb.pro/dashboard"
               - name: KC_TBPRO_SIGN_UP
                 value: "https://accounts.tb.pro/sign-up"
+              - name: KC_TBPRO_CONTACT
+                value: "https://accounts.tb.pro/contact"
               - name: KC_TBPRO_PRIMARY_DOMAIN
                 value: "thundermail.com"
 

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -252,6 +252,8 @@ resources:
                 value: "https://accounts-stage.tb.pro/dashboard"
               - name: KC_TBPRO_SIGN_UP
                 value: "https://accounts-stage.tb.pro/sign-up"
+              - name: KC_TBPRO_CONTACT
+                value: "https://accounts-stage.tb.pro/contact"
               - name: KC_TBPRO_PRIMARY_DOMAIN
                 value: "stage-thundermail.com"
 


### PR DESCRIPTION
Since `client.baseUrl` changes based on the client that started the auth flow for the user, we need to swap this to a semi-hardcoded link to accounts.

Fixes #447 
