### PR TITLE
Remove fixed prefix for server settings card

### DIFF
--- a/assets/app/vue/components/ServerSettingsCard.vue
+++ b/assets/app/vue/components/ServerSettingsCard.vue
@@ -23,19 +23,19 @@ const incomingServerSelectedTab = ref<INCOMING_SERVER_TABS>(INCOMING_SERVER_TABS
 
 const imapServerDetails = computed(() => ({
   protocol: 'IMAP',
-  server: `imap.${connectionInfo.value.IMAP.HOST}`,
+  server: connectionInfo.value.IMAP.HOST,
   port: `${connectionInfo.value.IMAP.PORT}${connectionInfo.value.IMAP.TLS ? ' (SSL/TLS)' : ''}`,
 }));
 
 const jmapServerDetails = computed(() => ({
   protocol: 'JMAP',
-  server: `jmap.${connectionInfo.value.JMAP.HOST}`,
+  server: connectionInfo.value.JMAP.HOST,
   port: `${connectionInfo.value.JMAP.PORT}${connectionInfo.value.JMAP.TLS ? ' (SSL/TLS)' : ''}`,
 }));
 
 const smtpServerDetails = computed(() => ({
   protocol: 'SMTP',
-  server: `smtp.${connectionInfo.value.SMTP.HOST}`,
+  server: connectionInfo.value.SMTP.HOST,
   port: `${connectionInfo.value.SMTP.PORT}${connectionInfo.value.SMTP.TLS ? ' (SSL/TLS)' : ''}`,
 }));
 


### PR DESCRIPTION
## Description of change

For some reason I've forcibly prepended the protocol to the the actual connection info value but that's wrong so reverting that!

## Known issues / Things to improve

Tests will be added as part of https://github.com/thunderbird/thunderbird-accounts/issues/741

## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/755