### PR TITLE
Add `:z` to volume mounts so selinux will allow access.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     #  context: ../stalwart
     #  dockerfile: Dockerfile
     volumes:
-      - ./mail:/opt/stalwart:z
+      - "./mail:/opt/stalwart:z"
     ports:
       - "443:443"
       - "8080:8080"


### PR DESCRIPTION
See https://projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/ for more information.

Now that I'm Asahi Remix with SELinux in enforcing mode I've run into a bit of a pickle with running docker. I don't think dev containers would fix this, since it's a mount / permission issue. Without `:z` I get permission denied as root in container for any mounted directories. 

I think I only need to do this for volumes that are shared between containers, but just in case I wrapped them all. Functionality seems normal. Would be nice to see it tested on a non-selinux machine to see if there's any side-effects.