### PR TITLE
Update browserstack build names

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -6,9 +6,9 @@
     "e2e-test": "npx playwright test --grep e2e-suite --project=firefox",
     "e2e-test-headed": "npx playwright test --grep e2e-suite --project=firefox --headed",
     "e2e-test-debug": "npx playwright test --grep e2e-suite --project=firefox --headed --ui",
-    "e2e-test-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-suite --project=Firefox-OSX --browserstack.config 'browserstack-desktop.yml'",
-    "prod-nightly-tests-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nighlty --project=Firefox-OSX --browserstack.config 'browserstack-desktop-nightly.yml'",
-    "prod-nightly-tests-browserstack-desktop-chromium": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nighlty --project=Chromium-OSX --browserstack.config 'browserstack-desktop-nightly.yml'",
+    "e2e-test-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-suite --project=Firefox-OSX --browserstack.buildName 'TB Accounts E2E Tests Firefox Desktop' --browserstack.config 'browserstack-desktop.yml'",
+    "prod-nightly-tests-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nighlty --project=Firefox-OSX --browserstack.buildName 'TB Accounts Nightly Tests Firefox Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
+    "prod-nightly-tests-browserstack-desktop-chromium": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nighlty --project=Chromium-OSX --browserstack.buildName 'TB Accounts Nightly Tests Chromium Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
     "postinstall": "npm update browserstack-node-sdk"
   },
   "keywords": [],


### PR DESCRIPTION
Add the browser and platform info to the BrowserStack build name so it is easier to identify on the BrowserStack dashboard (and be consistent with our other services). Fixes #607.

BrowserStack links: Running the test jobs on this branch on [Firefox](https://automate.browserstack.com/dashboard/v2/builds/e0a57a4b8eef20851e743be722ff75aa20340ede) and [Chromium](https://automate.browserstack.com/dashboard/v2/builds/224e4783339c023e1f9e20c9031905cfc9c6f38e) desktop. Here's the updated build names as seen on the BrowserStack dashboard:

<img width="216" height="194" alt="Screenshot 2026-02-19 at 10 32 23 AM" src="https://github.com/user-attachments/assets/fce659cc-ac56-4e04-befc-fae0e15ed0d5" />