### PR TITLE
Bump keycloak container's version to 26.5 (currently it pulls 26.5.4)

### DIFF
--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -18,7 +18,7 @@ RUN rm -rf /app/keycloak/assets/*
 #
 # Keycloak dockerfile for local development
 #
-FROM quay.io/keycloak/keycloak:26.3
+FROM quay.io/keycloak/keycloak:26.5
 
 # Load in our dev setup
 COPY --chown=keycloak:keycloak keycloak/data/import /opt/keycloak/data/import


### PR DESCRIPTION
Fixes #529 

This bumps the version to 26.5 from 26.3, this will pull all patch versions like before. So it should currently pull 26.5.4.

Here's the changelog https://www.keycloak.org/docs/latest/upgrading/#migrating-to-26-5-4

I couldn't find any breaking changes that affect us, and template/theme-wise it all worked fine. 