### PR TITLE
Allow traffic from the new Celery/Flower containers to Redis

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -135,6 +135,10 @@ redis_source_sgids = [
     .resources['container_security_groups'][f'celery-{project.stack}']['none']
     .resources['sg']
     .id,
+    autoscaling_fargate_clusters['accounts']
+    .resources['container_security_groups'][f'flower-{project.stack}']['flower']
+    .resources['sg']
+    .id,
 ]
 for afc_name, afc in autoscaling_fargate_clusters.items():
     for container_name, lbs in afc.resources['container_security_groups'].items():


### PR DESCRIPTION
This code change ensures that Redis allows traffic from the new containers. [The Pulumi diff is here.](https://app.pulumi.com/thunderbird/accounts/prod/previews/aa64fa51-70d7-4780-b7ab-f24fe6c755da)