### PR TITLE
FTUE Mail Dashboard Tour Cards

### DIFF
--- a/assets/app/vue/components/TourCard.vue
+++ b/assets/app/vue/components/TourCard.vue
@@ -1,35 +1,41 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { LinkButton, PrimaryButton } from '@thunderbirdops/services-ui';
 import { PhXCircle } from '@phosphor-icons/vue';
 
 const { t } = useI18n();
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   text: string;
+  title?: string;
   subtitle?: string;
   currentStep: number;
   totalSteps: number;
   showBack?: boolean;
   nextLabel?: string;
-  variant?: 'section' | 'header';
+  variant?: 'section' | 'header' | 'welcome';
 }>(), {
   variant: 'section',
 });
 
 const emit = defineEmits(['next', 'back', 'close']);
+
+const isWelcome = computed(() => props.variant === 'welcome');
 </script>
 
 <template>
   <div
     class="tour-card"
-    :class="{ 'tour-card--header': variant === 'header' }"
+    :class="{
+      'tour-card--header': variant === 'header' || variant === 'welcome',
+    }"
     role="dialog"
-    :aria-label="t('views.mail.ftue.step', { step: currentStep, total: totalSteps })"
+    :aria-label="isWelcome ? title : t('views.mail.ftue.step', { step: currentStep, total: totalSteps })"
     aria-modal="false"
     tabindex="-1"
   >
-    <header>
+    <header v-if="!isWelcome">
       <p>{{ t('views.mail.ftue.step', { step: currentStep, total: totalSteps }) }}</p>
       <button class="close-button" :aria-label="t('views.mail.ftue.close')" @click="emit('close')">
         <ph-x-circle size="24" />
@@ -37,11 +43,15 @@ const emit = defineEmits(['next', 'back', 'close']);
     </header>
 
     <div class="content">
+      <h2 v-if="isWelcome && title">{{ title }}</h2>
       <p>{{ text }}</p>
       <p v-if="subtitle">{{ subtitle }}</p>
   
       <div class="buttons-container">
-        <link-button v-if="showBack" size="small" @click="emit('back')">
+        <link-button v-if="isWelcome" size="small" @click="emit('close')">
+          {{ t('views.mail.ftue.skip') }}
+        </link-button>
+        <link-button v-else-if="showBack" size="small" @click="emit('back')">
           {{ t('views.mail.ftue.back') }}
         </link-button>
   

--- a/assets/app/vue/components/TourCard.vue
+++ b/assets/app/vue/components/TourCard.vue
@@ -18,10 +18,16 @@ const emit = defineEmits(['next', 'back', 'close']);
 </script>
 
 <template>
-  <div class="tour-card">
+  <div
+    class="tour-card"
+    role="dialog"
+    :aria-label="t('views.mail.ftue.step', { step: currentStep, total: totalSteps })"
+    aria-modal="false"
+    tabindex="-1"
+  >
     <header>
       <p>{{ t('views.mail.ftue.step', { step: currentStep, total: totalSteps }) }}</p>
-      <button class="close-button" @click="emit('close')">
+      <button class="close-button" :aria-label="t('views.mail.ftue.close')" @click="emit('close')">
         <ph-x-circle size="24" />
       </button>
     </header>
@@ -109,7 +115,7 @@ const emit = defineEmits(['next', 'back', 'close']);
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1280px) {
   .tour-card {
     top: -0.625rem;
     right: 0;

--- a/assets/app/vue/components/TourCard.vue
+++ b/assets/app/vue/components/TourCard.vue
@@ -26,17 +26,19 @@ const emit = defineEmits(['next', 'back', 'close']);
       </button>
     </header>
 
-    <p>{{ text }}</p>
-    <p v-if="subtitle">{{ subtitle }}</p>
-
-    <div class="buttons-container">
-      <link-button v-if="showBack" size="small" @click="emit('back')">
-        {{ t('views.mail.ftue.back') }}
-      </link-button>
-
-      <primary-button size="small" @click="emit('next')">
-        {{ nextLabel || t('views.mail.ftue.next') }}
-      </primary-button>
+    <div class="content">
+      <p>{{ text }}</p>
+      <p v-if="subtitle">{{ subtitle }}</p>
+  
+      <div class="buttons-container">
+        <link-button v-if="showBack" size="small" @click="emit('back')">
+          {{ t('views.mail.ftue.back') }}
+        </link-button>
+  
+        <primary-button size="small" @click="emit('next')">
+          {{ nextLabel || t('views.mail.ftue.next') }}
+        </primary-button>
+      </div>
     </div>
   </div>
 </template>
@@ -54,12 +56,12 @@ const emit = defineEmits(['next', 'back', 'close']);
   transform: translateX(50%);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   width: 240px;
   padding: 0.75rem 1rem;
   color: var(--colour-ti-base);
   background-color: var(--colour-neutral-base);
-  box-shadow: 0.25rem 0.25rem 1rem 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.2);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   z-index: 2;
@@ -85,12 +87,19 @@ const emit = defineEmits(['next', 'back', 'close']);
     }
 
     .close-button {
+      height: 1.5rem;
       background: none;
       border: none;
       cursor: pointer;
       padding: 0;
       color: var(--colour-ti-muted);
     }
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
   }
 
   .buttons-container {
@@ -100,8 +109,9 @@ const emit = defineEmits(['next', 'back', 'close']);
   }
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 768px) {
   .tour-card {
+    top: -0.625rem;
     right: 0;
   }
 }

--- a/assets/app/vue/components/TourCard.vue
+++ b/assets/app/vue/components/TourCard.vue
@@ -5,14 +5,17 @@ import { PhXCircle } from '@phosphor-icons/vue';
 
 const { t } = useI18n();
 
-defineProps<{
+withDefaults(defineProps<{
   text: string;
   subtitle?: string;
   currentStep: number;
   totalSteps: number;
   showBack?: boolean;
   nextLabel?: string;
-}>();
+  variant?: 'section' | 'header';
+}>(), {
+  variant: 'section',
+});
 
 const emit = defineEmits(['next', 'back', 'close']);
 </script>
@@ -20,6 +23,7 @@ const emit = defineEmits(['next', 'back', 'close']);
 <template>
   <div
     class="tour-card"
+    :class="{ 'tour-card--header': variant === 'header' }"
     role="dialog"
     :aria-label="t('views.mail.ftue.step', { step: currentStep, total: totalSteps })"
     aria-modal="false"
@@ -115,10 +119,22 @@ const emit = defineEmits(['next', 'back', 'close']);
   }
 }
 
+.tour-card--header {
+  top: 4.75rem;
+  right: 2rem;
+  z-index: 10;
+  transform: none;
+}
+
 @media (min-width: 1280px) {
   .tour-card {
     top: -0.625rem;
     right: 0;
+  }
+
+  .tour-card--header {
+    top: 4.75rem;
+    right: 2rem;
   }
 }
 </style>

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -1,4 +1,4 @@
-import { ref, watch } from 'vue';
+import { ref, watch, nextTick } from 'vue';
 
 export const FTUE_STEPS = {
   INITIAL: 0,
@@ -10,6 +10,7 @@ export const FTUE_STEPS = {
 }
 
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
+const TOUR_CARD_SELECTOR = '[role="dialog"][tabindex="-1"]';
 
 // Get the initial state of the FTUE from localStorage or return true if not available
 const getInitialState = () => {
@@ -23,12 +24,31 @@ const getInitialState = () => {
 const currentStep = ref(FTUE_STEPS.INITIAL);
 const showFTUE = ref(getInitialState());
 
-// When the showFTUE state changes to false, we mark it the FTUE as completed in localStorage
+const onEscapeKey = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    showFTUE.value = false;
+  }
+};
+
+const focusTourCard = () => {
+  nextTick(() => {
+    const card = document.querySelector<HTMLElement>(TOUR_CARD_SELECTOR);
+    card?.focus();
+  });
+};
+
 watch(showFTUE, (value) => {
-  if (!value && typeof localStorage !== 'undefined') {
+  if (value) {
+    document.addEventListener('keydown', onEscapeKey);
+    return;
+  }
+
+  document.removeEventListener('keydown', onEscapeKey);
+
+  if (typeof localStorage !== 'undefined') {
     localStorage.setItem(FTUE_STORAGE_KEY, 'true');
   }
-});
+}, { immediate: true });
 
 export const useTour = () => {
   const steps = [
@@ -78,7 +98,7 @@ export const useTour = () => {
     showFTUE.value = false;
   };
 
-  // Auto-scroll to target when step changes
+  // Auto-scroll to target and move focus when step changes
   watch(currentStep, (newStep) => {
     if (!showFTUE.value) return;
 
@@ -87,6 +107,7 @@ export const useTour = () => {
 
     if (newStep === FTUE_STEPS.INITIAL || newStep === FTUE_STEPS.FINAL) {
       window.scrollTo({ top: 0, behavior });
+      focusTourCard();
       return;
     }
 
@@ -99,6 +120,8 @@ export const useTour = () => {
         element.scrollIntoView({ behavior, block: 'center' });
       }
     }
+
+    focusTourCard();
   });
 
   return {

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -7,7 +7,7 @@ export const FTUE_STEPS = {
   EMAIL_ALIASES: 3,
   CUSTOM_DOMAINS: 4,
   FINAL: 5,
-}
+} as const;
 
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
 const TOUR_CARD_SELECTOR = '[role="dialog"][tabindex="-1"]';
@@ -21,7 +21,7 @@ const getInitialState = () => {
   return true;
 };
 
-const currentStep = ref(FTUE_STEPS.INITIAL);
+const currentStep = ref<typeof FTUE_STEPS[keyof typeof FTUE_STEPS]>(FTUE_STEPS.INITIAL);
 const showFTUE = ref(getInitialState());
 
 const onEscapeKey = (event: KeyboardEvent) => {

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -10,7 +10,7 @@ export const FTUE_STEPS = {
 } as const;
 
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
-const TOUR_CARD_SELECTOR = '[role="dialog"][tabindex="-1"]';
+const TOUR_CARD_SELECTOR = '[data-tour-card]';
 
 // Get the initial state of the FTUE from localStorage or return true if not available
 const getInitialState = () => {

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -2,9 +2,11 @@ import { ref, watch } from 'vue';
 
 export const FTUE_STEPS = {
   INITIAL: 0,
-  DASHBOARD: 1,
-  CUSTOM_DOMAINS: 2,
-  FINAL: 3,
+  CONNECT_EMAIL: 1,
+  APP_PASSWORDS: 2,
+  EMAIL_ALIASES: 3,
+  CUSTOM_DOMAINS: 4,
+  FINAL: 5,
 }
 
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
@@ -34,8 +36,16 @@ export const useTour = () => {
       id: FTUE_STEPS.INITIAL,
     },
     {
-      id: FTUE_STEPS.DASHBOARD,
-      targetId: 'dashboard',
+      id: FTUE_STEPS.CONNECT_EMAIL,
+      targetId: 'connect-email',
+    },
+    {
+      id: FTUE_STEPS.APP_PASSWORDS,
+      targetId: 'email-settings',
+    },
+    {
+      id: FTUE_STEPS.EMAIL_ALIASES,
+      targetId: 'email-aliases',
     },
     {
       id: FTUE_STEPS.CUSTOM_DOMAINS,
@@ -43,12 +53,11 @@ export const useTour = () => {
     },
     {
       id: FTUE_STEPS.FINAL,
-      targetId: 'email-settings',
     }
   ];
 
   const start = () => {
-    currentStep.value = FTUE_STEPS.DASHBOARD;
+    currentStep.value = FTUE_STEPS.CONNECT_EMAIL;
   };
 
   const next = () => {
@@ -76,7 +85,7 @@ export const useTour = () => {
     const noPrefersReducedMotion = window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
     const behavior = noPrefersReducedMotion ? 'smooth' : 'auto';
 
-    if (newStep === FTUE_STEPS.INITIAL) {
+    if (newStep === FTUE_STEPS.INITIAL || newStep === FTUE_STEPS.FINAL) {
       window.scrollTo({ top: 0, behavior });
       return;
     }

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -1,4 +1,4 @@
-import { ref, watch, nextTick } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 
 export const FTUE_STEPS = {
   INITIAL: 0,
@@ -8,6 +8,19 @@ export const FTUE_STEPS = {
   CUSTOM_DOMAINS: 4,
   FINAL: 5,
 } as const;
+
+type FtueStepId = typeof FTUE_STEPS[keyof typeof FTUE_STEPS];
+
+interface StepConfig {
+  targetId?: string;
+  teleportTarget?: string;
+  titleKey?: string;
+  textKey?: string;
+  subtitleNextStepKey?: string;
+  showBack?: boolean;
+  variant?: 'section' | 'header' | 'welcome';
+  nextLabelKey?: string;
+}
 
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
 const TOUR_CARD_SELECTOR = '[data-tour-card]';
@@ -21,7 +34,7 @@ const getInitialState = () => {
   return true;
 };
 
-const currentStep = ref<typeof FTUE_STEPS[keyof typeof FTUE_STEPS]>(FTUE_STEPS.INITIAL);
+const currentStep = ref<FtueStepId>(FTUE_STEPS.INITIAL);
 const showFTUE = ref(getInitialState());
 
 const onEscapeKey = (event: KeyboardEvent) => {
@@ -51,33 +64,55 @@ watch(showFTUE, (value) => {
 }, { immediate: true });
 
 export const useTour = () => {
-  const steps = [
-    {
-      id: FTUE_STEPS.INITIAL,
+  const steps: Record<FtueStepId, StepConfig> = {
+    [FTUE_STEPS.INITIAL]: {
+      teleportTarget: '#tour-target-header',
+      titleKey: 'views.mail.ftue.initialWelcomeTitle',
+      textKey: 'views.mail.ftue.initialWelcomeDescription',
+      variant: 'welcome',
+      nextLabelKey: 'views.mail.ftue.letsGo',
     },
-    {
-      id: FTUE_STEPS.CONNECT_EMAIL,
+    [FTUE_STEPS.CONNECT_EMAIL]: {
       targetId: 'connect-email',
+      teleportTarget: '#tour-target-connect-email',
+      textKey: 'views.mail.ftue.step1Text',
+      subtitleNextStepKey: 'views.mail.ftue.appPassword',
+      showBack: false,
     },
-    {
-      id: FTUE_STEPS.APP_PASSWORDS,
+    [FTUE_STEPS.APP_PASSWORDS]: {
       targetId: 'email-settings',
+      teleportTarget: '#tour-target-app-passwords',
+      textKey: 'views.mail.ftue.step2Text',
+      subtitleNextStepKey: 'views.mail.ftue.emailAliases',
+      showBack: true,
     },
-    {
-      id: FTUE_STEPS.EMAIL_ALIASES,
+    [FTUE_STEPS.EMAIL_ALIASES]: {
       targetId: 'email-aliases',
+      teleportTarget: '#tour-target-email-aliases',
+      textKey: 'views.mail.ftue.step3Text',
+      subtitleNextStepKey: 'views.mail.ftue.customDomains',
+      showBack: true,
     },
-    {
-      id: FTUE_STEPS.CUSTOM_DOMAINS,
+    [FTUE_STEPS.CUSTOM_DOMAINS]: {
       targetId: 'custom-domains',
+      teleportTarget: '#tour-target-custom-domains',
+      textKey: 'views.mail.ftue.step4Text',
+      subtitleNextStepKey: 'views.mail.ftue.yourAccount',
+      showBack: true,
     },
-    {
-      id: FTUE_STEPS.FINAL,
-    }
-  ];
+    [FTUE_STEPS.FINAL]: {
+      teleportTarget: '#tour-target-header',
+      textKey: 'views.mail.ftue.step5Text',
+      showBack: true,
+      variant: 'header',
+      nextLabelKey: 'views.mail.ftue.done',
+    },
+  };
+
+  const currentStepConfig = computed(() => steps[currentStep.value]);
 
   const next = () => {
-    if (currentStep.value < steps.length - 1) {
+    if (currentStep.value < FTUE_STEPS.FINAL) {
       currentStep.value++;
     } else {
       showFTUE.value = false;
@@ -85,7 +120,7 @@ export const useTour = () => {
   };
 
   const back = () => {
-    if (currentStep.value > 0) {
+    if (currentStep.value > FTUE_STEPS.INITIAL) {
       currentStep.value--;
     }
   };
@@ -107,9 +142,9 @@ export const useTour = () => {
       return;
     }
 
-    const step = steps.find(s => s.id === newStep);
+    const step = steps[newStep];
 
-    if (step && step.targetId) {
+    if (step.targetId) {
       const element = document.getElementById(step.targetId);
 
       if (element) {
@@ -122,6 +157,7 @@ export const useTour = () => {
 
   return {
     currentStep,
+    currentStepConfig,
     showFTUE,
     next,
     back,

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -20,7 +20,7 @@ interface StepConfig {
   showBack?: boolean;
   variant?: 'section' | 'header' | 'welcome';
   nextLabelKey?: string;
-}
+};
 
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
 const TOUR_CARD_SELECTOR = '[data-tour-card]';

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -76,10 +76,6 @@ export const useTour = () => {
     }
   ];
 
-  const start = () => {
-    currentStep.value = FTUE_STEPS.CONNECT_EMAIL;
-  };
-
   const next = () => {
     if (currentStep.value < steps.length - 1) {
       currentStep.value++;
@@ -127,7 +123,6 @@ export const useTour = () => {
   return {
     currentStep,
     showFTUE,
-    start,
     next,
     back,
     skip

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -277,9 +277,16 @@
         "back": "Back",
         "done": "Done",
         "step": "Step {step} of {total}",
-        "step1Text": "Download Thunderbird (or your preferred email app) and sign in with your primary email and password to access your new account.",
-        "step2Text": "{'Add a custom domain you own to create additional email addresses like you@yourdomain.com.'}",
-        "step3Text": "Add email addresses using your custom domains."
+        "nextStep": "Next: {step}",
+        "appPassword": "App Password",
+        "emailAliases": "Email aliases",
+        "customDomains": "Custom domains",
+        "yourAccount": "Your account",
+        "step1Text": "Connect your new email address to start sending and receiving messages. Use Thunderbird or any email app you prefer.",
+        "step2Text": "Create an app password for email, calendar, and other apps that need a separate sign-in.",
+        "step3Text": "Claim any additional email aliases you would like to use.",
+        "step4Text": "Add custom domains to create email aliases for any need.",
+        "step5Text": "Go to your Thunderbird Pro account to view account details, manage billing, or cancel your service."
       }
     },
     "manageMfa": {

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -286,7 +286,8 @@
         "step2Text": "Create an app password for email, calendar, and other apps that need a separate sign-in.",
         "step3Text": "Claim any additional email aliases you would like to use.",
         "step4Text": "Add custom domains to create email aliases for any need.",
-        "step5Text": "Go to your Thunderbird Pro account to view account details, manage billing, or cancel your service."
+        "step5Text": "Go to your Thunderbird Pro account to view account details, manage billing, or cancel your service.",
+        "close": "Close tour"
       }
     },
     "manageMfa": {

--- a/assets/app/vue/views/MailView/index.vue
+++ b/assets/app/vue/views/MailView/index.vue
@@ -47,7 +47,14 @@ export default {
     <!-- <security-settings-section /> -->
 
     <!-- FTUE Initial Welcome Tour Card -->
-    <div class="header-card" v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.INITIAL">
+    <div
+      class="header-card"
+      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.INITIAL"
+      role="dialog"
+      :aria-label="t('views.mail.ftue.initialWelcomeTitle')"
+      aria-modal="false"
+      tabindex="-1"
+    >
       <h2>{{ t('views.mail.ftue.initialWelcomeTitle') }}</h2>
       <p>{{ t('views.mail.ftue.initialWelcomeDescription') }}</p>
 
@@ -62,10 +69,17 @@ export default {
     </div>
 
     <!-- FTUE Final Tour Card -->
-    <div class="header-card final" v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL">
+    <div
+      class="header-card final"
+      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL"
+      role="dialog"
+      :aria-label="t('views.mail.ftue.step', { step: tour.currentStep.value, total: FTUE_STEPS.FINAL })"
+      aria-modal="false"
+      tabindex="-1"
+    >
       <header>
         <p class="step-label">{{ t('views.mail.ftue.step', { step: tour.currentStep.value, total: FTUE_STEPS.FINAL }) }}</p>
-        <button class="close-button" @click="tour.skip()">
+        <button class="close-button" :aria-label="t('views.mail.ftue.close')" @click="tour.skip()">
           <ph-x-circle size="24" />
         </button>
       </header>

--- a/assets/app/vue/views/MailView/index.vue
+++ b/assets/app/vue/views/MailView/index.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useTour, FTUE_STEPS } from '@/composables/useTour';
 import { LinkButton, PrimaryButton } from '@thunderbirdops/services-ui';
+import { PhXCircle } from '@phosphor-icons/vue';
 
 import WelcomeHeader from './sections/DashboardSection/components/WelcomeHeader.vue';
 import GetStartedWithThundermail from './sections/DashboardSection/components/GetStartedWithThundermail.vue';
@@ -46,7 +47,7 @@ export default {
     <!-- <security-settings-section /> -->
 
     <!-- FTUE Initial Welcome Tour Card -->
-    <div class="initial-welcome" v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.INITIAL">
+    <div class="header-card" v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.INITIAL">
       <h2>{{ t('views.mail.ftue.initialWelcomeTitle') }}</h2>
       <p>{{ t('views.mail.ftue.initialWelcomeDescription') }}</p>
 
@@ -57,6 +58,29 @@ export default {
         <primary-button size="small" @click="tour.next()">
           {{ t('views.mail.ftue.letsGo') }}
         </primary-button>
+      </div>
+    </div>
+
+    <!-- FTUE Final Tour Card -->
+    <div class="header-card final" v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL">
+      <header>
+        <p class="step-label">{{ t('views.mail.ftue.step', { step: tour.currentStep.value, total: FTUE_STEPS.FINAL }) }}</p>
+        <button class="close-button" @click="tour.skip()">
+          <ph-x-circle size="24" />
+        </button>
+      </header>
+
+      <div class="content">
+        <p>{{ t('views.mail.ftue.step5Text') }}</p>
+  
+        <div class="buttons-container">
+          <link-button size="small" @click="tour.back()">
+            {{ t('views.mail.ftue.back') }}
+          </link-button>
+          <primary-button size="small" @click="tour.next()">
+            {{ t('views.mail.ftue.done') }}
+          </primary-button>
+        </div>
       </div>
     </div>
   </div>
@@ -81,24 +105,59 @@ export default {
   font-size: 0.75rem;
 }
 
-.initial-welcome {
+.header-card {
   position: absolute;
   top: 4.75rem;
   right: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.875rem;
   width: 240px;
   padding: 0.75rem 1rem;
   color: var(--colour-ti-base);
   background-color: var(--colour-neutral-base);
-  box-shadow: 0.25rem 0.25rem 1rem 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.2);
   border-radius: 0.5rem;
   font-size: 0.875rem;
+  z-index: 10;
+
+  &.final {
+    gap: 0.5rem;
+  }
 
   h2 {
     font-weight: 700;
     font-size: 0.875rem;
+    margin: 0;
+  }
+
+  p {
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .step-label {
+      font-size: 0.6875rem;
+    }
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+  }
+
+  .close-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    color: var(--colour-ti-muted);
   }
 
   .buttons-container {

--- a/assets/app/vue/views/MailView/index.vue
+++ b/assets/app/vue/views/MailView/index.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useTour, FTUE_STEPS } from '@/composables/useTour';
 import { LinkButton, PrimaryButton } from '@thunderbirdops/services-ui';
-import { PhXCircle } from '@phosphor-icons/vue';
+import TourCard from '@/components/TourCard.vue';
 
 import WelcomeHeader from './sections/DashboardSection/components/WelcomeHeader.vue';
 import GetStartedWithThundermail from './sections/DashboardSection/components/GetStartedWithThundermail.vue';
@@ -69,34 +69,18 @@ export default {
     </div>
 
     <!-- FTUE Final Tour Card -->
-    <div
-      class="header-card final"
+    <tour-card
       v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL"
-      role="dialog"
-      :aria-label="t('views.mail.ftue.step', { step: tour.currentStep.value, total: FTUE_STEPS.FINAL })"
-      aria-modal="false"
-      tabindex="-1"
-    >
-      <header>
-        <p class="step-label">{{ t('views.mail.ftue.step', { step: tour.currentStep.value, total: FTUE_STEPS.FINAL }) }}</p>
-        <button class="close-button" :aria-label="t('views.mail.ftue.close')" @click="tour.skip()">
-          <ph-x-circle size="24" />
-        </button>
-      </header>
-
-      <div class="content">
-        <p>{{ t('views.mail.ftue.step5Text') }}</p>
-  
-        <div class="buttons-container">
-          <link-button size="small" @click="tour.back()">
-            {{ t('views.mail.ftue.back') }}
-          </link-button>
-          <primary-button size="small" @click="tour.next()">
-            {{ t('views.mail.ftue.done') }}
-          </primary-button>
-        </div>
-      </div>
-    </div>
+      variant="header"
+      :text="t('views.mail.ftue.step5Text')"
+      :current-step="tour.currentStep.value"
+      :total-steps="FTUE_STEPS.FINAL"
+      :next-label="t('views.mail.ftue.done')"
+      show-back
+      @next="tour.next()"
+      @back="tour.back()"
+      @close="tour.skip()"
+    />
   </div>
 </template>
 
@@ -135,10 +119,6 @@ export default {
   font-size: 0.875rem;
   z-index: 10;
 
-  &.final {
-    gap: 0.5rem;
-  }
-
   h2 {
     font-weight: 700;
     font-size: 0.875rem;
@@ -148,30 +128,6 @@ export default {
   p {
     margin: 0;
     line-height: 1.4;
-  }
-
-  header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    .step-label {
-      font-size: 0.6875rem;
-    }
-  }
-
-  .content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.875rem;
-  }
-
-  .close-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    color: var(--colour-ti-muted);
   }
 
   .buttons-container {

--- a/assets/app/vue/views/MailView/index.vue
+++ b/assets/app/vue/views/MailView/index.vue
@@ -2,7 +2,6 @@
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useTour, FTUE_STEPS } from '@/composables/useTour';
-import { LinkButton, PrimaryButton } from '@thunderbirdops/services-ui';
 import TourCard from '@/components/TourCard.vue';
 
 import WelcomeHeader from './sections/DashboardSection/components/WelcomeHeader.vue';
@@ -46,43 +45,34 @@ export default {
     <!-- TODO: Uncomment when implementing security settings -->
     <!-- <security-settings-section /> -->
 
-    <!-- FTUE Initial Welcome Tour Card -->
-    <div
-      data-tour-card
-      class="header-card"
-      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.INITIAL"
-      role="dialog"
-      :aria-label="t('views.mail.ftue.initialWelcomeTitle')"
-      aria-modal="false"
-      tabindex="-1"
+    <div id="tour-target-header" />
+
+    <Teleport
+      v-if="tour.showFTUE.value && tour.currentStepConfig.value?.teleportTarget"
+      :to="tour.currentStepConfig.value.teleportTarget"
+      defer
     >
-      <h2>{{ t('views.mail.ftue.initialWelcomeTitle') }}</h2>
-      <p>{{ t('views.mail.ftue.initialWelcomeDescription') }}</p>
-
-      <div class="buttons-container">
-        <link-button size="small" @click="tour.skip()">
-          {{ t('views.mail.ftue.skip') }}
-        </link-button>
-        <primary-button size="small" @click="tour.next()">
-          {{ t('views.mail.ftue.letsGo') }}
-        </primary-button>
-      </div>
-    </div>
-
-    <!-- FTUE Final Tour Card -->
-    <tour-card
-      data-tour-card
-      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL"
-      variant="header"
-      :text="t('views.mail.ftue.step5Text')"
-      :current-step="tour.currentStep.value"
-      :total-steps="FTUE_STEPS.FINAL"
-      :next-label="t('views.mail.ftue.done')"
-      show-back
-      @next="tour.next()"
-      @back="tour.back()"
-      @close="tour.skip()"
-    />
+      <tour-card
+        data-tour-card
+        :title="tour.currentStepConfig.value.titleKey
+          ? t(tour.currentStepConfig.value.titleKey)
+          : undefined"
+        :text="t(tour.currentStepConfig.value.textKey)"
+        :subtitle="tour.currentStepConfig.value.subtitleNextStepKey
+          ? t('views.mail.ftue.nextStep', { step: t(tour.currentStepConfig.value.subtitleNextStepKey) })
+          : undefined"
+        :current-step="tour.currentStep.value"
+        :total-steps="FTUE_STEPS.FINAL"
+        :show-back="tour.currentStepConfig.value.showBack"
+        :variant="tour.currentStepConfig.value.variant"
+        :next-label="tour.currentStepConfig.value.nextLabelKey
+          ? t(tour.currentStepConfig.value.nextLabelKey)
+          : undefined"
+        @next="tour.next()"
+        @back="tour.back()"
+        @close="tour.skip()"
+      />
+    </Teleport>
   </div>
 </template>
 
@@ -98,44 +88,5 @@ export default {
 
 .teleport-target {
   display: contents;
-}
-
-/* Overriding the link button font size */
-:deep(.base.link.small.filled > span) {
-  font-size: 0.75rem;
-}
-
-.header-card {
-  position: absolute;
-  top: 4.75rem;
-  right: 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.875rem;
-  width: 240px;
-  padding: 0.75rem 1rem;
-  color: var(--colour-ti-base);
-  background-color: var(--colour-neutral-base);
-  box-shadow: 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.2);
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  z-index: 10;
-
-  h2 {
-    font-weight: 700;
-    font-size: 0.875rem;
-    margin: 0;
-  }
-
-  p {
-    margin: 0;
-    line-height: 1.4;
-  }
-
-  .buttons-container {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
-  }
 }
 </style>

--- a/assets/app/vue/views/MailView/index.vue
+++ b/assets/app/vue/views/MailView/index.vue
@@ -48,6 +48,7 @@ export default {
 
     <!-- FTUE Initial Welcome Tour Card -->
     <div
+      data-tour-card
       class="header-card"
       v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.INITIAL"
       role="dialog"
@@ -70,6 +71,7 @@ export default {
 
     <!-- FTUE Final Tour Card -->
     <tour-card
+      data-tour-card
       v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL"
       variant="header"
       :text="t('views.mail.ftue.step5Text')"

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
@@ -34,7 +34,7 @@ const maxCustomDomains = window._page?.maxCustomDomains;
 
 const nextStepText = computed(() => {
   return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.yourAccount') });
-})
+});
 
 const handleStepChange = (step: STEP) => {
   currentStep.value = step;

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
@@ -32,6 +32,10 @@ const customDomainFormRef = ref(null);
 const verificationCriticalErrors = ref<string[]>([]);
 const maxCustomDomains = window._page?.maxCustomDomains;
 
+const nextStepText = computed(() => {
+  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.yourAccount') });
+})
+
 const handleStepChange = (step: STEP) => {
   currentStep.value = step;
 };
@@ -85,7 +89,8 @@ export default {
     >
       <tour-card
         v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.CUSTOM_DOMAINS"
-        :text="t('views.mail.ftue.step2Text')"
+        :text="t('views.mail.ftue.step4Text')"
+        :subtitle="nextStepText"
         :current-step="tour.currentStep.value"
         :total-steps="FTUE_STEPS.FINAL"
         show-back

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
@@ -88,6 +88,7 @@ export default {
       :subtitle="customDomainsDescription"
     >
       <tour-card
+        data-tour-card
         v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.CUSTOM_DOMAINS"
         :text="t('views.mail.ftue.step4Text')"
         :subtitle="nextStepText"

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
@@ -3,21 +3,17 @@ import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { PhGlobe, PhCheckCircle, PhX } from '@phosphor-icons/vue';
 import { BaseBadge, BaseBadgeTypes, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
-import { useTour, FTUE_STEPS } from '@/composables/useTour';
-
 // Types
 import { CustomDomain, DOMAIN_STATUS, STEP } from './types';
 
 // Shared components
 import CardContainer from '@/components/CardContainer.vue';
-import TourCard from '@/components/TourCard.vue';
 
 // Local components
 import CustomDomainForm from './components/CustomDomainForm.vue';
 import ActionsMenu from './components/ActionsMenu.vue';
 
 const { t } = useI18n();
-const tour = useTour();
 
 const currentStep = ref<STEP>(STEP.INITIAL);
 const customDomains = ref<CustomDomain[]>(window._page?.customDomains || []);
@@ -31,10 +27,6 @@ const errorMessage = ref<string>(null);
 const customDomainFormRef = ref(null);
 const verificationCriticalErrors = ref<string[]>([]);
 const maxCustomDomains = window._page?.maxCustomDomains;
-
-const nextStepText = computed(() => {
-  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.yourAccount') });
-});
 
 const handleStepChange = (step: STEP) => {
   currentStep.value = step;
@@ -87,18 +79,7 @@ export default {
       :title="t('views.mail.sections.customDomains.customDomains')"
       :subtitle="customDomainsDescription"
     >
-      <tour-card
-        data-tour-card
-        v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.CUSTOM_DOMAINS"
-        :text="t('views.mail.ftue.step4Text')"
-        :subtitle="nextStepText"
-        :current-step="tour.currentStep.value"
-        :total-steps="FTUE_STEPS.FINAL"
-        show-back
-        @next="tour.next()"
-        @back="tour.back()"
-        @close="tour.skip()"
-      />
+      <div id="tour-target-custom-domains" />
 
       <strong>{{ t('views.mail.sections.customDomains.domainsAdded', { domainCount: customDomains.length, domainLimit: maxCustomDomains }) }}</strong>
 

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/types.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/types.ts
@@ -2,13 +2,13 @@ export enum DOMAIN_STATUS {
   VERIFIED = 'verified',
   PENDING = 'pending',
   FAILED = 'failed',
-}
+};
 
 export enum STEP {
   INITIAL = 'initial',
   ADD = 'add',
   VERIFY_DOMAIN = 'verify',
-}
+};
 
 export type DNSRecord = {
   type: string;

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
@@ -49,7 +49,7 @@ const thunderbirdClientImage = new URL('@/assets/png/thundermail-dashboard-clien
 
 const nextStepText = computed(() => {
   return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.appPassword') });
-})
+});
 </script>
 
 <script lang="ts">

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
@@ -69,14 +69,13 @@ export default {
   >
     <div class="get-started-with-thundermail-content">
       <tour-card
+        data-tour-card
         v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.CONNECT_EMAIL"
         :text="t('views.mail.ftue.step1Text')"
         :subtitle="nextStepText"
         :current-step="tour.currentStep.value"
         :total-steps="FTUE_STEPS.FINAL"
-        show-back
         @next="tour.next()"
-        @back="tour.back()"
         @close="tour.skip()"
       />
 

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
@@ -4,6 +4,8 @@ import { useI18n } from 'vue-i18n';
 import { PhDesktop, PhDeviceMobile, PhGlobe } from '@phosphor-icons/vue';
 
 import CardContainer from '@/components/CardContainer.vue';
+import TourCard from '@/components/TourCard.vue';
+import { useTour, FTUE_STEPS } from '@/composables/useTour';
 import { SETUP_TABS, SegmentedControlTab } from '../types';
 import SegmentedControlSlider from './SegmentedControlSlider.vue';
 import GetStartedWithThundermailDesktop from './GetStartedWithThundermailDesktop.vue';
@@ -21,6 +23,7 @@ defineEmits<{
 }>();
 
 const { t } = useI18n();
+const tour = useTour();
 const selectedTab = ref<string>(SETUP_TABS.DESKTOP);
 
 const tabs = computed<SegmentedControlTab[]>(() => [
@@ -43,6 +46,10 @@ const tabs = computed<SegmentedControlTab[]>(() => [
 
 // https://vite.dev/guide/assets.html#new-url-url-import-meta-url
 const thunderbirdClientImage = new URL('@/assets/png/thundermail-dashboard-client.png', import.meta.url).href;
+
+const nextStepText = computed(() => {
+  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.appPassword') });
+})
 </script>
 
 <script lang="ts">
@@ -53,6 +60,7 @@ export default {
 
 <template>
   <card-container
+    id="connect-email"
     :title="t('views.mail.sections.dashboard.getStartedWithThundermail.title')"
     :subtitle="t('views.mail.sections.dashboard.getStartedWithThundermail.description')"
     is-pinnable
@@ -60,6 +68,18 @@ export default {
     @toggle-pinned="$emit('togglePinned')"
   >
     <div class="get-started-with-thundermail-content">
+      <tour-card
+        v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.CONNECT_EMAIL"
+        :text="t('views.mail.ftue.step1Text')"
+        :subtitle="nextStepText"
+        :current-step="tour.currentStep.value"
+        :total-steps="FTUE_STEPS.FINAL"
+        show-back
+        @next="tour.next()"
+        @back="tour.back()"
+        @close="tour.skip()"
+      />
+
       <segmented-control-slider
         v-model="selectedTab"
         :tabs="tabs"

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
@@ -4,8 +4,6 @@ import { useI18n } from 'vue-i18n';
 import { PhDesktop, PhDeviceMobile, PhGlobe } from '@phosphor-icons/vue';
 
 import CardContainer from '@/components/CardContainer.vue';
-import TourCard from '@/components/TourCard.vue';
-import { useTour, FTUE_STEPS } from '@/composables/useTour';
 import { SETUP_TABS, SegmentedControlTab } from '../types';
 import SegmentedControlSlider from './SegmentedControlSlider.vue';
 import GetStartedWithThundermailDesktop from './GetStartedWithThundermailDesktop.vue';
@@ -23,7 +21,6 @@ defineEmits<{
 }>();
 
 const { t } = useI18n();
-const tour = useTour();
 const selectedTab = ref<string>(SETUP_TABS.DESKTOP);
 
 const tabs = computed<SegmentedControlTab[]>(() => [
@@ -46,10 +43,6 @@ const tabs = computed<SegmentedControlTab[]>(() => [
 
 // https://vite.dev/guide/assets.html#new-url-url-import-meta-url
 const thunderbirdClientImage = new URL('@/assets/png/thundermail-dashboard-client.png', import.meta.url).href;
-
-const nextStepText = computed(() => {
-  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.appPassword') });
-});
 </script>
 
 <script lang="ts">
@@ -67,17 +60,8 @@ export default {
     :is-pinned="isPinned"
     @toggle-pinned="$emit('togglePinned')"
   >
+    <div id="tour-target-connect-email" />
     <div class="get-started-with-thundermail-content">
-      <tour-card
-        data-tour-card
-        v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.CONNECT_EMAIL"
-        :text="t('views.mail.ftue.step1Text')"
-        :subtitle="nextStepText"
-        :current-step="tour.currentStep.value"
-        :total-steps="FTUE_STEPS.FINAL"
-        @next="tour.next()"
-        @close="tour.skip()"
-      />
 
       <segmented-control-slider
         v-model="selectedTab"

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -35,7 +35,7 @@ const userEmail = computed(() => window._page?.userEmail);
 
 const nextStepText = computed(() => {
   return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.emailAliases') });
-})
+});
 
 const resetPasswordForm = () => {
   errorMessage.value = '';

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -13,8 +13,11 @@ import {
 } from '@thunderbirdops/services-ui';
 import { PhX, PhInfo } from '@phosphor-icons/vue';
 import { APP_PASSWORD_SUPPORT_URL } from '@/defines';
+import { useTour, FTUE_STEPS } from '@/composables/useTour';
+import TourCard from '@/components/TourCard.vue';
 
 const { t } = useI18n();
+const tour = useTour();
 
 const props = defineProps<{
   appPasswords?: string[];
@@ -29,6 +32,10 @@ const successMessage = ref<string>(null);
 const isSubmitting = ref(false);
 
 const userEmail = computed(() => window._page?.userEmail);
+
+const nextStepText = computed(() => {
+  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.emailAliases') });
+})
 
 const resetPasswordForm = () => {
   errorMessage.value = '';
@@ -91,6 +98,18 @@ const onCancelSetPassword = () => {
 
 <template>
   <div id="app-password-container" class="app-password-side-container">
+    <tour-card
+      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.APP_PASSWORDS"
+      :text="t('views.mail.ftue.step2Text')"
+      :current-step="tour.currentStep.value"
+      :total-steps="FTUE_STEPS.FINAL"
+      :subtitle="nextStepText"
+      show-back
+      @next="tour.next()"
+      @back="tour.back()"
+      @close="tour.skip()"
+    />
+
     <div class="app-password-set-indicator-container">
       <strong>{{ t('views.mail.sections.emailSettings.appPassword') }}:</strong>
       <template v-if="accountHasAppPasswords">

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -99,6 +99,7 @@ const onCancelSetPassword = () => {
 <template>
   <div id="app-password-container" class="app-password-side-container">
     <tour-card
+      data-tour-card
       v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.APP_PASSWORDS"
       :text="t('views.mail.ftue.step2Text')"
       :current-step="tour.currentStep.value"

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -13,11 +13,8 @@ import {
 } from '@thunderbirdops/services-ui';
 import { PhX, PhInfo } from '@phosphor-icons/vue';
 import { APP_PASSWORD_SUPPORT_URL } from '@/defines';
-import { useTour, FTUE_STEPS } from '@/composables/useTour';
-import TourCard from '@/components/TourCard.vue';
 
 const { t } = useI18n();
-const tour = useTour();
 
 const props = defineProps<{
   appPasswords?: string[];
@@ -32,10 +29,6 @@ const successMessage = ref<string>(null);
 const isSubmitting = ref(false);
 
 const userEmail = computed(() => window._page?.userEmail);
-
-const nextStepText = computed(() => {
-  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.emailAliases') });
-});
 
 const resetPasswordForm = () => {
   errorMessage.value = '';
@@ -98,18 +91,7 @@ const onCancelSetPassword = () => {
 
 <template>
   <div id="app-password-container" class="app-password-side-container">
-    <tour-card
-      data-tour-card
-      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.APP_PASSWORDS"
-      :text="t('views.mail.ftue.step2Text')"
-      :current-step="tour.currentStep.value"
-      :total-steps="FTUE_STEPS.FINAL"
-      :subtitle="nextStepText"
-      show-back
-      @next="tour.next()"
-      @back="tour.back()"
-      @close="tour.skip()"
-    />
+    <div id="tour-target-app-passwords" />
 
     <div class="app-password-set-indicator-container">
       <strong>{{ t('views.mail.sections.emailSettings.appPassword') }}:</strong>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -78,6 +78,7 @@ const onDeleteAliasError = (error: string) => {
 <template>
   <div class="email-aliases-content">
     <tour-card
+      data-tour-card
       v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.EMAIL_ALIASES"
       :text="t('views.mail.ftue.step3Text')"
       :current-step="tour.currentStep.value"

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -3,8 +3,6 @@ import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { NoticeBar, NoticeBarTypes, BaseBadge, BaseBadgeTypes } from '@thunderbirdops/services-ui';
 import { PhX } from '@phosphor-icons/vue';
-import TourCard from '@/components/TourCard.vue';
-import { useTour, FTUE_STEPS } from '@/composables/useTour';
 
 // Local components
 import EmailAliasActionsMenu from './EmailAliasActionsMenu.vue';
@@ -18,7 +16,6 @@ import { EmailAlias } from '../types';
 import { addEmailAlias } from '../api';
 
 const { t } = useI18n();
-const tour = useTour();
 
 const aliasLimit = window._page?.maxEmailAliases;
 
@@ -30,10 +27,6 @@ const emailAliases = ref<EmailAlias[]>(window._page?.emailAddresses?.map((email,
 })) || []);
 const isAddingEmailAlias = ref(false);
 const errorMessage = ref<string>(null);
-
-const nextStepText = computed(() => {
-  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.customDomains') });
-});
 
 const allDomainOptions = computed(() => {
   // Allowed domains include any verified custom domains
@@ -77,18 +70,7 @@ const onDeleteAliasError = (error: string) => {
 
 <template>
   <div class="email-aliases-content">
-    <tour-card
-      data-tour-card
-      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.EMAIL_ALIASES"
-      :text="t('views.mail.ftue.step3Text')"
-      :current-step="tour.currentStep.value"
-      :total-steps="FTUE_STEPS.FINAL"
-      :subtitle="nextStepText"
-      show-back
-      @next="tour.next()"
-      @back="tour.back()"
-      @close="tour.skip()"
-    />
+    <div id="tour-target-email-aliases" />
 
     <div id="email-aliases" class="header-content">
       <p>{{ t('views.mail.sections.emailSettings.emailAliasesDescription') }}</p>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -3,6 +3,8 @@ import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { NoticeBar, NoticeBarTypes, BaseBadge, BaseBadgeTypes } from '@thunderbirdops/services-ui';
 import { PhX } from '@phosphor-icons/vue';
+import TourCard from '@/components/TourCard.vue';
+import { useTour, FTUE_STEPS } from '@/composables/useTour';
 
 // Local components
 import EmailAliasActionsMenu from './EmailAliasActionsMenu.vue';
@@ -16,6 +18,7 @@ import { EmailAlias } from '../types';
 import { addEmailAlias } from '../api';
 
 const { t } = useI18n();
+const tour = useTour();
 
 const aliasLimit = window._page?.maxEmailAliases;
 
@@ -27,6 +30,10 @@ const emailAliases = ref<EmailAlias[]>(window._page?.emailAddresses?.map((email,
 })) || []);
 const isAddingEmailAlias = ref(false);
 const errorMessage = ref<string>(null);
+
+const nextStepText = computed(() => {
+  return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.customDomains') });
+})
 
 const allDomainOptions = computed(() => {
   // Allowed domains include any verified custom domains
@@ -70,7 +77,19 @@ const onDeleteAliasError = (error: string) => {
 
 <template>
   <div class="email-aliases-content">
-    <div class="header-content">
+    <tour-card
+      v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.EMAIL_ALIASES"
+      :text="t('views.mail.ftue.step3Text')"
+      :current-step="tour.currentStep.value"
+      :total-steps="FTUE_STEPS.FINAL"
+      :subtitle="nextStepText"
+      show-back
+      @next="tour.next()"
+      @back="tour.back()"
+      @close="tour.skip()"
+    />
+
+    <div id="email-aliases" class="header-content">
       <p>{{ t('views.mail.sections.emailSettings.emailAliasesDescription') }}</p>
       <p class="email-aliases-count-text">
         {{ t('views.mail.sections.emailSettings.emailAliasesDescriptionTwo', {

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -33,7 +33,7 @@ const errorMessage = ref<string>(null);
 
 const nextStepText = computed(() => {
   return t('views.mail.ftue.nextStep', { step: t('views.mail.ftue.customDomains') });
-})
+});
 
 const allDomainOptions = computed(() => {
   // Allowed domains include any verified custom domains

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
@@ -29,9 +29,12 @@ export default {
 
 <template>
   <section id="email-settings">
-    <card-container :title="t('views.mail.sections.emailSettings.emailSettings')">
+    <card-container
+      id="email-settings"
+      :title="t('views.mail.sections.emailSettings.emailSettings')"
+    >
       <tour-card
-        v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.FINAL"
+        v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.APP_PASSWORDS"
         :text="t('views.mail.ftue.step3Text')"
         :next-label="t('views.mail.ftue.done')"
         :current-step="tour.currentStep.value"
@@ -74,12 +77,17 @@ export default {
 }
 
 .email-aliases-details-summary {
+  position: relative;
   margin-block-end: 2.25rem;
 }
 
 @media (min-width: 768px) {
   .email-settings-content {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .email-aliases-details-summary :deep(.tour-card) {
+    right: -1.5rem;
   }
 }
 </style>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
@@ -2,12 +2,10 @@
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { PhSliders } from '@phosphor-icons/vue';
-import { useTour, FTUE_STEPS } from '@/composables/useTour';
 
 // Shared components
 import CardContainer from '@/components/CardContainer.vue';
 import DetailsSummary from '@/components/DetailsSummary.vue';
-import TourCard from '@/components/TourCard.vue';
 
 // Local components
 import AppPasswordSide from './components/AppPasswordSide.vue';
@@ -16,7 +14,6 @@ import EmailAliases from './components/EmailAliases.vue';
 import ViewServerSettings from './components/ViewServerSettings.vue';
 
 const { t } = useI18n();
-const tour = useTour();
 
 const appPasswords = ref<string[]>(window._page?.appPasswords || []);
 </script>
@@ -33,18 +30,6 @@ export default {
       id="email-settings"
       :title="t('views.mail.sections.emailSettings.emailSettings')"
     >
-      <tour-card
-        v-if="tour.showFTUE.value && tour.currentStep.value === FTUE_STEPS.APP_PASSWORDS"
-        :text="t('views.mail.ftue.step3Text')"
-        :next-label="t('views.mail.ftue.done')"
-        :current-step="tour.currentStep.value"
-        :total-steps="FTUE_STEPS.FINAL"
-        show-back
-        @next="tour.next()"
-        @back="tour.back()"
-        @close="tour.skip()"
-      />
-
       <div class="email-settings-content">
         <user-info-side/>
         <app-password-side :app-passwords="appPasswords" />
@@ -85,7 +70,9 @@ export default {
   .email-settings-content {
     grid-template-columns: 1fr 1fr;
   }
+}
 
+@media (min-width: 1280px) {
   .email-aliases-details-summary :deep(.tour-card) {
     right: -1.5rem;
   }

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
@@ -26,10 +26,7 @@ export default {
 
 <template>
   <section id="email-settings">
-    <card-container
-      id="email-settings"
-      :title="t('views.mail.sections.emailSettings.emailSettings')"
-    >
+    <card-container :title="t('views.mail.sections.emailSettings.emailSettings')">
       <div class="email-settings-content">
         <user-info-side/>
         <app-password-side :app-passwords="appPasswords" />


### PR DESCRIPTION
## Description of changes

- Updating the tour cards with the new copy, positioning and small UI tweaks (box-shadow, spacing inside the card)
- Added better support for screen readers and pressing ESC now closes the tour

Zeplin :https://zpl.io/romO4k3

Note that the initial and final cards are anchored to the header / user avatar where as the rest of the cards are positioned relative to their respective sections.

## Screenshots / Video

https://github.com/user-attachments/assets/1b1273ff-a67c-4d8a-9102-2e6042d60ed2

## How to test

The show / hide tour guide is controlled by a local storage key called `tb_accounts_ftue_completed` so make sure that you don't have that as `true` if you want to see it!

## Related issues

Related https://github.com/thunderbird/thunderbird-accounts/issues/658