### PR TITLE
Redirect to mail after payment

### DIFF
--- a/assets/app/vue/router.ts
+++ b/assets/app/vue/router.ts
@@ -174,7 +174,7 @@ router.beforeEach((to, _from) => {
   if (isAuthenticated && sendToSubscribe && !['subscribe', 'contact'].includes(to.name.toString())) {
     return { name: 'subscribe' };
   } else if (isAuthenticated && !sendToSubscribe && to.name === 'subscribe') {
-    return { name: 'dashboard' };
+    return { name: 'mail' };
   }
 
   return true;

--- a/assets/app/vue/views/SubscribeView/components/PaymentPendingStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/PaymentPendingStep.vue
@@ -4,7 +4,8 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
 onMounted(() => {
-  // After 5 seconds reload the page, if the payment came through they'll see the dashboard.
+  // After 5 seconds reload the page, if the payment came through they'll see the Mail view.
+  // This is controlled by a beforeEach hook in router.ts.
   window.setTimeout(() => {
     window.location.reload();
   }, 5000);


### PR DESCRIPTION
## Description of changes

We are controlling the post-payment redirect through a `beforeEach` hook in `router.ts` and I've missed this during my [navigation changes PR](https://github.com/thunderbird/thunderbird-accounts/pull/695).

In that PR, I've made it redirect to `mail` after logging in as part of changing the Keycloak + Vue router root path but this `beforeEach` hook was forcibly redirecting it to `dashboard` instead.

Added a comment for clarification!

## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/701 (for real this time)