### PR TITLE
feat(ci): migrate deploy workflows to GitHub Actions OIDC (#204)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   detect-changes:
@@ -75,8 +76,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -201,8 +201,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy-production:
@@ -36,8 +37,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
Part of thunderbird/platform-infrastructure#204.
Closes thunderbird/thunderbird-accounts#728.

## Summary

Migrates `merge.yml` and `release.yml` from long-lived IAM access keys to OIDC role assumption via `AWS_ROLE_ARN`.

**What changed:** Added `id-token: write` to top-level `permissions` in both files. Replaced `aws-access-key-id` / `aws-secret-access-key` with `role-to-assume: ${{ secrets.AWS_ROLE_ARN }}` in all three `configure-aws-credentials` steps (two in `merge.yml` — `accounts-deploy` and `keycloak-deploy`; one in `release.yml`).

**OIDC roles provisioned in platform-infrastructure:**
- `staging` → `arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-thunderbird-accounts-staging`
- `production` → `arn:aws:iam::768512802988:role/thunderbird-legacy-github-oidc-prod-thunderbird-accounts-prod`

`AWS_ROLE_ARN` is already set on both GitHub Environments.

## Test plan

- [ ] Merge triggers `merge.yml` — confirm `accounts-deploy` and `keycloak-deploy` jobs both authenticate via `AssumeRoleWithWebIdentity`
- [ ] Publish a release — confirm `release.yml` authenticates via OIDC
- [ ] Soak: ≥3 successful production deploys across ≥7 calendar days, zero `AccessDenied` on old IAM user
- [ ] After soak: delete `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from both environments; remove `AwsAutomationUser` from thunderbird-accounts Pulumi stack (tracked in platform-infrastructure#204)

## Test evidence

### merge.yml (deploy-stage)

> To be filled in after merge — paste the run URL and confirm `AssumeRoleWithWebIdentity` for each AWS credential step.

```
Run URL:
accounts-deploy:  ✅ / ❌
keycloak-deploy:  ✅ / ❌
```

### release.yml (deploy-production)

> To be filled in after first production release using this PR.

```
Run URL:
deploy-production: ✅ / ❌
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)