### PR TITLE
Add UTM tags to download buttons

### DIFF
--- a/assets/app/vue/defines.ts
+++ b/assets/app/vue/defines.ts
@@ -3,6 +3,6 @@ export const OTHER_APPS_SUPPORT_URL = 'https://support.tb.pro/hc/en-us/articles/
 export const WHAT_IS_IMAP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/46108465880467-What-is-IMAP';
 export const WHAT_IS_JMAP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/46109214513939-What-is-JMAP';
 export const WHAT_IS_SMTP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/46106891841043-What-is-SMTP';
-export const DOWNLOAD_THUNDERBIRD_DESKTOP_URL = 'https://www.thunderbird.net/thunderbird/all/';
-export const DOWNLOAD_THUNDERBIRD_MOBILE_URL = 'https://play.google.com/store/apps/details?id=net.thunderbird.android';
+export const DOWNLOAD_THUNDERBIRD_DESKTOP_URL = 'https://www.thunderbird.net/thunderbird/all?utm_campaign=main&utm_medium=tb_pro&utm_source=thundermail_dashboard&utm_content=desktop_download';
+export const DOWNLOAD_THUNDERBIRD_MOBILE_URL = 'https://play.google.com/store/apps/details?id=net.thunderbird.android&referrer=utm_campaign%3Dmain%26utm_medium%3Dtb_pro%26utm_source%3Dthundermail_dashboard%26utm_content%3Dmobile_download';
 export const STATUS_PAGE_URL = 'https://status.tb.pro/';


### PR DESCRIPTION
## Description of changes

Added UTM tags to the download button in the sections below:


Desktop

<img width="1004" height="366" alt="image" src="https://github.com/user-attachments/assets/2dbe42db-4cad-4c7a-977e-2e37ddaced60" />


Mobile

<img width="1001" height="511" alt="image" src="https://github.com/user-attachments/assets/447f3663-c966-4259-8a2e-a5695cfde320" />

## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/698
