### PR TITLE
Move sign up's email validation to utils, and call it in add_alias

### DIFF
--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -1,6 +1,6 @@
+from thunderbird_accounts.mail.exceptions import EmailNotValidError
+from thunderbird_accounts.mail.utils import validate_email
 from rest_framework.permissions import AllowAny
-from django.core.exceptions import ValidationError as DjValidationError
-from django.core.validators import EmailValidator
 from django.conf import settings
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.decorators import api_view, throttle_classes, permission_classes
@@ -28,17 +28,10 @@ def is_username_available(request: Request):
     full_username = f'{username}@{settings.PRIMARY_EMAIL_DOMAIN}'
     username_not_valid_err = _('This username is not valid. Try another one.')
 
-    # EmailValidator allows for up to 350 characters, but username is defined with max_length of 150.
-    if len(username) > User.USERNAME_MAX_LENGTH:
-        raise ValidationError(username_not_valid_err)
-
-    email_validator = EmailValidator(username_not_valid_err)
-    # So EmailValidator.__call__ will raise a ValidationError if it fails, but they're the wrong
-    # ValidationError...So catch this ValidationError so we can raise DRF's ValidationError.
     try:
-        email_validator(full_username)
-    except DjValidationError as ex:
-        raise ValidationError(ex.message)
+        validate_email(full_username, username_not_valid_err)
+    except EmailNotValidError as ex:
+        raise ValidationError(ex.error_message)
 
     user = User.objects.filter(username=full_username).first()
     if user:

--- a/src/thunderbird_accounts/mail/exceptions.py
+++ b/src/thunderbird_accounts/mail/exceptions.py
@@ -59,3 +59,16 @@ class DomainAlreadyExistsError(StalwartError):
 
     def __str__(self):
         return f'DomainAlreadyExistsError: {self.domain}'
+
+class EmailNotValidError(RuntimeError):
+    """Raises in utils.validate_email"""
+    email: str
+    error_message: str
+
+    def __init__(self, email, error_message, *args, **kwargs):
+        super().__init__(args, kwargs)
+        self.email = email
+        self.error_message = error_message
+
+    def __str__(self):
+        return f'EmailNotValidError: {self.email}, {self.error_message}'

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.utils.crypto import get_random_string
 from thunderbird_accounts.subscription.models import Plan
 import json
 from unittest.mock import patch, Mock
@@ -256,6 +257,36 @@ class AddEmailAliasTestCase(TestCase):
             json.loads(response.content.decode()),
             {'success': False, 'error': _('Email alias must be at least 3 characters long.')},
         )
+
+    @override_settings(ALLOWED_EMAIL_DOMAINS=['example.org', 'example.com'])
+    def test_allowed_domains_alias_too_long(self):
+        """Test that email aliases shorter than 3 characters are rejected for ALLOWED_EMAIL_DOMAINS."""
+        email_alias_url = reverse('add_email_alias')
+
+        random_string = get_random_string(User.USERNAME_MAX_LENGTH)
+
+        response = self.client.post(
+            email_alias_url,
+            data={'email-alias': random_string, 'domain': 'example.org'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400, msg=response.content.decode())
+        self.assertEqual(
+            json.loads(response.content.decode()),
+            {'success': False, 'error': _('This email is not valid. Try another one.')},
+        )
+
+        response = self.client.post(
+            email_alias_url,
+            data={'email-alias': random_string, 'domain': 'example.org'},
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400, msg=response.content.decode())
+        self.assertEqual(
+            json.loads(response.content.decode()),
+            {'success': False, 'error': _('This email is not valid. Try another one.')},
+        )
+
 
     @override_settings(ALLOWED_EMAIL_DOMAINS=['example.org', 'example.com'])
     @override_settings(MIN_CUSTOM_DOMAIN_ALIAS_LENGTH=3)

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -1,14 +1,42 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
+from thunderbird_accounts.mail.exceptions import EmailNotValidError
 import logging
 import uuid
 from typing import Optional
 from requests.exceptions import HTTPError
 from django.contrib.auth.hashers import make_password, identify_hasher
+from django.utils.translation import gettext_lazy as _
 import sentry_sdk
 
 from django.conf import settings
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.models import Account
 from thunderbird_accounts.mail import tasks
+
+
+def validate_email(email: str, error_message: str | None = None) -> bool:
+    """Validates the email and local part against Django's built-in email validation."""
+    not_valid_err_msg = error_message or _('This email is not valid. Try another one.')
+
+    if '@' not in email:
+        raise EmailNotValidError(email, not_valid_err_msg)
+
+    local_part = email.split('@')[0]
+
+    # EmailValidator allows for up to 350 characters, but username is defined with max_length of 150.
+    if len(local_part) >= User.USERNAME_MAX_LENGTH:
+        raise EmailNotValidError(email, not_valid_err_msg)
+
+    email_validator = EmailValidator(not_valid_err_msg)
+    # So EmailValidator.__call__ will raise a ValidationError if it fails, but they're the wrong
+    # ValidationError...So catch this ValidationError so we can raise DRF's ValidationError.
+    try:
+        email_validator(email)
+    except ValidationError as ex:
+        raise EmailNotValidError(email, ex.message)
+
+    return True
 
 
 def save_app_password(label, password):

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -27,9 +27,9 @@ from thunderbird_accounts.mail.exceptions import (
     AccessTokenNotFound,
     AccountNotFoundError,
     DomainAlreadyExistsError,
-    DomainNotFoundError,
+    DomainNotFoundError, EmailNotValidError,
 )
-from thunderbird_accounts.mail.utils import filter_app_passwords, is_address_taken
+from thunderbird_accounts.mail.utils import filter_app_passwords, is_address_taken, validate_email
 
 from thunderbird_accounts.mail.models import Account, Email, Domain
 from thunderbird_accounts.mail import utils
@@ -319,6 +319,12 @@ def add_email_alias(request: HttpRequest):
         email_alias = ''
 
     full_email_alias = f'{email_alias}@{domain}'
+
+    if not is_catch_all:
+        try:
+            validate_email(full_email_alias)
+        except EmailNotValidError as ex:
+            return JsonResponse({'success': False, 'error': ex.error_message}, status=400)
 
     if (not is_catch_all and not email_alias) or not domain:
         return JsonResponse({'success': False, 'error': _('Email alias and domain are required.')}, status=400)


### PR DESCRIPTION
Fixes #85 

Technically email aliases are limited to like 40 characters via frontend validation but we can sort that out later. 