### PR TITLE
Hide connect now button in a localstorage flag

### DIFF
--- a/assets/app/vue/defines.ts
+++ b/assets/app/vue/defines.ts
@@ -5,4 +5,4 @@ export const WHAT_IS_JMAP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/4610
 export const WHAT_IS_SMTP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/46106891841043-What-is-SMTP';
 export const DOWNLOAD_THUNDERBIRD_DESKTOP_URL = 'https://www.thunderbird.net/thunderbird/all/';
 export const DOWNLOAD_THUNDERBIRD_MOBILE_URL = 'https://play.google.com/store/apps/details?id=net.thunderbird.android';
-export const STATUS_PAGE_URL = 'https://status.tb.pro/'
+export const STATUS_PAGE_URL = 'https://status.tb.pro/';

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -7,9 +7,10 @@ import { DOWNLOAD_THUNDERBIRD_DESKTOP_URL } from '@/defines';
 
 const { t } = useI18n();
 
-function onConnectNow() {
-  // TODO: Implement connect action, custom protocol mapping TBD
-}
+const showConnectNow = window.localStorage.getItem('feature.show-connect-now') === 'true';
+
+// TODO: Update this when the full URL is ready
+const tbDesktopCustomProtocolUrl = 'net.thunderbird://replay';
 </script>
 
 <script lang="ts">
@@ -21,6 +22,7 @@ export default {
 <template>
   <div class="action-cards">
     <action-card
+      v-if="showConnectNow"
       :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectTitle')"
       :description="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectDescription')"
     >
@@ -28,7 +30,11 @@ export default {
         <ph-arrow-square-out :size="20" />
       </template>
       <template #action>
-        <primary-button size="small" @click="onConnectNow">
+        <primary-button
+          size="small"
+          :href="tbDesktopCustomProtocolUrl"
+          class="button-link"
+        >
           {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButton') }}
         </primary-button>
       </template>
@@ -44,11 +50,11 @@ export default {
       <template #action>
         <primary-button
           size="small"
-          variant="outline"
+          :variant="showConnectNow ? 'outline' : 'filled'"
           :href="DOWNLOAD_THUNDERBIRD_DESKTOP_URL"
           target="_blank"
           rel="noopener noreferrer"
-          class="download-button"
+          class="button-link"
         >
           {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.downloadButton') }}
         </primary-button>
@@ -64,7 +70,7 @@ export default {
   gap: 0.625rem;
 }
 
-.download-button {
+.button-link {
   height: 2rem;
 }
 </style>


### PR DESCRIPTION
## Description of changes

This is a very temporary piece of code while we don't have the custom protocol mapping setup so that we can deploy Accounts without confusing users / shipping unresponsive buttons.

When `feature.show-connect-now` is `true` in localStorage, it shows the "Connect now" button. Otherwise, it hides the card and makes the "Download" button be primary.

## Screenshots

- `feature.show-connect-now` is `true`
<img width="1763" height="468" alt="image" src="https://github.com/user-attachments/assets/4defe3c0-e404-42e2-adaa-4a569a177cb1" />

- `feature.show-connect-now` is not there
<img width="1757" height="480" alt="image" src="https://github.com/user-attachments/assets/ed5744c9-048f-49bd-8a9a-5fd51f6b19ac" />



## Related issues
Related https://github.com/thunderbird/thunderbird-accounts/issues/708