### PR TITLE
Reset the appointment-caldav-secret value, build an SMSecret out of it

### DIFF
--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -71,4 +71,4 @@ config:
   accounts:keycloak-admin-client-secret:
     secure: AAABACh3RnRJFRb37U658qPm+wN8GUDqeZ/Ck90/qJnGWmULNhVtn5u/+BD8NtVVvaqiMhRmwzja7wLeYypciQ==
   accounts:appointment-caldav-secret:
-    secure: AAABAForTqyhyLA5jEP8mv6uX1s2Kp9CFim/R+NCEAvC8ZgmBhqxsmcL8zWeTBsOZlfLGlkVNBFVo7/teEknbw==
+    secure: AAABAPXX4cm62Agkc0pob1MUB1c7qYxWgJeAFm1051m+Pe3uhZh9KA5qG9ZuTVCbj0i38CCkrefveMpxja23CQ==

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -300,6 +300,7 @@ resources:
         - stalwart-api-auth-key
         - keycloak-admin-client-id
         - keycloak-admin-client-secret
+        - appointment-caldav-secret
 
   tb:ec2:SshableInstance: {}
   # Fill out this template to build an SSH bastion


### PR DESCRIPTION
This resolves the issue that I probably created in a bad rebase the other day which caused Pulumi to want to delete this secret resource.