### PR TITLE
Use session.get to return oidc_access_token and create a testcase for this failure (Fixes #543)

### DIFF
--- a/src/thunderbird_accounts/mail/middleware.py
+++ b/src/thunderbird_accounts/mail/middleware.py
@@ -15,7 +15,10 @@ class FixMissingArchivesFolderMiddleware:
         return self.get_response(request)
 
     def check_if_we_need_to_fix_archives_folder(self, request: HttpRequest):
-        oidc_access_token = request.session['oidc_access_token']
+        oidc_access_token = request.session.get('oidc_access_token')
+        if not oidc_access_token:
+            return
+
         user = request.user
 
         # If the user exists, has a stalwart account reference and an oidc access token


### PR DESCRIPTION
Fixes #543 

This is the issue @kewisch was having earlier this week.