### PR TITLE
Add Zendesk form field support for Dynamic Content (i18n)

### DIFF
--- a/assets/app/vue/views/ContactView/components/ContactSupportForm.vue
+++ b/assets/app/vue/views/ContactView/components/ContactSupportForm.vue
@@ -256,6 +256,7 @@ onMounted(() => {
           :required="field.required"
           :options="field.custom_field_options?.map((option) => ({ label: option.name, value: option.value }))"
           :data-testid="`contact-${field.title}-input`"
+          :help="field.description"
         >
           {{ field.title }}
         </component>

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -148,7 +148,7 @@ def contact_fields(request: HttpRequest):
         if field['active'] and field['visible_in_portal'] and field['editable_in_portal']:
             field_data = {
                 'id': field['id'],
-                'title': field['title'],
+                'title': field['title_in_portal'] if 'title_in_portal' in field else field['title'],
                 'description': field['description'],
                 'required': field['required'],
                 'type': field['type'],


### PR DESCRIPTION
## Description of changes

- Added the description of the field as the `help` prop of our form fields
- Prefers the `title_in_portal` vs `title` when available since that's the desirable default value to be displayed to end users


## Screenshots

Before
<img width="2896" height="2996" alt="image" src="https://github.com/user-attachments/assets/0be3eb85-9e7f-4d53-9096-0f02009279b1" />


After
<img width="2896" height="3134" alt="image" src="https://github.com/user-attachments/assets/3977706e-326a-4c49-b922-c4b542887dbf" />


## Benefits

- Uses the correct key (for now) for the field title in English.

## Related Issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/537