### PR TITLE
Fix being able to block mail to a certain domain (Fixes #531)

### DIFF
--- a/src/thunderbird_accounts/mail/admin/__init__.py
+++ b/src/thunderbird_accounts/mail/admin/__init__.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from thunderbird_accounts.mail.admin.models import AccountAdmin
-from thunderbird_accounts.mail.models import Account
+from thunderbird_accounts.mail.admin.models import AccountAdmin, DomainAdmin
+from thunderbird_accounts.mail.models import Account, Domain
 
 # Register your models here.
 admin.site.register(Account, AccountAdmin)
+admin.site.register(Domain, DomainAdmin)

--- a/src/thunderbird_accounts/mail/admin/models.py
+++ b/src/thunderbird_accounts/mail/admin/models.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from thunderbird_accounts.mail.admin.actions import admin_fix_stalwart_ids
 from thunderbird_accounts.mail.admin.forms import CustomEmailBaseForm, CustomAccountBaseForm
-from thunderbird_accounts.mail.models import Email
+from thunderbird_accounts.mail.models import Email, Domain
 
 
 class EmailInline(admin.TabularInline):
@@ -19,4 +19,8 @@ class AccountAdmin(admin.ModelAdmin):
     add_form = CustomAccountBaseForm
 
     inlines = (EmailInline,)
+    readonly_fields = ('uuid', 'stalwart_id', 'stalwart_created_at', 'stalwart_updated_at')
+
+class DomainAdmin(admin.ModelAdmin):
+    model = Domain
     readonly_fields = ('uuid', 'stalwart_id', 'stalwart_created_at', 'stalwart_updated_at')

--- a/src/thunderbird_accounts/mail/models.py
+++ b/src/thunderbird_accounts/mail/models.py
@@ -151,3 +151,6 @@ class Domain(BaseStalwartObject):
     last_verification_attempt = models.DateTimeField(
         null=True, blank=True, help_text=_('Date and time of the last verification attempt')
     )
+
+    def __str__(self):
+        return f'{self.name} - {self.status.capitalize()}'


### PR DESCRIPTION
Fixes #531 and fixes #518

* Don't create a stalwart domain for unverified domains
* Once verified then create a stalwart domain entry
* Streamline dev-mode's handling of domain verification
* Fix #518 by requiring the user to remove all aliases first
* Show domains in admin panel