### PR TITLE
Add a window reload after 5 seconds on payment pending screen (Fixes #514)

### DIFF
--- a/assets/app/vue/views/SubscribeView/components/PaymentPendingStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/PaymentPendingStep.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
+import { onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
+
+onMounted(() => {
+  // After 5 seconds reload the page, if the payment came through they'll see the dashboard.
+  window.setTimeout(() => {
+    window.location.reload();
+  }, 5000);
+});
 </script>
 
 <template>


### PR DESCRIPTION
Fixes #514 

This will force a reload so the user isn't stuck here. After a reload or two they'll see the dashboard, and if they don't then they'll probably notice the reloading and go away for a while or contact support.