### PR TITLE
These variables are not under 'resources'

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -161,8 +161,7 @@ jobs:
 
           # Create a YAML config stump containing only the nested tree leading to the image tag update
           cat << EOF > newimage.yaml
-          resources:
-            .accounts_image: &ACCOUNTS_IMAGE $ECR_TAG
+          .accounts_image: &ACCOUNTS_IMAGE $ECR_TAG
           EOF
 
           # Use yq to merge the stump into the main config
@@ -286,8 +285,7 @@ jobs:
 
           # Create a YAML config stump containing only the nested tree leading to the image tag update
           cat << EOF > newimage.yaml
-          resources:
-            .keycloak_image: &KEYCLOAK_IMAGE $ECR_TAG
+          .keycloak_image: &KEYCLOAK_IMAGE $ECR_TAG
           EOF
 
           # Use yq to merge the stump into the main config


### PR DESCRIPTION
The merging content has these variables underneath the `resources` dict, but that's not where it actually lives, which is at the document root.