### PR TITLE
Allow CI access to new tasks

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -1117,3 +1117,5 @@ resources:
         - arn:aws:iam::768512802988:role/accounts-prod-fargate-keycloak
         - arn:aws:iam::768512802988:role/accounts-prod-fargate-accounts
         - arn:aws:iam::768512802988:role/accounts-prod-fargate-accounts-celery
+        - arn:aws:iam::768512802988:role/accounts-stage-afc-accounts-celery-prod
+        - arn:aws:iam::768512802988:role/accounts-stage-afc-accounts-flower-prod


### PR DESCRIPTION
This grants the CI user access to the new task definitions. The Pulumi diff [can be seen here](https://app.pulumi.com/thunderbird/accounts/prod/previews/70e08205-a43e-4d78-a20f-2fd816b59e4c).