### PR TITLE
Don't include a stalwart_id check when removing a custom domain.

### DIFF
--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -569,15 +569,14 @@ def remove_custom_domain(request: HttpRequest):
         domains = request.user.domains.filter(name=domain_name).all()
         # There should only be one here, but just in case...
         for _domain in domains:
-            if _domain.stalwart_id:
-                try:
-                    stalwart_client.delete_domain(domain.name)
-                except DomainNotFoundError:
-                    # While it's not in Stalwart we seem to have a local reference,
-                    # so try deleting dkim and then local ref
-                    pass
-                stalwart_client.delete_dkim(domain.name)
-                break
+            try:
+                stalwart_client.delete_domain(domain.name)
+            except DomainNotFoundError:
+                # While it's not in Stalwart we seem to have a local reference,
+                # so try deleting dkim and then local ref
+                pass
+            stalwart_client.delete_dkim(domain.name)
+            break
 
         domain.delete()
 


### PR DESCRIPTION
Some domains don't have stalwart_id set, and thus can lead to data rotting on stalwart blocking emails from being properly routed.

We already guard against domain not found so that should be good enough.

For reference: The stalwart_id is just a "hey we have this on stalwart too." You can't actually lookup by stalwart_id, and in the future we should bring this back, but some of our data is a bit messy. 