### PR TITLE
Sign up check for recovery email in use

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -305,7 +305,8 @@
             "subtitle": "Use an email address you already have access to. It must be different from your new Thundermail address.",
             "action": "Verify email",
             "verificationEmailPlaceholder": "yourname{'@'}example.com",
-            "verificationEmailHelp": "Thundermail will send a verification link to this address to confirm it belongs to you."
+            "verificationEmailHelp": "Thundermail will send a verification link to this address to confirm it belongs to you.",
+            "unknownError": "There was a problem with your verification email. Please try another one."
           },
           "step4": {
             "title": "Check your email",

--- a/assets/app/vue/views/SignUpView/views/Step3Verify/api.ts
+++ b/assets/app/vue/views/SignUpView/views/Step3Verify/api.ts
@@ -1,0 +1,20 @@
+export const isRecoveryEmailInUse = async (recoveryEmail: string) => {
+  const response = await fetch('/api/v1/mail/is-recovery-email-in-use/', {
+    method: 'POST',
+    body: JSON.stringify({
+      'recoveryEmail': recoveryEmail,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': window._page?.csrfToken,
+    },
+  });
+
+  if (response.status === 200) {
+    return { success: true, error: null };
+  } else if (response.status === 429) { // Throttled
+    return { success: false, error: (await response.json())['detail'] || false };
+  }
+
+  return { success: false, error: (await response.json())['0'] || false };
+}

--- a/assets/app/vue/views/SignUpView/views/Step3Verify/index.vue
+++ b/assets/app/vue/views/SignUpView/views/Step3Verify/index.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
-import { TextInput } from '@thunderbirdops/services-ui';
 import { nextTick, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useDebounceFn } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
+import { TextInput } from '@thunderbirdops/services-ui';
 import { useSignUpFlowStore } from '../../stores/signUpFlowStore';
 import SignUpLayout from '../../components/SignUpLayout.vue';
+import { isRecoveryEmailInUse } from './api';
+
+const { t } = useI18n();
 
 const loading = ref(false);
 
@@ -11,10 +16,36 @@ const signUpFlowStore = useSignUpFlowStore();
 
 const { verificationEmail } = storeToRefs(signUpFlowStore);
 const { submit } = signUpFlowStore;
+const emailOk = ref(false);
 const emailError = ref(null);
+
+const recoveryEmailCheckDebounced = useDebounceFn(async () => {
+  const { success, error } = await isRecoveryEmailInUse(verificationEmail.value);
+  loading.value = false;
+
+  if (success === true) {
+    emailOk.value = true;
+    emailError.value = null;
+    return;
+  }
+
+  emailOk.value = false;
+  if (error === false) {
+    emailError.value = t('views.mail.views.signUp.step3.unknownError');
+    return;
+  }
+
+  emailError.value = error;
+}, 250);
 
 const onSubmit = async () => {
   loading.value = true;
+
+  await recoveryEmailCheckDebounced();
+  if (!emailOk.value) {
+    return;
+  }
+
   const response = await submit();
 
   if (response === true) {
@@ -47,9 +78,17 @@ export default {
       <slot name="notice-bars" />
     </template>
     <template v-slot:form-elements>
-      <text-input data-testid="verification-email-input" name="verification-email" required autocomplete="email"
-        :error="emailError" :help="$t('views.mail.views.signUp.step3.verificationEmailHelp')"
-        :placeholder="$t('views.mail.views.signUp.step3.verificationEmailPlaceholder')" v-model="verificationEmail">
+      <text-input
+        data-testid="verification-email-input"
+        name="verification-email"
+        required
+        autocomplete="email"
+        @input="recoveryEmailCheckDebounced"
+        :error="emailError"
+        :help="$t('views.mail.views.signUp.step3.verificationEmailHelp')"
+        :placeholder="$t('views.mail.views.signUp.step3.verificationEmailPlaceholder')"
+        v-model="verificationEmail"
+      >
         {{ $t('views.mail.views.signUp.fields.verificationEmail') }}
       </text-input>
       <slot name="form-extras" />

--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -11,10 +11,15 @@ from django.utils.translation import gettext_lazy as _
 
 
 from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.mail.utils import is_address_taken
 
 
 class UsernameAvailableThrottle(UserRateThrottle):
     scope = 'is_username_available'
+
+
+class RecoveryEmailInUseThrottle(UserRateThrottle):
+    scope = 'is_recovery_email_in_use'
 
 
 @api_view(['POST'])
@@ -43,5 +48,19 @@ def is_username_available(request: Request):
     user = User.objects.filter(username=full_username).first()
     if user:
         raise ValidationError(_('This username is already taken. Try another one.'))
+
+    return Response(status=200)
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+@throttle_classes([RecoveryEmailInUseThrottle])
+def is_recovery_email_in_use(request: Request):
+    recovery_email = request.data.get('recoveryEmail')
+    if not recovery_email:
+        raise ValidationError(_('You need to enter a recovery email.'))
+
+    if is_address_taken(recovery_email):
+        raise ValidationError(_('User exists with same email.'))
 
     return Response(status=200)

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -202,6 +202,61 @@ class AddEmailAliasTestCase(TestCase):
             self.assertEqual(json.loads(response.content.decode()), {'success': True})
 
 
+class IsRecoveryEmailInUseTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+        self.url = reverse('api_is_recovery_email_in_use')
+
+    def test_missing_recovery_email(self):
+        response = self.client.post(self.url, data={}, content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+
+    def test_email_taken_by_user_email(self):
+        User.objects.create(
+            username=f'taken@{settings.PRIMARY_EMAIL_DOMAIN}',
+            email='taken@example.com',
+            oidc_id='1',
+        )
+        response = self.client.post(
+            self.url,
+            data={'recoveryEmail': 'taken@example.com'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_email_taken_by_username(self):
+        User.objects.create(
+            username=f'taken@{settings.PRIMARY_EMAIL_DOMAIN}',
+            oidc_id='2',
+        )
+        response = self.client.post(
+            self.url,
+            data={'recoveryEmail': f'taken@{settings.PRIMARY_EMAIL_DOMAIN}'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_email_taken_by_alias(self):
+        user = User.objects.create(username=f'alias@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='3')
+        account = Account.objects.create(name=f'alias@{settings.PRIMARY_EMAIL_DOMAIN}', user=user)
+        Email.objects.create(address='alias@custom.com', type=Email.EmailType.ALIAS, account=account)
+
+        response = self.client.post(
+            self.url,
+            data={'recoveryEmail': 'alias@custom.com'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_email_not_taken(self):
+        response = self.client.post(
+            self.url,
+            data={'recoveryEmail': 'fresh@example.com'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+
 class AppointmentCalDAVSetupTestCase(TestCase):
     def setUp(self):
         self.client = RequestClient()

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -263,6 +263,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_THROTTLE_RATES': {
         'is_username_available': '30/minute',
+        'is_recovery_email_in_use': '30/minute',
         'sign_up': '10/minute'
     }
 }

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -69,6 +69,11 @@ urlpatterns = [
         'api/v1/subscription/plan/info/', subscription_views.get_subscription_plan_info, name='subscription_plan_info'
     ),
     path('api/v1/mail/is-username-available/', mail_api.is_username_available, name='api_is_username_available'),
+    path(
+        'api/v1/mail/is-recovery-email-in-use/',
+        mail_api.is_recovery_email_in_use,
+        name='api_is_recovery_email_in_use',
+    ),
     # Stalwart telemetry webhook
     path('api/v1/telemetry/stalwart/webhook/', telemetry_views.stalwart_webhook, name='stalwart_webhook'),
     # Health check


### PR DESCRIPTION
## Description of changes

Added a throttled new endpoint `POST api/v1/mail/is-recovery-email-in-use/` to preemptively check if the verification email already belongs to an existing user before clicking the submit button.

## Screenshots / Video


https://github.com/user-attachments/assets/aebe7354-82e9-4ca2-9401-14dd942a2b12



## Related issues

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/759