### PR TITLE
Fix variable name so merging works

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -287,7 +287,7 @@ jobs:
           # Create a YAML config stump containing only the nested tree leading to the image tag update
           cat << EOF > newimage.yaml
           resources:
-            keycloak_image: &KEYCLOAK_IMAGE $ECR_TAG
+            .keycloak_image: &KEYCLOAK_IMAGE $ECR_TAG
           EOF
 
           # Use yq to merge the stump into the main config


### PR DESCRIPTION
Another "duplicate anchor" issue, this time because I decided to "dot" the keys in the YAML file (to prevent collision with anything legitimate that might need to use this term elsewhere) but forgot to update the workflows. When the YAML merge happens, you wind up with a duplicate, even though no duplicate exists in the original YAML config.