### PR TITLE
Use the correct key for showing quota used. (Fixes #582)

### DIFF
--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -244,7 +244,7 @@ def get_subscription_plan_info(request: Request):
         stalwart_client = MailClient()
         account = stalwart_client.get_account(request.user.stalwart_primary_email)
         quota = account.get('quota', 0)
-        used_quota = account.get('used_quota', 0)
+        used_quota = account.get('usedQuota', 0)
     except Exception as e:
         logging.error(f'Error getting used quota: {e}')
         return JsonResponse({'success': False, 'error': 'Error getting mail storage used quota'}, status=500)


### PR DESCRIPTION
Fixes #582 

This works on the admin panel view of stalwart, also you can confirm the key via the stalwart admin panel source code: https://github.com/stalwartlabs/webadmin/blob/a37053788d2bd35c359e49f84857c8d51871a139/src/pages/directory/mod.rs#L32C23-L34