### PR TITLE
Email settings UI updates

### DIFF
--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliasForm.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliasForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, useTemplateRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { TextInput, SelectInput, PrimaryButton } from '@thunderbirdops/services-ui';
+import { TextInput, SelectInput, PrimaryButton, LinkButton } from '@thunderbirdops/services-ui';
 
 // Types
 import { EMAIL_ALIAS_STEP } from '../types';
@@ -104,9 +104,14 @@ watch(selectedDomain, () => {
         </select-input>
       </div>
 
-      <primary-button @click="onSubmit">
-        {{ t('views.mail.sections.emailSettings.submit') }}
-      </primary-button>
+      <div class="email-alias-form-buttons">
+        <primary-button @click="onSubmit">
+          {{ t('views.mail.sections.emailSettings.submit') }}
+        </primary-button>
+        <link-button @click="step = EMAIL_ALIAS_STEP.INITIAL">
+          {{ t('views.mail.sections.emailSettings.cancel') }}
+        </link-button>
+      </div>
     </form>
   </template>
 </template>
@@ -138,5 +143,11 @@ watch(selectedDomain, () => {
 
 .notice-bar-error {
   margin-block-end: 1.5rem;
+}
+
+.email-alias-form-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 </style>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -103,6 +103,7 @@ const onDeleteAliasError = (error: string) => {
         </template>
 
         <email-alias-actions-menu
+          v-if="!alias.isSubscription"
           :alias="alias"
           @delete-alias-success="onDeleteAliasSuccess"
           @delete-alias-error="onDeleteAliasError"

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -130,9 +130,14 @@ const onDeleteAliasError = (error: string) => {
 </template>
 
 <style scoped>
+#email-aliases {
+  padding-inline: 0.5rem;
+}
+
 .email-aliases-content {
   line-height: 1.32;
   color: var(--colour-ti-secondary);
+  padding-block-start: 0.25rem;
 
   .notice-bar-warning {
     margin-block-end: 1rem;
@@ -142,7 +147,7 @@ const onDeleteAliasError = (error: string) => {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-block-end: 1rem;
+    margin-block-end: 1.25rem;
   }
 
   .email-aliases-count-text {
@@ -153,21 +158,20 @@ const onDeleteAliasError = (error: string) => {
   }
 
   .aliases-list {
-    border-block-start: 1px solid var(--colour-neutral-border);
-    border-block-end: 1px solid var(--colour-neutral-border);
     margin-block-end: 1.5rem;
 
     .alias-item {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      padding: 1rem 0.5rem;
+      padding: 0.5rem;
       gap: 0.5rem;
       height: 100%;
       min-height: 60px;
+      background-color: var(--colour-neutral-lower);
 
       & + .alias-item {
-        border-block-start: 1px solid var(--colour-neutral-border);
+        background-color: transparent;
       }
 
       p {

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/UserInfoSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/UserInfoSide.vue
@@ -6,7 +6,6 @@ import {
   NoticeBarTypes,
   PrimaryButton,
   TextInput,
-  VisualDivider,
   LinkButton,
 } from '@thunderbirdops/services-ui';
 
@@ -102,10 +101,6 @@ const onCancelSetDisplayName = () => {
         <link-button @click="showDisplayNameForm = true">{{ t('views.mail.sections.emailSettings.change') }}</link-button>
       </template>
     </div>
-
-    <visual-divider />
-
-    
   </div>
 </template>
 


### PR DESCRIPTION
## Description of changes

- Minor UI updates
- Only functional component added was a `Cancel` button in the Email Aliases form step

## Screenshots

### Before

Email settings section (before)
<img width="1004" height="822" alt="image" src="https://github.com/user-attachments/assets/fe65001e-94c3-4236-aa76-73d0de930561" />

### After

Email settings section (after)
<img width="1008" height="687" alt="image" src="https://github.com/user-attachments/assets/40cb3dfc-f0f2-4d9a-a7b1-3a927b6cba8f" />

### Before

<img width="950" height="472" alt="image" src="https://github.com/user-attachments/assets/21f3f43c-fa76-4040-955f-6d2876c23930" />


### After

Form open (after clicking "Add email alias")
<img width="946" height="478" alt="image" src="https://github.com/user-attachments/assets/d33a2b25-4a21-4e0b-a4e8-4e84588ae075" />



## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/717