### PR TITLE
Enforce one acceptance legal response per current docs

### DIFF
--- a/src/thunderbird_accounts/core/tests/test_views.py
+++ b/src/thunderbird_accounts/core/tests/test_views.py
@@ -610,6 +610,36 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context['needs_tos_acceptance'])
 
+    def test_needs_tos_acceptance_false_with_duplicate_acceptances(self):
+        """Duplicate acceptance responses should not cause the check to fail."""
+        tos = LegalDocument.objects.create(
+            document_type=LegalDocument.DocumentType.TOS,
+            version='2.0',
+            is_current=True,
+            content_path='tos/v2.0',
+        )
+        privacy = LegalDocument.objects.create(
+            document_type=LegalDocument.DocumentType.PRIVACY,
+            version='2.0',
+            is_current=True,
+            content_path='privacy/v2.0',
+        )
+
+        # Force duplicate responses
+        LegalDocumentResponse.objects.create(
+            user=self.user, document=tos, action=LegalDocumentResponse.Action.ACCEPTED,
+        )
+        LegalDocumentResponse.objects.create(
+            user=self.user, document=tos, action=LegalDocumentResponse.Action.ACCEPTED,
+        )
+        LegalDocumentResponse.objects.create(
+            user=self.user, document=privacy, action=LegalDocumentResponse.Action.ACCEPTED,
+        )
+
+        response = self._login_and_get_home()
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['needs_tos_acceptance'])
+
     def test_needs_tos_acceptance_ignores_non_current_docs(self):
         LegalDocument.objects.create(
             document_type=LegalDocument.DocumentType.TOS,

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -121,7 +121,7 @@ def home(request: HttpRequest):
             is_current=True,
             responses__user=request.user,
             responses__action=LegalDocumentResponse.Action.ACCEPTED,
-        ).count()
+        ).distinct().count()
         needs_tos_acceptance = legal_doc_count != accepted_current_doc_count
 
     form_data = request.session.get('form_data')

--- a/src/thunderbird_accounts/legal/tests/test_views.py
+++ b/src/thunderbird_accounts/legal/tests/test_views.py
@@ -289,7 +289,8 @@ class AcceptLegalDocsTestCase(LegalDocCleanSlateTestCase):
             2,
         )
 
-    def test_duplicate_decline_does_not_create_new_responses(self):
+    def test_decline_still_creates_duplicate_responses(self):
+        """Decline responses are always recorded for audit purposes."""
         oidc_force_login(self.client, self.user)
 
         # Give user an active subscription so decline doesn't delete user
@@ -315,7 +316,7 @@ class AcceptLegalDocsTestCase(LegalDocCleanSlateTestCase):
             LegalDocumentResponse.objects.filter(
                 user=self.user, action=LegalDocumentResponse.Action.DECLINED
             ).count(),
-            1,
+            2,
         )
 
     def test_rejects_non_post_methods(self):

--- a/src/thunderbird_accounts/legal/tests/test_views.py
+++ b/src/thunderbird_accounts/legal/tests/test_views.py
@@ -254,6 +254,70 @@ class AcceptLegalDocsTestCase(LegalDocCleanSlateTestCase):
         resp = LegalDocumentResponse.objects.get(user=self.user)
         self.assertEqual(resp.source_context, '')
 
+    def test_duplicate_accept_does_not_create_new_responses(self):
+        oidc_force_login(self.client, self.user)
+
+        LegalDocument.objects.create(
+            document_type=LegalDocument.DocumentType.TOS,
+            version='2.0',
+            is_current=True,
+            content_path='tos/v2.0',
+        )
+        LegalDocument.objects.create(
+            document_type=LegalDocument.DocumentType.PRIVACY,
+            version='2.0',
+            is_current=True,
+            content_path='privacy/v2.0',
+        )
+
+        payload = json.dumps({'source_context': 'sign-up'})
+
+        response1 = self.client.post(self.url, data=payload, content_type='application/json')
+        self.assertEqual(response1.status_code, 200)
+        data1 = json.loads(response1.content)
+        self.assertEqual(len(data1['responses']), 2)
+
+        response2 = self.client.post(self.url, data=payload, content_type='application/json')
+        self.assertEqual(response2.status_code, 200)
+        data2 = json.loads(response2.content)
+        self.assertEqual(len(data2['responses']), 0)
+
+        self.assertEqual(
+            LegalDocumentResponse.objects.filter(
+                user=self.user, action=LegalDocumentResponse.Action.ACCEPTED
+            ).count(),
+            2,
+        )
+
+    def test_duplicate_decline_does_not_create_new_responses(self):
+        oidc_force_login(self.client, self.user)
+
+        # Give user an active subscription so decline doesn't delete user
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
+
+        LegalDocument.objects.create(
+            document_type=LegalDocument.DocumentType.TOS,
+            version='2.0',
+            is_current=True,
+            content_path='tos/v2.0',
+        )
+
+        payload = json.dumps({'source_context': 'dashboard'})
+        decline_url = self.url.replace('accept', 'decline')
+
+        response1 = self.client.post(decline_url, data=payload, content_type='application/json')
+        self.assertEqual(response1.status_code, 200)
+
+        response2 = self.client.post(decline_url, data=payload, content_type='application/json')
+        self.assertEqual(response2.status_code, 200)
+
+        self.assertEqual(
+            LegalDocumentResponse.objects.filter(
+                user=self.user, action=LegalDocumentResponse.Action.DECLINED
+            ).count(),
+            1,
+        )
+
     def test_rejects_non_post_methods(self):
         oidc_force_login(self.client, self.user)
         response = self.client.get(self.url)

--- a/src/thunderbird_accounts/legal/views.py
+++ b/src/thunderbird_accounts/legal/views.py
@@ -55,8 +55,18 @@ def _record_response(request, action: str) -> JsonResponse:
 
     current_docs = LegalDocument.objects.filter(is_current=True)
 
+    already_responded_ids = set(
+        LegalDocumentResponse.objects.filter(
+            user=request.user,
+            document__in=current_docs,
+            action=action,
+        ).values_list('document_id', flat=True)
+    )
+
     created = []
     for doc in current_docs:
+        if doc.pk in already_responded_ids:
+            continue
         response = LegalDocumentResponse.objects.create(
             user=request.user,
             document=doc,

--- a/src/thunderbird_accounts/legal/views.py
+++ b/src/thunderbird_accounts/legal/views.py
@@ -49,23 +49,30 @@ def _read_legal_content(content_path: str, locale: str) -> str:
 
 
 def _record_response(request, action: str) -> JsonResponse:
-    """Record an accept or decline response for all current legal documents."""
+    """Record an accept or decline response for all current legal documents.
+
+    For acceptance, skips documents that the user has already accepted
+    but we still want to record the decline action as many times as they declined.
+    """
     data = json.loads(request.body)
     source_context = data.get('source_context', '')
 
     current_docs = LegalDocument.objects.filter(is_current=True)
 
-    already_responded_ids = set(
-        LegalDocumentResponse.objects.filter(
-            user=request.user,
-            document__in=current_docs,
-            action=action,
-        ).values_list('document_id', flat=True)
-    )
+    if action == LegalDocumentResponse.Action.ACCEPTED:
+        already_accepted_ids = set(
+            LegalDocumentResponse.objects.filter(
+                user=request.user,
+                document__in=current_docs,
+                action=LegalDocumentResponse.Action.ACCEPTED,
+            ).values_list('document_id', flat=True)
+        )
+    else:
+        already_accepted_ids = set()
 
     created = []
     for doc in current_docs:
-        if doc.pk in already_responded_ids:
+        if doc.pk in already_accepted_ids:
             continue
         response = LegalDocumentResponse.objects.create(
             user=request.user,


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- The check for legal document acceptance now has a `.distinct()` to allow for folks with duplicated acceptance records to pass the check successfully.
- We are now preventing duplicated _acceptance_ of legal docs but we still allow for duplicated _declined_ responses for audit purposes as it might be important to record that.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We were assuming that there would only be one acceptance possible per current docs so in the check for legal acceptance docs we were comparing equal amounts of current docs with accepted docs. That was wrong since it was technically possible for accepting the same document multiple times.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/776