### PR TITLE
Apply bolt's font-size only on BaseTemplate.

### DIFF
--- a/keycloak/themes/tbpro/assets/css/bolt.css
+++ b/keycloak/themes/tbpro/assets/css/bolt.css
@@ -20,6 +20,6 @@
   --density-relaxed: var(--space-12);
 }
 
-body {
+.bolt-defaults {
   font-size: var(--txt-default);
 }

--- a/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
+++ b/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
@@ -14,7 +14,7 @@ const onWiggle = async () => {
 </script>
 
 <template>
-  <section>
+  <section class="bolt-defaults">
     <div class="debug-page-id" @click="onWiggle" :class="{ wiggle: playingAnimation }">{{ pageId }}</div>
 
     <div class="card">


### PR DESCRIPTION
Fixes #508 

I don't know why this is bolt's default size, but we can fix that in a later issue as it seems like the tbpro theme is correctly sized.