### PR TITLE
Update sign-up E2E test for latest app changes

### DIFF
--- a/test/e2e/tests/sign-up.spec.ts
+++ b/test/e2e/tests/sign-up.spec.ts
@@ -24,18 +24,20 @@ test.beforeEach(async ({ page }) => {
 test.describe('sign up form', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY],
 }, () => {
-  test('form successfully submits but is not on allow list', async ({ page }) => {    
+  test('form successfully submits but is not on allow list', async ({ page }) => {
+    const testEmail: string = 'test@example.com';
+
     // Test that no query params = empty recovery email
     await expect(signUpPage.recoveryEmailInput).toBeEmpty();
 
     // go to the contact / submit an issue form and wait for it to load
     const randomUUID = crypto.randomUUID().replaceAll('-', '');
-    await signUpPage.fillForm(randomUUID, 'test@example.com', 'abc123', 'abc123');
+    await signUpPage.fillForm(randomUUID, testEmail, 'abc123', 'abc123');
     await signUpPage.submitForm();
 
     // new page!
     await page.waitForLoadState('domcontentloaded');
-    expect(page.url()).toEqual(TB_PRO_WAIT_LIST_URL);
+    expect(page.url()).toEqual(`${TB_PRO_WAIT_LIST_URL}?email=${encodeURIComponent(testEmail)}`);
   });
 
   test('navigating to sign-up with query param pre-fills form', async ({ page }) => {


### PR DESCRIPTION
Update the sign-up E2E test for the latest app changes (email address now appears as URL parameter when redirecting to wait list). Fixes #600.

BrowserStack link running updated test on [Firefox](https://automate.browserstack.com/dashboard/v2/builds/61fe3a18c67586ce0fb51978e9bfa3e9986a3e83) and [Chromium](https://automate.browserstack.com/dashboard/v2/builds/cdf0135a5bc64c2b957f7f24ed5671efb5aba3eb).