### PR TITLE
Scale flower-prod to 1 container

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -576,7 +576,7 @@ resources:
           container_port: 5555
           load_balancer: flower
           service:
-            desired_count: 0
+            desired_count: 1
           target: flower
 
       registries:
@@ -598,8 +598,8 @@ resources:
           min_capacity: 0
           max_capacity: 0
         flower-prod:
-          min_capacity: 0
-          max_capacity: 0
+          min_capacity: 1
+          max_capacity: 1
 
   tb:fargate:FargateClusterWithLogging:
     keycloak:


### PR DESCRIPTION
This is the next step in Issue #621, in which we scale the Flower containers up to a single instance. This should be a completely unintrusive step because even if something goes wrong, this service cannot interrupt any production services. [Terraform diff can be found here.](https://app.pulumi.com/thunderbird/accounts/prod/previews/4be166c7-cf59-49dd-91ea-09cb00f30986)