### PR TITLE
Clean up DNS records by removing useless entries. (Fixes #507)

### DIFF
--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -202,7 +202,7 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
         <p>{{ record.type }}</p>
         <p>{{ record.name }}</p>
         <p>{{ record.content }}</p>
-        <p>{{ record.priority }}</p>
+        <p>{{ record.priority || '-' }}</p>
       </div>
     </div>
 

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/utils.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/utils.ts
@@ -17,30 +17,6 @@ export const generateDNSRecords = (domainName: string) => {
       priority: '10',
     },
     {
-      type: 'CNAME',
-      name: `mail.${domainName}`,
-      content: dnsHostname,
-      priority: '-',
-    },
-    {
-      type: 'CNAME',
-      name: `autoconfig.${domainName}.`,
-      content: dnsHostname,
-      priority: '-',
-    },
-    {
-      type: 'CNAME',
-      name: `autodiscover.${domainName}.`,
-      content: dnsHostname,
-      priority: '-',
-    },
-    {
-      type: 'CNAME',
-      name: `mta-sts.${domainName}.`,
-      content: dnsHostname,
-      priority: '-',
-    },
-    {
       type: 'SRV',
       name: `_jmap._tcp.${domainName}.`,
       content: `1 443 ${dnsHostname}`,
@@ -55,12 +31,6 @@ export const generateDNSRecords = (domainName: string) => {
     {
       type: 'SRV',
       name: `_carddavs._tcp.${domainName}.`,
-      content: `1 443 ${dnsHostname}`,
-      priority: '0',
-    },
-    {
-      type: 'SRV',
-      name: `_imap._tcp.${domainName}.`,
       content: `1 443 ${dnsHostname}`,
       priority: '0',
     },


### PR DESCRIPTION
Fixes #507 

Fixes the accounts side issues for that ticket anyways. SPF records come from stalwart so any other changes will need some tweaks there.

