### PR TITLE
Update the keycloak info template to show verify_email specific content.

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/views/InfoView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/InfoView/index.vue
@@ -1,11 +1,16 @@
 <script setup>
 import MessageBar from '@kc/vue/components/MessageBar.vue';
+import { PrimaryButton } from '@thunderbirdops/services-ui';
+import { computed, onMounted } from 'vue';
 
 const message = window._page.message;
 const messageHeader = window._page.currentView?.messageHeader;
 const actionUrl = window._page.currentView?.actionUrl;
 const actionText = window._page.currentView?.actionText;
-const requiredActions = window._page.currentView?.requiredActions ?? [];
+const requiredActions = window._page.currentView?.requiredActions ?? {};
+
+const isSingleAction = computed(() => Object.keys(requiredActions).length === 1);
+const isVerifyEmailAction = computed(() => isSingleAction.value && Object.keys(requiredActions)[0] === 'VERIFY_EMAIL');
 </script>
 
 <script>
@@ -15,21 +20,30 @@ export default {
 </script>
 
 <template>
-  <message-bar />
-  <h2>
-    <template v-if="messageHeader">
-      {{ messageHeader }}
+  <header>
+    <h1 class="title">
+      <template v-if="isVerifyEmailAction">
+        {{ $t('infoVerifyEmailTitle') }}
+      </template>
+      <template v-else-if="messageHeader">
+        {{ messageHeader }}
+      </template>
+      <template v-else>
+        {{ message?.summary }}
+      </template>
+    </h1>
+    <p class="text" v-if="isVerifyEmailAction">{{ $t('infoVerifyEmailText') }}</p>
+    <message-bar v-if="messageHeader && messageHeader !== message?.summary" />
+  </header>
+  <main>
+    <ul class="required-actions" v-if="!isSingleAction">
+      <li v-for="action in requiredActions" v-bind:key="action">{{ action }}</li>
+    </ul>
+    <template v-if="actionUrl">
+      <primary-button class="perform-action" :href="actionUrl" data-testid="action-url">{{ actionText
+        }}</primary-button>
     </template>
-    <template v-else>
-      {{ message?.summary }}
-    </template>
-  </h2>
-  <ul class="required-actions">
-    <li v-for="action in requiredActions" v-bind:key="action">{{ action }}</li>
-  </ul>
-  <template v-if="actionUrl">
-    <a :href="actionUrl" data-testid="action-url">{{ actionText }}</a>
-  </template>
+  </main>
 </template>
 
 <style scoped>
@@ -42,35 +56,52 @@ export default {
 }
 
 .required-actions {
-  margin-bottom: 1rem;
+  margin: 0;
+  margin-bottom: 1.5rem;
 
   li {
     list-style: none;
   }
 }
 
-h2 {
-  font-size: 1.5rem;
-  font-family: metropolis;
-  font-weight: normal;
-  line-height: 1.1;
-  color: var(--colour-primary-default);
-  margin: 0 0 1.5rem 0;
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0 0 3rem 0;
+
+  .title {
+    font-size: 2.25rem;
+    font-family: metropolis;
+    font-weight: normal;
+    font-weight: 300;
+
+    font-stretch: normal;
+
+    font-style: normal;
+    letter-spacing: -0.36px;
+    line-height: 1.2;
+    color: var(--colour-primary-default);
+  }
+
+  .text {
+    font-size: 1rem;
+    line-height: 1.32;
+  }
+
+  .title,
+  .text {
+    margin: 0;
+  }
 }
 
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
+main {
+  display: flex;
+  flex-direction: column;
+}
 
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
+.perform-action {
+  align-self: flex-end;
+  width: fit-content;
 }
 </style>

--- a/keycloak/themes/tbpro/login/info.ftl
+++ b/keycloak/themes/tbpro/login/info.ftl
@@ -23,13 +23,20 @@
         // <#else>
         messageHeader: null,
         // </#if>
-        requiredActions: [
+        requiredActions: {
             //<#if requiredActions??><#list requiredActions>
               //<#items as reqActionItem>
-              '${kcSanitize(msg("requiredAction.${reqActionItem}"))?no_esc}',
+              ${reqActionItem}: '${kcSanitize(msg("requiredAction.${reqActionItem}"))?no_esc}',
               //</#items>
             // </#list></#if>
-        ],
+        },
+      };
+      window._l10n = {
+        ...window._l10n,
+        infoRedirectTitle: '${kcSanitize(msg("infoRedirectTitle"))?no_esc}',
+        infoRedirectText: '${kcSanitize(msg("infoRedirectText"))?no_esc}',
+        infoVerifyEmailTitle: '${kcSanitize(msg("infoVerifyEmailTitle"))?no_esc}',
+        infoVerifyEmailText:'${kcSanitize(msg("infoVerifyEmailText"))?no_esc}',
       };
     </script>
     </#if>

--- a/keycloak/themes/tbpro/login/messages/messages_en.properties
+++ b/keycloak/themes/tbpro/login/messages/messages_en.properties
@@ -29,6 +29,12 @@ routeNotImplementedTitle=Route Not Implemented
 routeNotImplementedText1=This route isn't implemented, please report this issue and the route name in the top left corner.
 routeNotImplementedText2=You can use the unformatted template below this panel to continue.
 
+infoRedirectTitle=You are being redirected
+infoRedirectText=We are performing the following actions automatically. If you are not redirected within a few seconds, please click the button below.
+infoVerifyEmailTitle=Verify your Email
+infoVerifyEmailText=Click the button below to verify your email.
+
+
 # General
 doLogIn=Sign In
 doRegister=Create Account
@@ -415,7 +421,7 @@ confirmAccountLinkingBody=If you link the account, you will also be able to logi
 confirmEmailAddressVerification=Confirm validity of e-mail address {0}.
 confirmExecutionOfActions=Perform the following action(s)
 
-backToApplication=&laquo; Back to Application
+backToApplication=Back to Application
 missingParameterMessage=Missing parameters\: {0}
 clientNotFoundMessage=Client not found.
 clientDisabledMessage=Client disabled.
@@ -423,7 +429,7 @@ invalidParameterMessage=Invalid parameter\: {0}
 alreadyLoggedIn=You are already logged in.
 differentUserAuthenticated=You are already authenticated as different user ''{0}'' in this session. Please sign out first.
 brokerLinkingSessionExpired=Requested broker account linking, but current session is no longer valid.
-proceedWithAction=&raquo; Click here to proceed
+proceedWithAction=Click here to proceed
 acrNotFulfilled=Authentication requirements not fulfilled
 
 requiredAction.CONFIGURE_TOTP=Configure OTP


### PR DESCRIPTION
Part of #659 

This is annoyingly hard coded in keycloak. So we still need some sort of "Click this button" action and landing page for that. I'm looking into it but we may need to wait until we start making modifications to keycloak itself to be able to match the design.

This change updates the generic info template / sfc, detects if "VERIFY_EMAIL" is the only required action, and if so then displays this custom text. If "VERIFY_EMAIL" is paired with other required actions (like set otp, or change password) then it will be displayed in the old list format. 

We can continue to iterate on this as we go forward. 

## Screenshots
<img width="3032" height="2206" alt="Screen Shot 2026-04-23 at 15 06 32-fullpage" src="https://github.com/user-attachments/assets/0f255a5a-98dc-43bf-9512-ad6ec3cdf64f" />
<img width="3032" height="2206" alt="Screen Shot 2026-04-23 at 15 06 36-fullpage" src="https://github.com/user-attachments/assets/c32d4351-4a69-4c8a-ad61-f201100cf5d3" />
