### PR TITLE
[PoC] Apple Mail QR Code Flow

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -100,7 +100,15 @@
             "description": "Scan the QR code from within the app to automatically configure your account:",
             "qrCodeAltDescription": "A QR Code to be used with Thunderbird for Android account importing."
           },
+          "appleMailQrModal": {
+            "title": "Setup Apple Mail",
+            "description": "Scan this QR code with your iPhone camera to install a mail profile that automatically configures your Thundermail account in Apple Mail:",
+            "qrCodeAltDescription": "A QR code to configure Apple Mail with your Thundermail account.",
+            "loading": "Generating QR code…",
+            "errorMessage": "Failed to generate the Apple Mail QR code. Please try again."
+          },
           "generateQrCodeButtonLabel": "Generate QR Code for Thunderbird for Android",
+          "generateAppleMailQrCodeButtonLabel": "Generate QR Code for Apple Mail",
           "setUpAnEmailApp": "Set up an Email app",
           "downloadDescription": "For a quick and easy setup, we recommend using Thunderbird. Just download the app, enter your email address and password, and you're ready to go.",
           "downloadButtonLabel": "Download",

--- a/assets/app/vue/views/DashboardView/api.ts
+++ b/assets/app/vue/views/DashboardView/api.ts
@@ -10,6 +10,18 @@ export const getSubscriptionPortalLink = async () => {
   return await response.json();
 }
 
+export const getAppleMailQrCode = async (): Promise<string> => {
+  const response = await fetch('/apple-mail/qr', { credentials: 'same-origin' });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const svgText = await response.text();
+
+  return `data:image/svg+xml,${encodeURIComponent(svgText)}`;
+}
+
 export const getSubscriptionPlanInfo = async () => {
   const response = await fetch('/api/v1/subscription/plan/info/', {
     method: 'POST',

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/QrCodeAppleMailModal.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/QrCodeAppleMailModal.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import GenericModal from '@/components/GenericModal.vue';
+import { getAppleMailQrCode } from '@/views/DashboardView/api';
+
+const { t } = useI18n();
+
+const genericModal = useTemplateRef<InstanceType<typeof GenericModal>>('genericModal');
+const svgSrc = ref<string | null>(null);
+const loading = ref(false);
+const errorMessage = ref<string | null>(null);
+
+const fetchQrCode = async () => {
+  loading.value = true;
+  errorMessage.value = null;
+  svgSrc.value = null;
+
+  try {
+    svgSrc.value = await getAppleMailQrCode();
+  } catch (_error) {
+    errorMessage.value = t('views.mail.sections.dashboard.appleMailQrModal.errorMessage');
+  } finally {
+    loading.value = false;
+  }
+};
+
+defineExpose({
+  open: () => {
+    genericModal.value.open();
+    fetchQrCode();
+  },
+});
+</script>
+
+<template>
+  <generic-modal ref="genericModal" :title="t('views.mail.sections.dashboard.appleMailQrModal.title')">
+    <p>{{ t('views.mail.sections.dashboard.appleMailQrModal.description') }}</p>
+    <div v-if="loading" class="loading">
+      {{ t('views.mail.sections.dashboard.appleMailQrModal.loading') }}
+    </div>
+    <p v-else-if="errorMessage" class="error">{{ errorMessage }}</p>
+    <img
+      v-else-if="svgSrc"
+      :src="svgSrc"
+      :alt="t('views.mail.sections.dashboard.appleMailQrModal.qrCodeAltDescription')"
+    />
+  </generic-modal>
+</template>
+
+<style scoped>
+img {
+  max-width: 300px;
+}
+
+.loading {
+  padding: 2rem;
+  color: var(--colour-ti-secondary);
+}
+
+.error {
+  color: var(--colour-danger);
+}
+</style>

--- a/assets/app/vue/views/MailView/sections/DashboardSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { PhDownloadSimple, PhGlobe, PhQrCode } from '@phosphor-icons/vue';
+import { PhAppleLogo, PhDownloadSimple, PhGlobe, PhQrCode } from '@phosphor-icons/vue';
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import { useTour, FTUE_STEPS } from '@/composables/useTour';
 
@@ -14,10 +14,12 @@ import TourCard from '@/components/TourCard.vue';
 import WelcomeHeader from './components/WelcomeHeader.vue';
 import ViewServerSettings from './components/ViewServerSettings.vue';
 import QrCodeModal from './components/QrCodeModal.vue';
+import QrCodeAppleMailModal from './components/QrCodeAppleMailModal.vue';
 
 const { t } = useI18n();
 const tour = useTour();
 const qrCodeModalRef = useTemplateRef<InstanceType<typeof QrCodeModal>>('qrCodeModal');
+const qrCodeAppleMailModalRef = useTemplateRef<InstanceType<typeof QrCodeAppleMailModal>>('qrCodeAppleMailModal');
 
 // https://vite.dev/guide/assets.html#new-url-url-import-meta-url
 const thunderbirdClientImage = new URL('@/assets/png/thundermail-dashboard-client.png', import.meta.url).href;
@@ -67,6 +69,13 @@ export default {
                 </template>
                 {{ t('views.mail.sections.dashboard.generateQrCodeButtonLabel') }}
               </primary-button>
+
+              <primary-button @click="qrCodeAppleMailModalRef?.open()">
+                <template #iconLeft>
+                  <ph-apple-logo size="16" />
+                </template>
+                {{ t('views.mail.sections.dashboard.generateAppleMailQrCodeButtonLabel') }}
+              </primary-button>
             </div>
           </div>
 
@@ -90,6 +99,7 @@ export default {
   </section>
 
   <qr-code-modal ref="qrCodeModal" />
+  <qr-code-apple-mail-modal ref="qrCodeAppleMailModal" />
 </template>
 
 <style scoped>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "django-types>=0.22.0",
     "django-stubs-ext>=5.2.8",
     "flower>=2.0.1",
+    "segno>=1.6.1",
 ]
 description = "Accounts hub for Thunderbird Pro Services."
 readme = "README.md"

--- a/src/thunderbird_accounts/mail/files/thundermail-profile.mobileconfig
+++ b/src/thunderbird_accounts/mail/files/thundermail-profile.mobileconfig
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ConsentText</key>
+	<dict>
+		<key>default</key>
+		<string>This profile configures your Thundermail email account in Apple Mail.</string>
+	</dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>EmailAccountDescription</key>
+			<string>Thundermail</string>
+			<key>EmailAccountName</key>
+			<string>$display_name</string>
+			<key>EmailAccountType</key>
+			<string>EmailTypeIMAP</string>
+			<key>EmailAddress</key>
+			<string>$email_address</string>
+			<key>IncomingMailServerAuthentication</key>
+			<string>EmailAuthPassword</string>
+			<key>IncomingMailServerHostName</key>
+			<string>$imap_host</string>
+			<key>IncomingMailServerPortNumber</key>
+			<integer>$imap_port</integer>
+			<key>IncomingMailServerUseSSL</key>
+			<$imap_use_ssl/>
+			<key>IncomingMailServerUsername</key>
+			<string>$email_address</string>
+			<key>IncomingPassword</key>
+			<string>$app_password</string>
+			<key>OutgoingMailServerAuthentication</key>
+			<string>EmailAuthPassword</string>
+			<key>OutgoingMailServerHostName</key>
+			<string>$smtp_host</string>
+			<key>OutgoingMailServerPortNumber</key>
+			<integer>$smtp_port</integer>
+			<key>OutgoingMailServerUseSSL</key>
+			<$smtp_use_ssl/>
+			<key>OutgoingMailServerUsername</key>
+			<string>$email_address</string>
+			<key>OutgoingPasswordSameAsIncomingPassword</key>
+			<true/>
+			<key>PayloadDescription</key>
+			<string>Configures Email settings</string>
+			<key>PayloadDisplayName</key>
+			<string>Thundermail</string>
+			<key>PayloadIdentifier</key>
+			<string>$payload_identifier_inner</string>
+			<key>PayloadType</key>
+			<string>com.apple.mail.managed</string>
+			<key>PayloadUUID</key>
+			<string>$payload_uuid_inner</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>SMIMEEnableEncryptionPerMessageSwitch</key>
+			<false/>
+			<key>SMIMEEnablePerMessageSwitch</key>
+			<false/>
+			<key>SMIMEEnabled</key>
+			<false/>
+			<key>SMIMEEncryptionEnabled</key>
+			<false/>
+			<key>SMIMESigningEnabled</key>
+			<false/>
+			<key>SMIMESigningUserOverrideable</key>
+			<false/>
+			<key>allowMailDrop</key>
+			<true/>
+			<key>disableMailRecentsSyncing</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Configure Thundermail in Apple Mail</string>
+	<key>PayloadDisplayName</key>
+	<string>Thundermail</string>
+	<key>PayloadIdentifier</key>
+	<string>$payload_identifier_outer</string>
+	<key>PayloadOrganization</key>
+	<string>Thunderbird</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>$payload_uuid_outer</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -29,14 +29,22 @@ def save_app_password(label, password):
 
 
 def filter_app_passwords(secrets: list[str], *, filter_prefix: str | None = None) -> list[str]:
-    """Return app-password secrets with Appointment CalDAV entry excluded.
+    """Return app-password secrets with internal entries excluded.
 
     If filter_prefix is given, only secrets whose label starts with that
-    prefix are kept (all others are returned).  By default the
-    ``APPOINTMENT_APP_PASSWORD_PREFIX`` is stripped out.
+    prefix are kept (all others are returned).  By default both the
+    ``APPOINTMENT_APP_PASSWORD_PREFIX`` and ``APPLE_MAIL_APP_PASSWORD_PREFIX``
+    are stripped out.
     """
-    prefix = f'$app${filter_prefix or settings.APPOINTMENT_APP_PASSWORD_PREFIX}'
-    return [s for s in secrets if not s.startswith(prefix)]
+    if filter_prefix:
+        prefix = f'$app${filter_prefix}'
+        return [s for s in secrets if not s.startswith(prefix)]
+
+    excluded_prefixes = (
+        f'$app${settings.APPOINTMENT_APP_PASSWORD_PREFIX}',
+        f'$app${settings.APPLE_MAIL_APP_PASSWORD_PREFIX}',
+    )
+    return [s for s in secrets if not s.startswith(excluded_prefixes)]
 
 
 def decode_app_password(secret):

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -1,11 +1,15 @@
 from thunderbird_accounts.authentication.exceptions import AuthenticationUnavailable
 from gettext import gettext
+import io
 import sys
 import datetime
 import json
 import logging
 import secrets
+import uuid
+
 import requests
+import segno
 
 import requests.exceptions
 import sentry_sdk
@@ -14,7 +18,8 @@ from django.contrib import messages
 from django.db import IntegrityError
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest, HttpResponseRedirect, JsonResponse
+from django.core.cache import cache
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound, HttpResponseRedirect, JsonResponse
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -830,6 +835,77 @@ def appointment_caldav_setup(request: HttpRequest):
         sentry_sdk.capture_exception(ex)
         error_response.status_code = 500
         return error_response
+
+
+@login_required
+@require_http_methods(['GET'])
+def apple_mail_qr(request: HttpRequest) -> HttpResponse:
+    """Generate a QR code SVG that encodes a one-time download URL for
+    an Apple Mail .mobileconfig profile pre-filled with the user's
+    credentials."""
+    user = request.user
+
+    stalwart_client = MailClient()
+    email_user = stalwart_client.get_account(user.stalwart_primary_email)
+    display_name = email_user.get('description', '')
+
+    label = f'{settings.APPLE_MAIL_APP_PASSWORD_PREFIX}{user.stalwart_primary_email}'
+    expected_prefix = f'$app${label}$'
+    for secret in email_user.get('secrets', []):
+        if secret.startswith(expected_prefix):
+            stalwart_client.delete_app_password(user.stalwart_primary_email, secret)
+
+    base64_password = secrets.token_urlsafe(64)
+    app_password_hash = utils.save_app_password(label, base64_password)
+    stalwart_client.save_app_password(user.stalwart_primary_email, app_password_hash)
+
+    imap = settings.CONNECTION_INFO['IMAP']
+    smtp = settings.CONNECTION_INFO['SMTP']
+
+    apple_mobileconfig_template = settings.APPLE_MOBILECONFIG_TEMPLATE_PATH.read_text()
+
+    mobileconfig_content = apple_mobileconfig_template.substitute(
+        display_name=display_name,
+        email_address=user.stalwart_primary_email,
+        app_password=base64_password,
+        imap_host=imap['HOST'],
+        imap_port=imap['PORT'],
+        imap_use_ssl='true' if imap['TLS'] else 'false',
+        smtp_host=smtp['HOST'],
+        smtp_port=smtp['PORT'],
+        smtp_use_ssl='true' if smtp['TLS'] else 'false',
+        payload_uuid_inner=str(uuid.uuid4()),
+        payload_uuid_outer=str(uuid.uuid4()),
+        payload_identifier_inner=f'com.thunderbird.thundermail.email.{uuid.uuid4()}',
+        payload_identifier_outer=f'com.thunderbird.thundermail.profile.{uuid.uuid4()}',
+    )
+
+    token = secrets.token_urlsafe(32)
+    cache.set(f'apple-mail-profile:{token}', mobileconfig_content, timeout=600)
+
+    download_url = request.build_absolute_uri(f'/apple-mail/download/{token}')
+
+    svg_buffer = io.BytesIO()
+    qr = segno.make(download_url)
+    qr.save(svg_buffer, kind='svg', scale=4)
+
+    return HttpResponse(svg_buffer.getvalue(), content_type='image/svg+xml')
+
+
+@require_http_methods(['GET'])
+def apple_mail_profile_download(request: HttpRequest, token: str) -> HttpResponse:
+    """Serve a one-time .mobileconfig download keyed by *token*."""
+    cache_key = f'apple-mail-profile:{token}'
+    mobileconfig_content = cache.get(cache_key)
+
+    if mobileconfig_content is None:
+        return HttpResponseNotFound()
+
+    cache.delete(cache_key)
+
+    response = HttpResponse(mobileconfig_content, content_type='application/x-apple-aspen-config')
+    response['Content-Disposition'] = 'attachment; filename="thundermail-profile.mobileconfig"'
+    return response
 
 
 @login_required

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -887,7 +887,7 @@ def apple_mail_qr(request: HttpRequest) -> HttpResponse:
 
     svg_buffer = io.BytesIO()
     qr = segno.make(download_url)
-    qr.save(svg_buffer, kind='svg', scale=4)
+    qr.save(svg_buffer, kind='svg', border=3, scale=10)
 
     return HttpResponse(svg_buffer.getvalue(), content_type='image/svg+xml')
 

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -7,6 +7,7 @@ import json
 import logging
 import secrets
 import uuid
+from string import Template
 
 import requests
 import segno
@@ -862,9 +863,8 @@ def apple_mail_qr(request: HttpRequest) -> HttpResponse:
     imap = settings.CONNECTION_INFO['IMAP']
     smtp = settings.CONNECTION_INFO['SMTP']
 
-    apple_mobileconfig_template = settings.APPLE_MOBILECONFIG_TEMPLATE_PATH.read_text()
-
-    mobileconfig_content = apple_mobileconfig_template.substitute(
+    template = Template(settings.APPLE_MOBILECONFIG_TEMPLATE_PATH.read_text())
+    mobileconfig_content = template.substitute(
         display_name=display_name,
         email_address=user.stalwart_primary_email,
         app_password=base64_password,
@@ -905,6 +905,7 @@ def apple_mail_profile_download(request: HttpRequest, token: str) -> HttpRespons
 
     response = HttpResponse(mobileconfig_content, content_type='application/x-apple-aspen-config')
     response['Content-Disposition'] = 'attachment; filename="thundermail-profile.mobileconfig"'
+
     return response
 
 

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -509,3 +509,7 @@ VERIFY_PRIVATE_LINK_SSL = True if os.getenv('VERIFY_PRIVATE_LINK_SSL', 'true').l
 
 # For Appointment's CalDAV auto-setup
 APPOINTMENT_APP_PASSWORD_PREFIX: str = 'appointment-caldav-setup-'
+
+# For Apple Mail qr code / .mobileconfig profile template
+APPLE_MAIL_APP_PASSWORD_PREFIX: str = 'apple-mail-setup-'
+APPLE_MOBILECONFIG_TEMPLATE_PATH: Path = Path(__file__).parent / 'mail' / 'files' / 'thundermail-profile.mobileconfig'

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -53,6 +53,9 @@ urlpatterns = [
     path('subscription/paddle/complete/', subscription_views.paddle_transaction_complete, name='paddle_completed'),
     # CalDAV auto-setup for Appointment
     path('appointment/caldav/setup/', mail_views.appointment_caldav_setup, name='appointment_caldav_setup'),
+    # Apple Mail mobileconfig QR setup
+    path('apple-mail/qr', mail_views.apple_mail_qr, name='apple_mail_qr'),
+    path('apple-mail/download/<str:token>', mail_views.apple_mail_profile_download, name='apple_mail_profile_download'),
     # API
     path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),


### PR DESCRIPTION
## Description of changes

- Added `segno` to generate the QR codes on the backend
- Added a `GET` to `/apple-mail/qr` that replaces the `.mobileconfig` file template strings with the user credentials / configs and stores this in the cache with a cache_key of a generated token. This token then gets encoded in a download URL and sent back in the form of a QR code
- Added a `GET` to `/apple-mail/download/:token` that access the cache with the token as key and then provides the `.mobileconfig` file for downloading


## Screenshots

Generate QR Code for Apple Mail
<img width="1473" height="939" alt="image" src="https://github.com/user-attachments/assets/d52da953-3092-4bce-8f2d-bbfefd1a839c" />


QR Code Modal
<img width="1471" height="937" alt="image" src="https://github.com/user-attachments/assets/0efe4e15-1222-4b72-97d5-c821b0c7e2be" />



## Related Issues
Fixes https://github.com/thunderbird/thunderbird-accounts/issues/656