### PR TITLE
Fix environment name in permissions

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -1118,5 +1118,5 @@ resources:
         - arn:aws:iam::768512802988:role/accounts-prod-fargate-keycloak
         - arn:aws:iam::768512802988:role/accounts-prod-fargate-accounts
         - arn:aws:iam::768512802988:role/accounts-prod-fargate-accounts-celery
-        - arn:aws:iam::768512802988:role/accounts-stage-afc-accounts-celery-prod
-        - arn:aws:iam::768512802988:role/accounts-stage-afc-accounts-flower-prod
+        - arn:aws:iam::768512802988:role/accounts-prod-afc-accounts-celery-prod
+        - arn:aws:iam::768512802988:role/accounts-prod-afc-accounts-flower-prod


### PR DESCRIPTION
Missed some `stage`s when copying.