### PR TITLE
Prefer required_in_portal for contact support form required field

### DIFF
--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -163,7 +163,7 @@ def contact_fields(request: HttpRequest):
                 'id': field.get('id'),
                 'title': field.get('title_in_portal') or field.get('title', ''),
                 'description': field.get('description', ''),
-                'required': field.get('required_in_portal', field.get('required', False)),
+                'required': field.get('required_in_portal') or field.get('required', False),
                 'type': field.get('type', ''),
             }
 


### PR DESCRIPTION
## Description of changes

Turns out that Zendesk API, for some reason, have different `required` keys in form fields that don't necessarily match.

After investigating, it seems like the `required` key of the form fields is `False` but the `required_in_portal` of some of the fields are `True` 🤷 which corresponds to what the user is expected to see in the support.tb.pro/hc/en-us/requests/new form as well.

This PR now prioritizes the `required_in_portal` key if it exists, otherwise defaults to the `required` key as a fallback.

## Screenshots

<img width="2846" height="3134" alt="image" src="https://github.com/user-attachments/assets/a104330c-5b9e-4b0d-894d-94e6e6f88959" />


## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/516