### PR TITLE
Don't enable payment verification mode if they already have a sub (Fixes #642)

### DIFF
--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -48,7 +48,6 @@ def decode_app_password(secret):
 
 
 def create_stalwart_account(user, app_password: Optional[str] = None) -> bool:
-    # Run this immediately for now, in the future we'll ship these to celery
     if user.account_set.count() > 0 and user.account_set.first().stalwart_id:
         return False
 

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -124,8 +124,11 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     status = transaction.status.value
 
     if transaction and status in [Transaction.StatusValues.COMPLETED.value, Transaction.StatusValues.PAID.value]:
-        user.is_awaiting_payment_verification = True
-        user.save()
+        # Only set enable payment verification mode if they don't have an active subscription
+        # As the webhook could technically come in before or during this successUrl redirect...
+        if not user.has_active_subscription:
+            user.is_awaiting_payment_verification = True
+            user.save()
 
         if settings.IS_DEV:
             tasks.dev_only_paddle_fake_webhook.delay(transaction_id=transaction_id, user_uuid=user.uuid.hex)


### PR DESCRIPTION
Fixes #642 

During the Paypal checkout there's a chance the Paypal side can take longer than Paddle's webhook send & processing. So if we already digest and process the Paddle webhook (which would flip has_active_subscription to True) then we should be sure that we're not reverting a step on the redirect response. 