### PR TITLE
chore(pulumi): remove legacy IAM automation user

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -4,7 +4,6 @@ import pulumi
 import pulumi_cloudflare as cloudflare
 import tb_pulumi
 import tb_pulumi.autoscale
-import tb_pulumi.ci
 import tb_pulumi.cloudwatch
 import tb_pulumi.ec2
 import tb_pulumi.elasticache
@@ -173,14 +172,6 @@ monitoring_opts = resources.get('tb:cloudwatch:CloudWatchMonitoringGroup', {}).g
 monitoring = tb_pulumi.cloudwatch.CloudWatchMonitoringGroup(
     name=f'{project.name_prefix}-monitoring', project=project, **monitoring_opts
 )
-
-auto_users_opts = resources.get('tb:ci:AwsAutomationUser', {})
-for user, user_opts in auto_users_opts.items():
-    tb_pulumi.ci.AwsAutomationUser(
-        f'{project.name_prefix}-{user}',
-        project=project,
-        **user_opts,
-    )
 
 sap = tb_pulumi.iam.StackAccessPolicies(
     f'{project.name_prefix}-sap',

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -912,21 +912,3 @@ resources:
           accounts-prod-fargate-accounts-fargateservicealb-alb-accounts:
             response_time:
               threshold: 2
-
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      enable_ecr_image_push: true
-      ecr_repositories:
-        - thunderbird/accounts
-      enable_fargate_deployments: true
-      fargate_clusters:
-        - accounts-prod-fargate-keycloak
-        - accounts-prod-fargate-accounts
-        - accounts-prod
-      fargate_task_role_arns:
-        - arn:aws:iam::768512802988:role/accounts-prod-fargate-keycloak
-        - arn:aws:iam::768512802988:role/accounts-prod-fargate-accounts
-        - arn:aws:iam::768512802988:role/accounts-prod-afc-accounts-celery-prod
-        - arn:aws:iam::768512802988:role/accounts-prod-afc-accounts-flower-prod

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -899,22 +899,3 @@ resources:
             response_time:
               threshold: 2
 
-  tb:ci:AwsAutomationUser:
-    ci:
-      access_keys: {}
-      enable_legacy_access_key: True
-      enable_ecr_image_push: True
-      ecr_repositories:
-        - thunderbird/accounts
-      enable_fargate_deployments: True
-      fargate_clusters:
-        - accounts-stage-fargate-accounts
-        - accounts-stage-fargate-accounts-celery
-        - accounts-stage-fargate-keycloak
-        - accounts-stage
-      fargate_task_role_arns:
-        - arn:aws:iam::768512802988:role/accounts-stage-fargate-accounts
-        - arn:aws:iam::768512802988:role/accounts-stage-fargate-keycloak
-        - arn:aws:iam::768512802988:role/accounts-stage-afc-accounts-celery-stage
-        - arn:aws:iam::768512802988:role/accounts-stage-afc-accounts-flower-stage
-


### PR DESCRIPTION
## Summary

- Removes `tb_pulumi.ci.AwsAutomationUser` from `pulumi/__main__.py` and drops `tb:ci:AwsAutomationUser` config from `config.prod.yaml` and `config.stage.yaml`
- OIDC soak complete: 2 prod deploys via OIDC (r-0320 2026-04-24, r-0324 2026-04-27); CloudTrail shows zero events on `accounts-{prod,stage}-ci` since cutover (2026-04-23)

## Follow-up (after merge)

- [x] `pulumi up` in the accounts stack (prod + stage) to destroy the IAM user resources
- [x] Confirm IAM users gone: `aws iam get-user --user-name accounts-{prod,stage}-ci --profile mzla-legacy`
- [x] Delete `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from `staging` and `production` GitHub Environments
- [ ] Update `docs/oidc-migration-inventory.md` row 2 — mark migration complete
- [ ] Close thunderbird/platform-infrastructure#249 and thunderbird/platform-infrastructure#204

Part of thunderbird/platform-infrastructure#249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)