### PR TITLE
Clean up contact support E2E test

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -357,7 +357,6 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
-      ACCTS_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-tests-desktop.yaml
+++ b/.github/workflows/nightly-tests-desktop.yaml
@@ -24,7 +24,6 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
-      ACCTS_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/test/e2e/.env.dev.example
+++ b/test/e2e/.env.dev.example
@@ -19,10 +19,9 @@ SMTP_TLS="None"
 # Sign-in credentials
 ACCTS_OIDC_EMAIL=admin@example.org
 ACCTS_OIDC_PWORD=admin
-ACCTS_RECOVERY_EMAIL=admin@example.com
 
 # Thundermail associated with the above account
-PRIMARY_THUNDERMAIL_EMAIL=
+PRIMARY_THUNDERMAIL_EMAIL=admin@example.com
 
 # Custom OIDC paths since this runs from outside the Docker context
 OIDC_URL_AUTH=http://localhost:8999/realms/tbpro/protocol/openid-connect/auth

--- a/test/e2e/.env.prod.example
+++ b/test/e2e/.env.prod.example
@@ -16,7 +16,6 @@ SMTP_PORT=465
 # Sign-in credentials
 ACCTS_OIDC_EMAIL=
 ACCTS_OIDC_PWORD=
-ACCTS_RECOVERY_EMAIL=
 
 # Thundermail associated with the above account
 PRIMARY_THUNDERMAIL_EMAIL=

--- a/test/e2e/.env.stage.example
+++ b/test/e2e/.env.stage.example
@@ -16,7 +16,6 @@ SMTP_PORT=465
 # Sign-in credentials
 ACCTS_OIDC_EMAIL=
 ACCTS_OIDC_PWORD=
-ACCTS_RECOVERY_EMAIL=
 
 # Thundermail associated with the above account
 PRIMARY_THUNDERMAIL_EMAIL=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -52,7 +52,6 @@ Then edit your local `.env` file and provide the following values:
 ACCTS_HUB_URL=<URL-for-TB-Accts-Hub>
 ACCTS_OIDC_EMAIL=<existing-tbpro-user-email>
 ACCTS_OIDC_PWORD=<exisiting-tbro-password>
-ACCTS_RECOVERY_EMAIL=<tbpro-recovery-email>
 PRIMARY_THUNDERMAIL_EMAIL=<primary-thundermail-email-address>
 ```
 
@@ -114,7 +113,6 @@ Then edit your local `.env` file and provide the following values:
 ACCTS_HUB_URL=<URL-for-TB-Accts-Hub>
 ACCTS_OIDC_EMAIL=<existing-tbpro-user-email>
 ACCTS_OIDC_PWORD=<exisiting-tbro-password>
-ACCTS_RECOVERY_EMAIL=<tbpro-recovery-email>
 PRIMARY_THUNDERMAIL_EMAIL=<primary-thundermail-email-address>
 ```
 
@@ -148,7 +146,6 @@ Once you have credentials for an existing TB Accounts test account, edit your lo
 ACCTS_HUB_URL=<URL-for-TB-Accts-Hub>
 ACCTS_OIDC_EMAIL=<existing-tbpro-user-email>
 ACCTS_OIDC_PWORD=<exisiting-tbro-password>
-ACCTS_RECOVERY_EMAIL=<tbpro-recovery-email>
 PRIMARY_THUNDERMAIL_EMAIL=<primary-thundermail-email-address>
 ```
 

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -11,7 +11,6 @@ export const TB_PRO_WAIT_LIST_URL = String(process.env.TB_PRO_WAIT_LIST_URL);
 // sign-in credentials and corresponding info
 export const ACCTS_OIDC_EMAIL = String(process.env.ACCTS_OIDC_EMAIL);
 export const ACCTS_OIDC_PWORD = String(process.env.ACCTS_OIDC_PWORD);
-export const ACCTS_RECOVERY_EMAIL = String(process.env.ACCTS_RECOVERY_EMAIL);
 export const PRIMARY_THUNDERMAIL_EMAIL = String(process.env.PRIMARY_THUNDERMAIL_EMAIL);
 
 // playwright test tags

--- a/test/e2e/tests/contact.spec.ts
+++ b/test/e2e/tests/contact.spec.ts
@@ -7,7 +7,7 @@ import {
   PLAYWRIGHT_TAG_E2E_SUITE,
   PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY,
   ACCTS_OIDC_EMAIL,
-  ACCTS_RECOVERY_EMAIL,
+  PRIMARY_THUNDERMAIL_EMAIL,
   TIMEOUT_2_SECONDS,
   TIMEOUT_5_SECONDS,
   TIMEOUT_30_SECONDS,
@@ -146,7 +146,7 @@ test.describe('contact support form', {
     await contactPage.verifyFormDisplayed();
 
     // since we're signed in, email field should be pre-filled with the user's recovery email
-    await expect(contactPage.emailInput).toHaveValue(ACCTS_RECOVERY_EMAIL);
+    await expect(contactPage.emailInput).toHaveValue(PRIMARY_THUNDERMAIL_EMAIL);
   });
   
   test('contact form displayed correctly when not signed in', async ({ page }) => {


### PR DESCRIPTION
Clean up the contact support E2E test:

- The contact form pre-populates the email address with the primary Thundermail email (test was using recovery email)
- Recovery email .env var is no longer needed anywhere in these E2E tests so remove all references to it and the related GHA secret
- After this lands remove the `E2E_ACCTS_RECOVERY_EMAIL` GitHub actions secret from the repo as it won't be used anymore

Fixes #737.

BrowserStack [link here](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Tests+Firefox+Desktop/86?tab=sessions&testListView=spec) running the updated E2E tests on stage (all tests passed).