### PR TITLE
Update GetStartedWithThundermail UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ Ensure you have the requirements in docs installed and run the following command
 sphinx-build docs build
 ```
 
+## Feature Flags
+
+Feature flags are stored in `localStorage` and read at runtime to toggle UI behavior.
+
+| Key | Values | Description |
+| --- | ------ | ----------- |
+| `feature.show-connect-now` | `true` | Shows the "Connect Now" action card on the desktop panel, which launches Thunderbird Desktop via a custom protocol URL. |
+| `feature.phase` | `2` | Enables phase 2 UI: QR code setup flow on mobile and the "Connect Now" card on desktop, replacing the auto-config placeholders. |
+
 ## Running tests
 
 Make sure that the containers are already running.

--- a/assets/app/vue/components/ServerSettingsCard.vue
+++ b/assets/app/vue/components/ServerSettingsCard.vue
@@ -6,9 +6,13 @@ import { ToolTip } from '@thunderbirdops/services-ui';
 import ServerSettingsCardItem from '@/components/ServerSettingsCardItem.vue';
 import { WHAT_IS_IMAP_SUPPORT_URL, WHAT_IS_JMAP_SUPPORT_URL, WHAT_IS_SMTP_SUPPORT_URL } from '@/defines';
 
-defineProps<{
-  isManualConfigurationSection?: boolean;
-}>();
+withDefaults(defineProps<{
+  isManualConfigurationSection: boolean;
+  showFooter: boolean;
+}>(), {
+  isManualConfigurationSection: false,
+  showFooter: true,
+});
 
 const { t } = useI18n();
 
@@ -81,7 +85,7 @@ const incomingServerDetails = computed(() =>
           </div>
         </template>
   
-        <template #footer>
+        <template #footer v-if="showFooter">
           <template v-if="incomingServerSelectedTab === INCOMING_SERVER_TABS.IMAP">
             <div class="what-is-container">
               <ph-info size="24" weight="fill" />
@@ -129,7 +133,7 @@ const incomingServerDetails = computed(() =>
           </div>
         </template>
   
-        <template #footer>
+        <template #footer v-if="showFooter">
           <div class="what-is-container">
             <ph-info size="24" weight="fill" />
             <span>{{ t('views.mail.sections.dashboard.whatIsSmtp') }}</span>

--- a/assets/app/vue/defines.ts
+++ b/assets/app/vue/defines.ts
@@ -5,4 +5,5 @@ export const WHAT_IS_JMAP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/4610
 export const WHAT_IS_SMTP_SUPPORT_URL = 'https://support.tb.pro/hc/articles/46106891841043-What-is-SMTP';
 export const DOWNLOAD_THUNDERBIRD_DESKTOP_URL = 'https://www.thunderbird.net/thunderbird/all?utm_campaign=main&utm_medium=tb_pro&utm_source=thundermail_dashboard&utm_content=desktop_download';
 export const DOWNLOAD_THUNDERBIRD_MOBILE_URL = 'https://play.google.com/store/apps/details?id=net.thunderbird.android&referrer=utm_campaign%3Dmain%26utm_medium%3Dtb_pro%26utm_source%3Dthundermail_dashboard%26utm_content%3Dmobile_download';
+export const IOS_SUPPORT_URL = 'https://support.tb.pro/hc/en-us/articles/51053665815827-Setting-Up-Thundermail-on-iOS';
 export const STATUS_PAGE_URL = 'https://status.tb.pro/';

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -114,7 +114,10 @@
               "downloadDescription": "Install the mobile app on your phone or tablet.",
               "downloadButton": "Download",
               "autoConfigTitle": "Automatic Configuration",
-              "autoConfigDescription": "Add a new account in Thunderbird for Android using your Thundermail email and password."
+              "autoConfigDescription": "Add a new account in Thunderbird for Android using your Thundermail email and password.",
+              "iosTitle": "Need iOS Help?",
+              "iosDescription": "Read our step-by-step guide for connecting popular email applications.",
+              "iosSupportButtonLabel": "Visit Support Article"
             },
             "otherAppsPanel": {
               "title": "Automatic Configuration",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -105,7 +105,8 @@
             },
             "mobilePanel": {
               "qrCodeTitle": "Scan QR Code",
-              "qrCodeDescription": "Go to Settings in Thunderbird for Android, add an account, and scan the QR code below.",
+              "qrCodeDescription": "In {thunderbirdForAndroid}, go to settings, add an account, and scan the QR code below.",
+              "thunderbirdForAndroid": "Thunderbird for Android",
               "qrCodeAlt": "A QR Code to be used with Thunderbird for Android account importing.",
               "downloadTitle": "Download Thunderbird for Android",
               "downloadDescription": "Install the mobile app on your phone or tablet.",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -114,8 +114,7 @@
             },
             "otherAppsPanel": {
               "title": "Automatic Configuration",
-              "descriptionOne": "Most modern email applications will detect your account settings automatically. Just enter your email and password.",
-              "descriptionTwo": "Some email apps may require an {appPassword} instead of your regular account sign-in.",
+              "description": "Most email apps will set up your account automatically with your email address and password. Some applications may require your {appPassword}.",
               "appPassword": "app password",
               "manualConfigurationTitle": "Manual Configuration",
               "needHelpTitle": "Need Help?",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -112,7 +112,9 @@
               "qrCodeAlt": "A QR Code to be used with Thunderbird for Android account importing.",
               "downloadTitle": "Download Thunderbird for Android",
               "downloadDescription": "Install the mobile app on your phone or tablet.",
-              "downloadButton": "Download"
+              "downloadButton": "Download",
+              "autoConfigTitle": "Automatic Configuration",
+              "autoConfigDescription": "Add a new account in Thunderbird for Android using your Thundermail email and password."
             },
             "otherAppsPanel": {
               "title": "Automatic Configuration",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -97,11 +97,13 @@
             },
             "desktopPanel": {
               "connectTitle": "Connect Thunderbird Desktop",
-              "connectDescription": "Launch the configuration wizard to add Thundermail to desktop automatically.",
+              "connectDescription": "Add Thundermail to Thunderbird Desktop automatically.",
               "connectButton": "Connect now",
               "downloadTitle": "Download Thunderbird Desktop",
               "downloadDescription": "We recommend using the desktop application for the best experience.",
-              "downloadButton": "Download"
+              "downloadButton": "Download",
+              "autoConfigTitle": "Automatic Configuration",
+              "autoConfigDescription": "Add a new account easily in Thunderbird Desktop using your Thundermail email and password."
             },
             "mobilePanel": {
               "qrCodeTitle": "Scan QR Code",

--- a/assets/app/vue/types.ts
+++ b/assets/app/vue/types.ts
@@ -11,3 +11,8 @@ export type ServerMessage = {
   level: SERVER_MESSAGE_LEVEL;
   message: string;
 };
+
+export enum FeatureFlag {
+  SHOW_CONNECT_NOW = 'feature.show-connect-now',
+  PHASE = 'feature.phase',
+}

--- a/assets/app/vue/types.ts
+++ b/assets/app/vue/types.ts
@@ -16,3 +16,8 @@ export enum FeatureFlag {
   SHOW_CONNECT_NOW = 'feature.show-connect-now',
   PHASE = 'feature.phase',
 }
+
+export enum FeatureFlagValue {
+  TRUE = 'true',
+  PHASE_TWO = '2',
+}

--- a/assets/app/vue/utils.ts
+++ b/assets/app/vue/utils.ts
@@ -1,6 +1,11 @@
+import { FeatureFlag } from '@/types';
+
 // Check if we already have a local user preferred language
 // Otherwise just use the navigators language.
 export const defaultLocale = () => {
   const user = JSON.parse(localStorage?.getItem('tba/user') ?? '{}');
   return user?.settings?.language ?? navigator.language.split('-')[0];
 };
+
+export const getFeatureFlag = (flag: FeatureFlag, expected: string): boolean =>
+  window.localStorage.getItem(flag) === expected;

--- a/assets/app/vue/utils.ts
+++ b/assets/app/vue/utils.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag } from '@/types';
+import { FeatureFlag, FeatureFlagValue } from '@/types';
 
 // Check if we already have a local user preferred language
 // Otherwise just use the navigators language.
@@ -7,5 +7,6 @@ export const defaultLocale = () => {
   return user?.settings?.language ?? navigator.language.split('-')[0];
 };
 
-export const getFeatureFlag = (flag: FeatureFlag, expected: string): boolean =>
+export const isFeatureFlagEnabled = (flag: FeatureFlag, expected: FeatureFlagValue): boolean =>
   window.localStorage.getItem(flag) === expected;
+

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermail.vue
@@ -21,7 +21,7 @@ defineEmits<{
 }>();
 
 const { t } = useI18n();
-const selectedTab = ref<string>(SETUP_TABS.DESKTOP);
+const selectedTab = ref<string>(window.matchMedia("(max-width: 768px)").matches ? SETUP_TABS.MOBILE : SETUP_TABS.DESKTOP);
 
 const tabs = computed<SegmentedControlTab[]>(() => [
   {

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -4,10 +4,13 @@ import { PhArrowSquareOut, PhDownloadSimple } from '@phosphor-icons/vue';
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import ActionCard from '@/components/ActionCard.vue';
 import { DOWNLOAD_THUNDERBIRD_DESKTOP_URL } from '@/defines';
+import { FeatureFlag } from '@/types';
+import { getFeatureFlag } from '@/utils';
 
 const { t } = useI18n();
 
-const showConnectNow = window.localStorage.getItem('feature.show-connect-now') === 'true';
+const showConnectNow = getFeatureFlag(FeatureFlag.SHOW_CONNECT_NOW, 'true');
+const phaseTwo = getFeatureFlag(FeatureFlag.PHASE, '2');
 
 // TODO: Update this when the full URL is ready
 const tbDesktopCustomProtocolUrl = 'net.thunderbird://replay';
@@ -21,24 +24,32 @@ export default {
 
 <template>
   <div class="action-cards">
-    <action-card
-      v-if="showConnectNow"
-      :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectTitle')"
-      :description="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectDescription')"
-    >
-      <template #icon>
-        <ph-arrow-square-out :size="20" />
-      </template>
-      <template #action>
-        <primary-button
-          size="small"
-          :href="tbDesktopCustomProtocolUrl"
-          class="button-link"
-        >
-          {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButton') }}
-        </primary-button>
-      </template>
-    </action-card>
+    <template v-if="phaseTwo">
+      <action-card
+        v-if="showConnectNow"
+        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectTitle')"
+        :description="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectDescription')"
+      >
+        <template #icon>
+          <ph-arrow-square-out :size="20" />
+        </template>
+        <template #action>
+          <primary-button
+            size="small"
+            :href="tbDesktopCustomProtocolUrl"
+            class="button-link"
+          >
+            {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButton') }}
+          </primary-button>
+        </template>
+      </action-card>
+    </template>
+    <template v-else>
+      <action-card
+        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.autoConfigTitle')"
+        :description="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.autoConfigDescription')"
+      />
+    </template>
 
     <action-card
       :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.downloadTitle')"

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -4,13 +4,13 @@ import { PhArrowSquareOut, PhDownloadSimple } from '@phosphor-icons/vue';
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import ActionCard from '@/components/ActionCard.vue';
 import { DOWNLOAD_THUNDERBIRD_DESKTOP_URL } from '@/defines';
-import { FeatureFlag } from '@/types';
-import { getFeatureFlag } from '@/utils';
+import { FeatureFlag, FeatureFlagValue } from '@/types';
+import { isFeatureFlagEnabled } from '@/utils';
 
 const { t } = useI18n();
 
-const showConnectNow = getFeatureFlag(FeatureFlag.SHOW_CONNECT_NOW, 'true');
-const phaseTwo = getFeatureFlag(FeatureFlag.PHASE, '2');
+const showConnectNow = isFeatureFlagEnabled(FeatureFlag.SHOW_CONNECT_NOW, FeatureFlagValue.TRUE);
+const isPhaseTwo = isFeatureFlagEnabled(FeatureFlag.PHASE, FeatureFlagValue.PHASE_TWO);
 
 // TODO: Update this when the full URL is ready
 const tbDesktopCustomProtocolUrl = 'net.thunderbird://replay';
@@ -24,7 +24,7 @@ export default {
 
 <template>
   <div class="action-cards">
-    <template v-if="phaseTwo">
+    <template v-if="isPhaseTwo">
       <action-card
         v-if="showConnectNow"
         :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectTitle')"

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { PhDownloadSimple, PhQrCode } from '@phosphor-icons/vue';
+import { PhDownloadSimple, PhQrCode, PhLifebuoy, PhArrowRight } from '@phosphor-icons/vue';
 import encodeQR from 'qr';
-import { PrimaryButton } from '@thunderbirdops/services-ui';
+import { PrimaryButton, LinkButton } from '@thunderbirdops/services-ui';
 import {
   encodeAccounts,
   INCOMING_PROTOCOL,
   CONNECTION_SECURITY,
   AUTHENTICATION_TYPE,
 } from 'thunderbird-account-qr-code';
-import { DOWNLOAD_THUNDERBIRD_MOBILE_URL } from '@/defines';
+import { DOWNLOAD_THUNDERBIRD_MOBILE_URL, IOS_SUPPORT_URL } from '@/defines';
 import { FeatureFlag } from '@/types';
 import { getFeatureFlag } from '@/utils';
 import ActionCard from '@/components/ActionCard.vue';
@@ -106,6 +106,24 @@ export default {
         </primary-button>
       </template>
     </action-card>
+
+    <action-card
+      :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.iosTitle')"
+      :description="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.iosDescription')"
+    >
+      <template #icon>
+        <ph-lifebuoy :size="20" />
+      </template>
+      <template #action>
+        <link-button size="small" :href="IOS_SUPPORT_URL" target="_blank" class="ios-help-button">
+          {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.iosSupportButtonLabel') }}
+
+          <template #iconRight>
+            <ph-arrow-right :size="16" />
+          </template>
+        </link-button>
+      </template>
+    </action-card>
   </div>
 </template>
 
@@ -117,6 +135,15 @@ export default {
 
   .download-button {
     height: 2rem;
+  }
+
+  :deep(.ios-help-button) {
+    color: var(--colour-primary-pressed);
+    padding-inline-end: 0;
+
+    span.text {
+      font-size: 0.75rem;
+    }
   }
 
   .qr-code-container {

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { PhDownloadSimple } from '@phosphor-icons/vue';
+import { PhDownloadSimple, PhQrCode } from '@phosphor-icons/vue';
 import encodeQR from 'qr';
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import {
@@ -12,6 +12,7 @@ import {
 } from 'thunderbird-account-qr-code';
 import { DOWNLOAD_THUNDERBIRD_MOBILE_URL } from '@/defines';
 import ActionCard from '@/components/ActionCard.vue';
+import DetailsSummary from '@/components/DetailsSummary.vue';
 
 const { t } = useI18n();
 
@@ -47,14 +48,30 @@ export default {
 <template>
   <div class="action-cards">
     <div class="qr-code-container">
-      <p class="qr-code-title">{{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeTitle') }}</p>
-      <p class="qr-code-description">{{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription') }}</p>
-
-      <img
-        class="qr-code"
-        :src="`data:image/svg+xml,${qrCode}`"
-        :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeAlt')"
-      />
+      <i18n-t
+        keypath="views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription"
+        class="qr-code-description"
+        tag="p"
+      >
+        <template #thunderbirdForAndroid>
+          <strong>
+            {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.thunderbirdForAndroid') }}
+          </strong>
+        </template>
+      </i18n-t>
+      <details-summary
+        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeTitle')"
+        class="qr-code-details-summary"
+      >
+        <template #icon>
+          <ph-qr-code :size="20" />
+        </template>
+        <img
+          class="qr-code"
+          :src="`data:image/svg+xml,${qrCode}`"
+          :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeAlt')"
+        />
+      </details-summary>
     </div>
 
     <action-card
@@ -89,21 +106,19 @@ export default {
   .download-button {
     height: 2rem;
   }
-  
+
   .qr-code-container {
     display: flex;
     flex-direction: column;
-    align-items: center;
     gap: 0.5rem;
     padding: 0.75rem 0.5rem 0.5rem;
     border: 1px solid var(--colour-neutral-border);
     border-radius: 8px;
-  
-    .qr-code-title {
-      font-size: 0.875rem;
-      color: #000;
+
+    .qr-code-details-summary {
+      margin-block-end: 0;
     }
-  
+
     .qr-code-description {
       font-size: 0.75rem;
       color: var(--colour-ti-secondary);

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
@@ -11,10 +11,14 @@ import {
   AUTHENTICATION_TYPE,
 } from 'thunderbird-account-qr-code';
 import { DOWNLOAD_THUNDERBIRD_MOBILE_URL } from '@/defines';
+import { FeatureFlag } from '@/types';
+import { getFeatureFlag } from '@/utils';
 import ActionCard from '@/components/ActionCard.vue';
 import DetailsSummary from '@/components/DetailsSummary.vue';
 
 const { t } = useI18n();
+
+const phaseTwo = getFeatureFlag(FeatureFlag.PHASE, '2');
 
 const primaryEmail = computed(() => window._page?.emailAddresses?.[0] || '');
 const connectionInfo = computed(() => window._page?.connectionInfo);
@@ -47,32 +51,40 @@ export default {
 
 <template>
   <div class="action-cards">
-    <div class="qr-code-container">
-      <i18n-t
-        keypath="views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription"
-        class="qr-code-description"
-        tag="p"
-      >
-        <template #thunderbirdForAndroid>
-          <strong>
-            {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.thunderbirdForAndroid') }}
-          </strong>
-        </template>
-      </i18n-t>
-      <details-summary
-        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeTitle')"
-        class="qr-code-details-summary"
-      >
-        <template #icon>
-          <ph-qr-code :size="20" />
-        </template>
-        <img
-          class="qr-code"
-          :src="`data:image/svg+xml,${qrCode}`"
-          :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeAlt')"
-        />
-      </details-summary>
-    </div>
+    <template v-if="phaseTwo">
+      <div class="qr-code-container">
+        <i18n-t
+          keypath="views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription"
+          class="qr-code-description"
+          tag="p"
+        >
+          <template #thunderbirdForAndroid>
+            <strong>
+              {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.thunderbirdForAndroid') }}
+            </strong>
+          </template>
+        </i18n-t>
+        <details-summary
+          :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeTitle')"
+          class="qr-code-details-summary"
+        >
+          <template #icon>
+            <ph-qr-code :size="20" />
+          </template>
+          <img
+            class="qr-code"
+            :src="`data:image/svg+xml,${qrCode}`"
+            :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeAlt')"
+          />
+        </details-summary>
+      </div>
+    </template>
+    <template v-else>
+      <action-card
+        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.autoConfigTitle')"
+        :description="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.autoConfigDescription')"
+      />
+    </template>
 
     <action-card
       :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.downloadTitle')"

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
@@ -11,14 +11,14 @@ import {
   AUTHENTICATION_TYPE,
 } from 'thunderbird-account-qr-code';
 import { DOWNLOAD_THUNDERBIRD_MOBILE_URL, IOS_SUPPORT_URL } from '@/defines';
-import { FeatureFlag } from '@/types';
-import { getFeatureFlag } from '@/utils';
+import { FeatureFlag, FeatureFlagValue } from '@/types';
+import { isFeatureFlagEnabled } from '@/utils';
 import ActionCard from '@/components/ActionCard.vue';
 import DetailsSummary from '@/components/DetailsSummary.vue';
 
 const { t } = useI18n();
 
-const phaseTwo = getFeatureFlag(FeatureFlag.PHASE, '2');
+const isPhaseTwo = isFeatureFlagEnabled(FeatureFlag.PHASE, FeatureFlagValue.PHASE_TWO);
 
 const primaryEmail = computed(() => window._page?.emailAddresses?.[0] || '');
 const connectionInfo = computed(() => window._page?.connectionInfo);
@@ -51,7 +51,7 @@ export default {
 
 <template>
   <div class="action-cards">
-    <template v-if="phaseTwo">
+    <template v-if="isPhaseTwo">
       <div class="qr-code-container">
         <i18n-t
           keypath="views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription"

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
@@ -26,7 +26,7 @@ const { t } = useI18n();
         <ph-gear :size="20" />
       </template>
 
-      <server-settings-card is-manual-configuration-section />
+      <server-settings-card is-manual-configuration-section :show-footer=false />
     </action-card>
 
     <!-- Need Help? -->

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { PhArrowSquareOut, PhQuestion, PhArrowRight, PhGear } from '@phosphor-icons/vue';
+import { PhLifebuoy, PhArrowRight, PhGear } from '@phosphor-icons/vue';
 import { LinkButton } from '@thunderbirdops/services-ui';
 import ActionCard from '@/components/ActionCard.vue';
 import ServerSettingsCard from '@/components/ServerSettingsCard.vue';
@@ -13,15 +13,7 @@ const { t } = useI18n();
   <div class="action-cards">
     <!-- Automatic Configuration -->
     <action-card :title="t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.title')">
-      <template #icon>
-        <ph-arrow-square-out :size="20" />
-      </template>
-
-      <p class="action-description">
-        {{ t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.descriptionOne') }}
-      </p>
-
-      <i18n-t keypath="views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.descriptionTwo" tag="p">
+      <i18n-t keypath="views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.description" tag="p">
         <template #appPassword>
           <a href="#app-password-container" class="app-password-link">{{ t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.appPassword') }}</a>
         </template>
@@ -43,7 +35,7 @@ const { t } = useI18n();
       :description="t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.needHelpDescription')"
     >
       <template #icon>
-        <ph-question :size="20" />
+        <ph-lifebuoy :size="20" />
       </template>
       <template #action>
         <link-button size="small" :href="OTHER_APPS_SUPPORT_URL" target="_blank" class="need-help-button">
@@ -67,10 +59,6 @@ const { t } = useI18n();
   p {
     font-size: 0.75rem;
     color: var(--colour-ti-secondary);
-  }
-
-  .action-description {
-    margin-block-end: 1ch;
   }
 
   .app-password-link {

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
@@ -66,9 +66,13 @@ const { t } = useI18n();
     color: var(--colour-ti-secondary);
   }
 
-  .need-help-button {
+  :deep(.need-help-button) {
     color: var(--colour-primary-pressed);
     padding-inline-end: 0;
+
+    span.text {
+      font-size: 0.75rem;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Description of changes

- Enumify-ed / typed the feature flags to make it a bit more consistent and resuable
- In mobile viewports, set the Mobile tab as the selected one by default
- Implemented design changes for phase 1 (current) and 2

Zeplin for reference (click on the tabs in Zeplin for the various phases / devices):
https://zpl.io/JQO6yj6

## How to test

(Assuming that you have a user set up, went through Paddle, etc)

- Phase 1 is the default, no nothing to change here.
- For Phase 2, add the following key to the local storage: `feature.phase` to `2`

## Screenshots

Phase 1 (current, no local storage needed)

Desktop
<img width="997" height="360" alt="image" src="https://github.com/user-attachments/assets/b338454a-4e61-4932-9729-1f8c2df73074" />

Mobile
<img width="998" height="425" alt="image" src="https://github.com/user-attachments/assets/49ff2754-8fe1-4947-9c04-c2fec28cacfa" />


Other Apps
<img width="999" height="580" alt="image" src="https://github.com/user-attachments/assets/c57c53e5-e3ae-49a8-a54a-4dd100e38d8d" />


Phase 2 (`feature.phase = 2` in local storage)

Desktop
<img width="991" height="367" alt="image" src="https://github.com/user-attachments/assets/3398b7bb-249d-4b14-9e90-29ce5b5febc2" />

Mobile (QR code starts collapsed)
<img width="1002" height="658" alt="image" src="https://github.com/user-attachments/assets/1c738321-07ca-458a-aaca-1c6e216946ef" />



Other Apps
<img width="1004" height="584" alt="image" src="https://github.com/user-attachments/assets/28afe05c-2f36-49f5-9974-cd839b3ef99b" />


## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/757
Fixes https://github.com/thunderbird/thunderbird-accounts/issues/700