### PR TITLE
Add desktop Safari to nightly E2E tests job

### DIFF
--- a/.github/workflows/e2e-desktop-nightly-chrome.yml
+++ b/.github/workflows/e2e-desktop-nightly-chrome.yml
@@ -1,7 +1,7 @@
-name: nightly-tests-desktop
+name: e2e-desktop-nightly-chrome
 
 concurrency:
-  group: nightly-tests-desktop
+  group: e2e-desktop-nightly-chrome
   cancel-in-progress: true
 
 on:
@@ -15,8 +15,8 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  prod-sanity-browserstack:
-    name: nightly-tests-desktop-browserstack
+  desktop-nightly-chrome:
+    name: prod-desktop-nightly-chrome
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -45,15 +45,7 @@ jobs:
           username:  ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: 'Thunderbird Accounts'
-          build-name: 'TB Accounts Nightly Tests (Desktop): BUILD_INFO'
-
-      - name: Prod E2E Tests on Desktop Firefox
-        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
-        continue-on-error: true
-        run: |
-          cd ./test/e2e
-          cp .env.prod.example .env
-          npm run prod-nightly-tests-browserstack-desktop-firefox
+          build-name: 'TB Accounts Nightly Tests (Desktop Chromium): BUILD_INFO'
 
       - name: Prod E2E Tests on Desktop Chromium
         # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)

--- a/.github/workflows/e2e-desktop-nightly-firefox.yml
+++ b/.github/workflows/e2e-desktop-nightly-firefox.yml
@@ -1,0 +1,56 @@
+name: e2e-desktop-nightly-firefox
+
+concurrency:
+  group: e2e-desktop-nightly-firefox
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 4am UTC (11PM EST)
+    - cron:  '20 4 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  desktop-nightly-firefox:
+    name: prod-desktop-nightly-firefox
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Accounts'
+          build-name: 'TB Accounts Nightly Tests (Desktop Firefox): BUILD_INFO'
+
+      - name: Prod E2E Tests on Desktop Firefox
+        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
+        continue-on-error: true
+        run: |
+          cd ./test/e2e
+          cp .env.prod.example .env
+          npm run prod-nightly-tests-browserstack-desktop-firefox

--- a/.github/workflows/e2e-desktop-nightly-safari.yml
+++ b/.github/workflows/e2e-desktop-nightly-safari.yml
@@ -1,0 +1,56 @@
+name: e2e-desktop-nightly-safari
+
+concurrency:
+  group: e2e-desktop-nightly-safari
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 4am UTC (11PM EST)
+    - cron:  '10 4 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  desktop-nightly-safari:
+    name: prod-desktop-nightly-safari
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Accounts'
+          build-name: 'TB Accounts Nightly Tests (Desktop Safari): BUILD_INFO'
+
+      - name: Prod E2E Tests on Desktop Safari
+        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
+        continue-on-error: true
+        run: |
+          cd ./test/e2e
+          cp .env.prod.example .env
+          npm run prod-nightly-tests-browserstack-desktop-safari

--- a/test/e2e/browserstack-desktop-nightly.yml
+++ b/test/e2e/browserstack-desktop-nightly.yml
@@ -49,6 +49,18 @@ platforms:
       use:
         storageState: 'test-results/.auth/user.json'
 
+  - os: OS X
+    osVersion: Sequoia
+    browserName: playwright-webkit
+    browserVersion: 18.5
+    playwrightConfigOptions:
+      name: Safari-OSX
+      setup: 
+      - name: 'setup_webkit'
+        testMatch: 'auth.desktop.setup.ts'
+      use:
+        storageState: 'test-results/.auth/user.json'
+
 # =======================
 # Parallels per Platform
 # =======================

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -15,7 +15,7 @@ export const PRIMARY_THUNDERMAIL_EMAIL = String(process.env.PRIMARY_THUNDERMAIL_
 
 // playwright test tags
 export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
-export const PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY = '@e2e-prod-desktop-nighlty';
+export const PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY = '@e2e-prod-desktop-nightly';
 
 // timeouts
 export const TIMEOUT_2_SECONDS = 2000;

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -7,8 +7,9 @@
     "e2e-test-headed": "npx playwright test --grep e2e-suite --project=firefox --headed",
     "e2e-test-debug": "npx playwright test --grep e2e-suite --project=firefox --headed --ui",
     "e2e-test-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-suite --project=Firefox-OSX --browserstack.buildName 'TB Accounts E2E Tests Firefox Desktop' --browserstack.config 'browserstack-desktop.yml'",
-    "prod-nightly-tests-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nighlty --project=Firefox-OSX --browserstack.buildName 'TB Accounts Nightly Tests Firefox Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
-    "prod-nightly-tests-browserstack-desktop-chromium": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nighlty --project=Chromium-OSX --browserstack.buildName 'TB Accounts Nightly Tests Chromium Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
+    "prod-nightly-tests-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Firefox-OSX --browserstack.buildName 'TB Accounts Nightly Tests Firefox Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
+    "prod-nightly-tests-browserstack-desktop-chromium": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Chromium-OSX --browserstack.buildName 'TB Accounts Nightly Tests Chromium Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
+    "prod-nightly-tests-browserstack-desktop-safari": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Safari-OSX --browserstack.buildName 'TB Accounts Nightly Tests Safari Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
     "postinstall": "npm update browserstack-node-sdk"
   },
   "keywords": [],

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -79,6 +79,17 @@ export default defineConfig({
        },
       dependencies: ['desktop-setup'],
     },
+
+    {
+      name: 'safari',
+      use: {
+        ...devices['Desktop Safari'],
+        screenshot: 'only-on-failure',
+        // Use prepared auth state
+        storageState: 'test-results/.auth/user.json',
+      },
+      dependencies: ['desktop-setup'],
+    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/test/e2e/tests/contact.spec.ts
+++ b/test/e2e/tests/contact.spec.ts
@@ -145,7 +145,7 @@ test.describe('contact support form', {
     // we are already signed into TB Accounts; ensure the form shows as expected when signed in
     await contactPage.verifyFormDisplayed();
 
-    // since we're signed in, email field should be pre-filled with the user's recovery email
+    // since we're signed in, email field should be pre-filled with the user's primary email
     await expect(contactPage.emailInput).toHaveValue(PRIMARY_THUNDERMAIL_EMAIL);
   });
   

--- a/test/e2e/tests/sign-up.spec.ts
+++ b/test/e2e/tests/sign-up.spec.ts
@@ -77,7 +77,7 @@ test.describe('sign up form', {
     await signUpPage.fillForm(testUsername, testPassword, testConfirmPassword);
     await signUpPage.submitForm();
 
-    const errorText = page.getByText('Please use at least 12 characters (you are currently using 3 characters).');
+    const errorText = page.getByText('12 characters');
     await expect(errorText).toBeVisible();
   });
 


### PR DESCRIPTION
Currently the TB Accounts nightly E2E tests run on desktop Firefox and Chromium; adding desktop Safari to the lineup. Also splitting up the workflows for each browser, that way we can manually trigger the test job for a single platform instead of having to run on all every time. Fixes #764.

Also the 'minimum password' error text is different in Safari vs Firefox vs Chrome so had to update the locator for that text to one that works for all.

BrowserStack link running the nightly test jobs on prod using this branch (all tests passed):

- [Safari desktop](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Safari+Desktop/2?tab=sessions&testListView=spec)
- [Firefox desktop](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Firefox+Desktop/76?tab=sessions)
- [Chromium desktop](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Chromium+Desktop/74?tab=sessions)