### PR TITLE
Add Android mobile to nightly tests

### DIFF
--- a/.github/workflows/e2e-mobile-nightly-android.yml
+++ b/.github/workflows/e2e-mobile-nightly-android.yml
@@ -1,0 +1,56 @@
+name: e2e-mobile-nightly-android
+
+concurrency:
+  group: e2e-mobile-nightly-android
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # run every day at 3:30am UTC (10:30PM EST)
+    - cron:  '30 3 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read    # This is required for actions/checkout
+
+jobs:
+  mobile-nightly-android:
+    name: prod-mobile-nightly-android
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    env:
+      ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
+      ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'test/e2e/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd ./test/e2e
+          npm install
+
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: 'Thunderbird Accounts'
+          build-name: 'TB Accounts Nightly Tests (Mobile Android): BUILD_INFO'
+
+      - name: Prod E2E Tests on Mobile Android
+        # don't send GHA failure email if any of the E2E tests fail, can be annoying (I check the jobs each day in BrowserStack)
+        continue-on-error: true
+        run: |
+          cd ./test/e2e
+          cp .env.prod.example .env
+          npm run prod-nightly-tests-mobile-browserstack-android-chrome

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -96,6 +96,18 @@ If you don't want to or cannot setup the backend for Paddle you can skip the Pad
 npm run e2e-test -- --grep-invert @paddle
 ```
 
+## Running on a Local Playwright Emulated Mobile Browser View
+
+You can run the E2E tests on your local machine on emulated mobile browser views provided by Playwright (as installed above). Note: This is not a real device emulator, it just uses a local plawyright browser and sets the browser screen size to match a mobile device, etc. More info about mobile emulation [is here](https://playwright.dev/docs/emulation).
+
+To run the E2E tests on an emulated Google Pixel 7 mobile browser view (still in `test/e2e`):
+
+```bash
+npx playwright test --grep e2e-mobile-suite --project=Google-Pixel-7-View --headed
+```
+
+Note that for project you can use any of the project/browser names as listed in the [playwright.config.ts](./playwright.config.ts) file (but the browser must be installed on your local machine).
+
 ## Running the E2E tests against the stage environmnent
 
 `Prerequisite`: When running the tests on the stage env, the TB Accounts test account must have a Thundermail email address already set up.
@@ -163,6 +175,12 @@ To run the E2E tests on BrowserStack (still in `test/e2e`):
 
 ```bash
 npm run e2e-test-browserstack-desktop-firefox
+```
+
+Or on mobile:
+
+```bash
+npm run e2e-tests-mobile-browserstack-android-chrome
 ```
 
 After the tests finish in your local console you'll see a link to the BrowserStack test session; when signed into your BrowserStack account you'll be able to use that link to see the test session results including video playback.

--- a/test/e2e/browserstack-desktop.yml
+++ b/test/e2e/browserstack-desktop.yml
@@ -68,7 +68,7 @@ debug: false # <boolean> # Set to true if you need screenshots for every seleniu
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
 consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
-browserstack.playwrightVersion: 1.55.0 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
+browserstack.playwrightVersion: 1.59.1 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/test/e2e/browserstack-mobile-nightly.yml
+++ b/test/e2e/browserstack-mobile-nightly.yml
@@ -11,7 +11,7 @@
 # Set 'projectName' to the name of your project. Example, Marketing Website
 projectName: Thunderbird Accounts
 # Set `buildName` as the name of the job / testsuite being run
-buildName: TB Accounts E2E Tests
+buildName: Nightly TB Accounts E2E Tests (Mobile)
 # `buildIdentifier` is a unique id to differentiate every execution that gets appended to
 # buildName. Choose your buildIdentifier format from the available expressions:
 # ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
@@ -23,43 +23,25 @@ buildIdentifier: '${DATE_TIME}'
 # Platforms (Browsers / Devices to test)
 # =======================================
 # Platforms object contains all the browser / device combinations you want to test on.
-# Entire list available here -> (https://www.browserstack.com/list-of-browsers-and-platforms/automate)
+# For browser/os versions compatible with our playwright version see https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
 platforms:
-  - os: OS X
-    osVersion: Sequoia
-    browserName: playwright-firefox
-    browserVersion: latest
+  - browserName: chrome
+    osVersion: 16.0
+    deviceName: Google Pixel 10
     playwrightConfigOptions:
-      name: Firefox-OSX
-      setup:
-      - name: 'setup_firefox_auth'
-        testMatch: 'auth.desktop.setup.ts'
-      use:
-        storageState: 'test-results/.auth/user.json'
+      name: android-chrome
+    chrome:
+      chromeOptions:
+        prefs:
+          credentials_enable_service: false
+        profile:
+          password_manager_enabled: false
 
-  - os: OS X
-    osVersion: Sequoia
-    browserName: playwright-chromium
-    browserVersion: latest
+  - browserName: safari
+    osVersion: 26
+    deviceName: iPhone 17
     playwrightConfigOptions:
-      name: Chromium-OSX
-      setup:
-      - name: 'setup_chrome_auth'
-        testMatch: 'auth.desktop.setup.ts'
-      use:
-        storageState: 'test-results/.auth/user.json'
-
-  - os: OS X
-    osVersion: Sequoia
-    browserName: playwright-webkit
-    browserVersion: 18.5
-    playwrightConfigOptions:
-      name: Safari-OSX
-      setup: 
-      - name: 'setup_webkit'
-        testMatch: 'auth.desktop.setup.ts'
-      use:
-        storageState: 'test-results/.auth/user.json'
+      name: ios-safari
 
 # =======================
 # Parallels per Platform
@@ -92,7 +74,12 @@ debug: false # <boolean> # Set to true if you need screenshots for every seleniu
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
 consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
-browserstack.playwrightVersion: 1.59.1 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
+idleTimeout: 500 # seeing if this helps rid BROWSERSTACK_IDLE_TIMEOUTs on ios
+# the e2e tests use the same node.js project so the playwright version dependecy must work on both desktop
+# and mobile browsers; and therefore must be the same in all of our browserstack-*.yml config files
+# for playwright ver we need one compatible with our desktop and mobile browsers, see:
+# https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
+browserstack.playwrightVersion: 1.59.1 # must match ver in package.json
 browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs

--- a/test/e2e/browserstack-mobile.yml
+++ b/test/e2e/browserstack-mobile.yml
@@ -11,7 +11,7 @@
 # Set 'projectName' to the name of your project. Example, Marketing Website
 projectName: Thunderbird Accounts
 # Set `buildName` as the name of the job / testsuite being run
-buildName: TB Accounts E2E Tests
+buildName: TB Accounts E2E Tests (Mobile)
 # `buildIdentifier` is a unique id to differentiate every execution that gets appended to
 # buildName. Choose your buildIdentifier format from the available expressions:
 # ${BUILD_NUMBER} (Default): Generates an incremental counter with every execution
@@ -23,44 +23,26 @@ buildIdentifier: '${DATE_TIME}'
 # Platforms (Browsers / Devices to test)
 # =======================================
 # Platforms object contains all the browser / device combinations you want to test on.
-# Entire list available here -> (https://www.browserstack.com/list-of-browsers-and-platforms/automate)
+# For browser/os versions compatible with our playwright version see https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
 platforms:
-  - os: OS X
-    osVersion: Sequoia
-    browserName: playwright-firefox
-    browserVersion: latest
+  - browserName: chrome
+    osVersion: 16.0
+    deviceName: Google Pixel 10
     playwrightConfigOptions:
-      name: Firefox-OSX
-      setup:
-      - name: 'setup_firefox_auth'
-        testMatch: 'auth.desktop.setup.ts'
-      use:
-        storageState: 'test-results/.auth/user.json'
+      name: android-chrome
+    chrome:
+      chromeOptions:
+        prefs:
+          credentials_enable_service: false
+        profile:
+          password_manager_enabled: false
 
-  - os: OS X
-    osVersion: Sequoia
-    browserName: playwright-chromium
-    browserVersion: latest
+  - browserName: safari
+    osVersion: 26
+    deviceName: iPhone 17
     playwrightConfigOptions:
-      name: Chromium-OSX
-      setup:
-      - name: 'setup_chrome_auth'
-        testMatch: 'auth.desktop.setup.ts'
-      use:
-        storageState: 'test-results/.auth/user.json'
-
-  - os: OS X
-    osVersion: Sequoia
-    browserName: playwright-webkit
-    browserVersion: 18.5
-    playwrightConfigOptions:
-      name: Safari-OSX
-      setup: 
-      - name: 'setup_webkit'
-        testMatch: 'auth.desktop.setup.ts'
-      use:
-        storageState: 'test-results/.auth/user.json'
-
+      name: ios-safari
+  
 # =======================
 # Parallels per Platform
 # =======================
@@ -92,8 +74,13 @@ debug: false # <boolean> # Set to true if you need screenshots for every seleniu
 networkLogs: false # <boolean> Set to true to enable HAR logs capturing; off as may contain sensitive info like login API requests
 consoleLogs: info # <string> Remote browser's console debug levels to be printed (`disable`, `errors`, `warnings`, `info`, or `verbose`)
 framework: playwright
-browserstack.playwrightVersion: 1.59.1 # must match our client playwright version in package.json; this is the latest supported in BrowserStack
-browserstack.playwrightLogs: false # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
+idleTimeout: 500 # seeing if this helps rid BROWSERSTACK_IDLE_TIMEOUTs on ios
+# the e2e tests use the same node.js project so the playwright version dependecy must work on both desktop
+# and mobile browsers; and therefore must be the same in all of our browserstack-*.yml config files
+# for playwright ver we need one compatible with our desktop and mobile browsers, see:
+# https://www.browserstack.com/docs/automate/playwright/browsers-and-os?fw-lang=nodejs
+browserstack.playwrightVersion: 1.59.1 # must match ver in package.json
+browserstack.playwrightLogs: true # disable playwright logs appearing on browserstack builds as may contain sensitive info like credentials
 # CUSTOM_TAG_<INT>: # <string> (Default: parent folder name of the test file) Custom tag for your test suite
 browserstack.maskBasicAuth: true # mask username and passwords from browserstack session logs
 browserstack.maskCommands: sendType, sendPress, setHTTPCredentials, setStorageState, setWebAuthnCredentials # prevent sensitive info appearing in browserstack session logs

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -16,6 +16,8 @@ export const PRIMARY_THUNDERMAIL_EMAIL = String(process.env.PRIMARY_THUNDERMAIL_
 // playwright test tags
 export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
 export const PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY = '@e2e-prod-desktop-nightly';
+export const PLAYWRIGHT_TAG_E2E_SUITE_MOBILE = '@e2e-mobile-suite';
+export const PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY = '@e2e-prod-mobile-nightly';
 
 // timeouts
 export const TIMEOUT_2_SECONDS = 2000;

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "1.56.1",
-        "@types/node": "^22.10.1",
-        "browserstack-node-sdk": "^1.52.1",
-        "dotenv": "^16.3.1",
+        "@playwright/test": "1.59.1",
+        "@types/node": "^24.10.1",
+        "browserstack-node-sdk": "1.52.3",
+        "dotenv": "^17.2.1",
         "form-data": ">=4.0.4",
         "tmp": ">=0.2.4"
       }
@@ -260,6 +260,23 @@
         "ws": "^8.18.2"
       }
     },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@open-draft/until": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
@@ -317,13 +334,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.1"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -557,13 +574,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
-      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -1298,9 +1315,9 @@
       }
     },
     "node_modules/browserstack-node-sdk": {
-      "version": "1.53.5",
-      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.53.5.tgz",
-      "integrity": "sha512-JmJkT0EwjtFsTlHFhyAq2+TqZD1oE3Zdfo1OoilaTz1LNwEhzCuNFqrmJl0yE19MKoRyCUwuqilVOQZp3UtmhA==",
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/browserstack-node-sdk/-/browserstack-node-sdk-1.52.3.tgz",
+      "integrity": "sha512-ypdpBSL8ZG39ZhQV9zOJOTfG5p7WQcxx08e10rTLeoXB33HH8ot/hkZlo1/ObSvmzwnWrIj/57tjgAnEZDZPhQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -1358,6 +1375,19 @@
         "browserstack-cli": "src/bin/runner.js",
         "browserstack-node-sdk": "src/bin/runner.js",
         "setup": "src/bin/setup.js"
+      }
+    },
+    "node_modules/browserstack-node-sdk/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/buffer": {
@@ -2230,9 +2260,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4638,13 +4668,13 @@
       "license": "MIT"
     },
     "node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4657,9 +4687,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5680,9 +5710,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -7,9 +7,13 @@
     "e2e-test-headed": "npx playwright test --grep e2e-suite --project=firefox --headed",
     "e2e-test-debug": "npx playwright test --grep e2e-suite --project=firefox --headed --ui",
     "e2e-test-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-suite --project=Firefox-OSX --browserstack.buildName 'TB Accounts E2E Tests Firefox Desktop' --browserstack.config 'browserstack-desktop.yml'",
+    "e2e-tests-mobile-browserstack-android-chrome": "npx browserstack-node-sdk playwright test --grep e2e-mobile-suite --project=android-chrome --browserstack.buildName 'TB Accounts E2E Tests Android Chrome' --browserstack.config 'browserstack-mobile.yml'",
+    "e2e-tests-mobile-browserstack-ios-safari": "npx browserstack-node-sdk playwright test --grep e2e-mobile-suite --project=ios-safari --browserstack.buildName 'TB Accounts E2E Tests iOS Safari' --browserstack.config 'browserstack-mobile.yml'",
     "prod-nightly-tests-browserstack-desktop-firefox": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Firefox-OSX --browserstack.buildName 'TB Accounts Nightly Tests Firefox Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
     "prod-nightly-tests-browserstack-desktop-chromium": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Chromium-OSX --browserstack.buildName 'TB Accounts Nightly Tests Chromium Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
     "prod-nightly-tests-browserstack-desktop-safari": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Safari-OSX --browserstack.buildName 'TB Accounts Nightly Tests Safari Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
+    "prod-nightly-tests-mobile-browserstack-android-chrome": "npx browserstack-node-sdk playwright test --grep prod-mobile-nightly --project=android-chrome --browserstack.buildName 'TB Accounts Nightly Tests Android Chrome' --browserstack.config 'browserstack-mobile-nightly.yml'",
+    "prod-nightly-tests-mobile-browserstack-ios-safari": "npx browserstack-node-sdk playwright test --grep prod-mobile-nightly --project=ios-safari --browserstack.buildName 'TB Accounts Nightly Tests iOS Safari' --browserstack.config 'browserstack-mobile-nightly.yml'",
     "postinstall": "npm update browserstack-node-sdk"
   },
   "keywords": [],
@@ -17,10 +21,10 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "1.56.1",
-    "@types/node": "^22.10.1",
-    "browserstack-node-sdk": "^1.52.1",
-    "dotenv": "^16.3.1",
+    "@playwright/test": "1.59.1",
+    "@types/node": "^24.10.1",
+    "browserstack-node-sdk": "1.52.3",
+    "dotenv": "^17.2.1",
     "form-data": ">=4.0.4",
     "tmp": ">=0.2.4"
   }

--- a/test/e2e/pages/tb-accts-signup-page.ts
+++ b/test/e2e/pages/tb-accts-signup-page.ts
@@ -4,7 +4,7 @@ import { waitForVueApp } from '../utils/utils';
 
 export class TbAcctsSignUpPage {
   readonly page: Page;
-
+  readonly testPlatform: String;
   readonly stepId: Locator;
   readonly formTitle: Locator;
   readonly formSubtitle: Locator;
@@ -19,8 +19,9 @@ export class TbAcctsSignUpPage {
   readonly zoneInfoInput: Locator;
   readonly submitButton: Locator;
 
-  constructor(page: Page) {
+  constructor(page: Page, testPlatform: string = 'desktop') {
     this.page = page;
+    this.testPlatform = testPlatform;
     this.stepId = this.page.getByTestId('step-id');
     this.formTitle = this.page.getByTestId('title');
     this.formSubtitle = this.page.getByTestId('subtitle');
@@ -51,7 +52,10 @@ export class TbAcctsSignUpPage {
    * This relies on the locators being lazy loaded.
    */
   async fillForm(username: string, password?: string, passwordConfirm?: string, verificationEmail?: string) {
-    await expect(this.stepId).toHaveValue('step-username');
+    // locator.toHaveValue is not supported in iOS BrowserStack so must get value then verify it
+    var stepValue = await this.stepId.inputValue();
+    expect(stepValue).toBe('step-username');
+
     await this.userNameInput?.fill(username);
     await this.submitForm();
 
@@ -59,7 +63,11 @@ export class TbAcctsSignUpPage {
       return;
     }
     
-    await expect(this.stepId).toHaveValue('step-password');
+    // we expect to be on the next step; need time for the next page/step to load (will timeout if fails)
+    await expect.poll(async () => {
+      return await this.stepId.inputValue();
+    }).toBe('step-password');
+
     await this.passwordInput?.fill(password);
     await this.passwordConfirmInput?.fill(passwordConfirm);
     await this.submitForm();
@@ -68,11 +76,20 @@ export class TbAcctsSignUpPage {
       return;
     }
 
-    await expect(this.stepId).toHaveValue('step-verify-email');
+    // we expect to be on the next step; need time for the next page/step to load (will timeout if fails)
+    await expect.poll(async () => {
+      return await this.stepId.inputValue();
+    }).toBe('step-verify-email');
+
     await this.verificationEmailInput?.fill(verificationEmail);
   }
 
-  async submitForm() {
-    await this.submitButton.click();
+  async submitForm() { 
+    // when clicking on android it won't click it unless we force it; but force doesn't work on ios
+    if (this.testPlatform.includes('android')) { 
+      await this.submitButton.click({ force: true, clickCount: 1 });
+    } else {
+      await this.submitButton.click();
+    }
   }
 }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -99,6 +99,16 @@ export default defineConfig({
       },
       dependencies: ['desktop-setup'],
     },
+  
+      /* Test against mobile viewports. */
+    {
+      name: 'Google-Pixel-7-View',
+      use: {
+        ...devices['Pixel 7'],
+        screenshot: 'only-on-failure',
+       },
+    },
+    // no dependency as mobile browsers don't support loading auth state so must sign-in for each test
   ],
 
   /* Run your local dev server before starting the tests */

--- a/test/e2e/tests/desktop/auth.desktop.setup.ts
+++ b/test/e2e/tests/desktop/auth.desktop.setup.ts
@@ -2,11 +2,11 @@ import { test as setup } from '@playwright/test';
 
 import path from 'path';
 
-import { navigateToAccountsHubAndSignIn } from '../utils/utils';
+import { navigateToAccountsHubAndSignIn } from '../../utils/utils';
 
 
 const fs = require('fs');
-const directoryPath = path.join(__dirname, '../test-results/.auth');
+const directoryPath = path.join(__dirname, '../../test-results/.auth');
 
 // when use storageState in browserstack yml, browserstack requires the file to exist already even on the
 // first time the auth-setup step is run; so must create an empty user.json file here
@@ -21,7 +21,7 @@ try {
 }
 
 // We write it here so it is blown away and re-created at the start of every test run; and is in .gitignore
-const authFile = path.join(__dirname, '../test-results/.auth/user.json');
+const authFile = path.join(__dirname, '../../test-results/.auth/user.json');
 
 setup('desktop browser authenticate', async ({ page }) => {
   console.log('inside authenticate setup, about to call navigate and sign in');

--- a/test/e2e/tests/desktop/contact.spec.ts
+++ b/test/e2e/tests/desktop/contact.spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
-import { ContactPage } from '../pages/contact-page';
-import { ensureWeAreSignedIn } from '../utils/utils';
+import { ContactPage } from '../../pages/contact-page';
+import { ensureWeAreSignedIn } from '../../utils/utils';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE,
@@ -12,7 +12,7 @@ import {
   TIMEOUT_2_SECONDS,
   TIMEOUT_5_SECONDS,
   TIMEOUT_30_SECONDS,
-} from '../const/constants';
+} from '../../const/constants';
 
 let contactPage: ContactPage;
 
@@ -136,7 +136,7 @@ test.beforeEach(async ({ page }) => {
   await ensureWeAreSignedIn(page);
 });
 
-test.describe('contact support form', {
+test.describe('contact support form on desktop browser', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY],
 }, () => {
   test('contact form displayed correctly when signed in', async ({ page }) => {
@@ -226,7 +226,7 @@ test.describe('contact support form', {
     await contactPage.emailInput.fill('not-on-allow-list@example.com');
 
     await expect(contactPage.allowListWarning).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
-    await expect(contactPage.joinWaitlistLink).toHaveAttribute('href', TB_PRO_WAIT_LIST_URL);
+    await expect(contactPage.joinWaitlistLink).toContainText('waitlist');
     await expect(contactPage.submitButton).toBeEnabled();
   });
 
@@ -298,7 +298,7 @@ test.describe('contact support form', {
     );
 
     // upload a test file
-    const testFilePath = path.join(__dirname, '../test-files/test-attachment.txt');
+    const testFilePath = path.join(__dirname, '../../test-files/test-attachment.txt');
     await contactPage.uploadFile(testFilePath);
 
     // submit the form
@@ -312,7 +312,7 @@ test.describe('contact support form', {
     // go to the contact / submit an issue form and wait for it to load
     await contactPage.navigateToContactPage();
     // Upload a test file
-    const testFilePath = path.join(__dirname, '../test-files/test-attachment.txt');
+    const testFilePath = path.join(__dirname, '../../test-files/test-attachment.txt');
     await contactPage.uploadFile(testFilePath);
 
     // Check that the file appears in the attachment list

--- a/test/e2e/tests/desktop/sign-up.spec.ts
+++ b/test/e2e/tests/desktop/sign-up.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from '@playwright/test';
-import { TbAcctsSignUpPage } from '../pages/tb-accts-signup-page';
-import { isAllowListEnabled, waitForVueApp } from '../utils/utils';
+import { TbAcctsSignUpPage } from '../../pages/tb-accts-signup-page';
+import { isAllowListEnabled, waitForVueApp } from '../../utils/utils';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE,
   PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY,
   ACCTS_SIGN_UP_URL,
   TB_PRO_WAIT_LIST_URL,
-} from '../const/constants';
+} from '../../const/constants';
 
 let signUpPage: TbAcctsSignUpPage;
 
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
   await signUpPage.navigateToPage();
 });
 
-test.describe('sign up form', {
+test.describe('sign up form on desktop browser', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY],
 }, () => {
   test('form successfully submits but is not on allow list', async ({ page }) => {
@@ -34,7 +34,7 @@ test.describe('sign up form', {
     await signUpPage.fillForm(testUsername, testPassword, testPassword, testEmail);
     await signUpPage.submitForm();
 
-    // tb.pro may insert a locale prefix (e.g. /en-US/waitlist/) when redirecting.
+    // tb.pro may insert a locale prefix (e.g. /en-US/waitlist/) when redirecting
     await page.waitForLoadState('domcontentloaded');
     const waitListOrigin = new URL(TB_PRO_WAIT_LIST_URL).origin;
     await page.waitForURL(
@@ -52,9 +52,7 @@ test.describe('sign up form', {
     await page.goto(`${ACCTS_SIGN_UP_URL}?email=${verificationEmail}`);
     await waitForVueApp(page);
 
-
     await signUpPage.fillForm(testUsername, testPassword, testPassword);
-    await signUpPage.submitForm();
 
     expect(signUpPage.verificationEmailInput).toBeTruthy();
     await expect(signUpPage.verificationEmailInput).toHaveValue(verificationEmail);

--- a/test/e2e/tests/mobile/contact.spec.ts
+++ b/test/e2e/tests/mobile/contact.spec.ts
@@ -1,0 +1,338 @@
+import path from 'path';
+import { test, expect } from '@playwright/test';
+import { ContactPage } from '../../pages/contact-page';
+import { navigateToAccountsHubAndSignIn } from '../../utils/utils';
+
+import {
+  PLAYWRIGHT_TAG_E2E_SUITE_MOBILE,
+  PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY,
+  ACCTS_OIDC_EMAIL,
+  PRIMARY_THUNDERMAIL_EMAIL,
+  TIMEOUT_2_SECONDS,
+  TIMEOUT_5_SECONDS,
+  TIMEOUT_30_SECONDS,
+  TB_PRO_WAIT_LIST_URL,
+} from '../../const/constants';
+
+let contactPage: ContactPage;
+
+const MOCK_PRODUCT_VALUE = 'pro_service_thundermail';
+const MOCK_TYPE_VALUE = 'pro_technical';
+const TEST_NAME = 'Automated E2E Test';
+const TEST_SUBJECT = 'Test Subject';
+const TEST_DESC = 'Issue created by automated E2E test'
+
+const verifyFormPostData = async (postData: string | null) => {
+  // verify the data captured in the submit form post is as expected
+  expect(postData).toContain('email');
+  expect(postData).toContain(ACCTS_OIDC_EMAIL);
+  expect(postData).toContain('name');
+  expect(postData).toContain(TEST_NAME);
+  expect(postData).toContain('subject');
+  expect(postData).toContain(TEST_SUBJECT);
+  expect(postData).toContain('Product');
+  expect(postData).toContain(MOCK_PRODUCT_VALUE);
+  expect(postData).toContain('type');
+  expect(postData).toContain(MOCK_TYPE_VALUE);
+  expect(postData).toContain('description');
+  expect(postData).toContain(TEST_DESC);
+};
+
+
+test.beforeEach(async ({ page }) => {
+  contactPage = new ContactPage(page);
+
+  // mock the /contact/fields endpoint to return predictable values for the form
+  await page.route('*/**/contact/fields', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        ticket_fields: [
+          {
+              "id": 1001,
+              "title": "Subject",
+              "description": "",
+              "required": true,
+              "type": "subject"
+          },
+          {
+              "id": 2001,
+              "title": "Description",
+              "description": "Please shared detailed information about your issue or request.",
+              "required": true,
+              "type": "description"
+          },
+          {
+              "id": 3001,
+              "title": "Product",
+              "description": "Which service do you need help with?",
+              "required": true,
+              "type": "tagger",
+              "custom_field_options": [
+                  {
+                      "id": 4001,
+                      "name": "Account Hub",
+                      "value": "pro_service_account_hub"
+                  },
+                  {
+                      "id": 5001,
+                      "name": "Appointment",
+                      "value": "pro_service_appointment"
+                  },
+                  {
+                      "id": 6001,
+                      "name": "Send",
+                      "value": "pro_service_send"
+                  },
+                  {
+                      "id": 7001,
+                      "name": "Thundermail",
+                      "value": MOCK_PRODUCT_VALUE
+                  }
+              ]
+          },
+          {
+              "id": 8001,
+              "title": "Type of request",
+              "description": "Let us know what we can help you with today.",
+              "required": true,
+              "type": "tagger",
+              "custom_field_options": [
+                  {
+                      "id": 9001,
+                      "name": "Accounts & Login \t",
+                      "value": "pro_accounts"
+                  },
+                  {
+                      "id": 10001,
+                      "name": "Provide Feedback or Request Features",
+                      "value": "pro_feedback"
+                  },
+                  {
+                      "id": 11001,
+                      "name": "Payments & Billing \t",
+                      "value": "pro_bililng"
+                  },
+                  {
+                      "id": 12001,
+                      "name": "Technical",
+                      "value": MOCK_TYPE_VALUE
+                  },
+                  {
+                      "id": 13001,
+                      "name": " Something else",
+                      "value": "pro_not_listed"
+                  }
+              ]
+          }
+        ]
+      })
+    });
+  });
+
+  // mobile doesn't support saving browser context so we need to sign-in to TB Accounts for each test
+  await navigateToAccountsHubAndSignIn(page);
+});
+
+test.describe('contact support form on mobile browser', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE_MOBILE, PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY],
+}, () => {
+  test('contact form displayed correctly when signed in', async ({ page }) => {
+    // go to the contact / submit an issue form and wait for it to load
+    await contactPage.navigateToContactPage();
+
+    // we are already signed into TB Accounts; ensure the form shows as expected when signed in
+    await contactPage.verifyFormDisplayed();
+
+    // since we're signed in, email field should be pre-filled with the user's primary email
+    // locator.toHaveValue is not supported in iOS BrowserStack so must get value then verify it
+    //await expect(contactPage.emailInput).toHaveValue(PRIMARY_THUNDERMAIL_EMAIL);
+    const emailValue = await contactPage.emailInput.inputValue();
+    expect(emailValue).toBe(PRIMARY_THUNDERMAIL_EMAIL);
+  });
+
+  test('contact form displayed correctly when not signed in', async ({ page }) => {
+    // clear authentication state for this test
+    await page.context().clearCookies();
+    await page.reload();
+    await page.waitForTimeout(TIMEOUT_5_SECONDS);
+    await contactPage.navigateToContactPage();
+
+    // check that the contact form is visible
+    await contactPage.verifyFormDisplayed();
+
+    // not signed in, so check that email is not pre-filled
+    await expect(contactPage.emailInput).toBeEmpty();
+    await expect(contactPage.nameInput).toBeEmpty();
+  });
+
+  test('able to submit contact form successfully', async ({ page }) => {
+    // go to the contact / submit an issue form and wait for it to load
+    await contactPage.navigateToContactPage();
+
+    // capture the POST /contact/submit and mock the response
+    await page.route('*/**/contact/submit', async (route, request) => {
+      const postData = request.postData();
+      expect(postData).not.toBeNull();
+
+      const contentType = request.headers()['content-type'];
+      expect(contentType).toContain('multipart/form-data');
+
+      // verify that the posted FormData contains the expected fields
+      await verifyFormPostData(postData);
+
+      // send a fake response to the contact submit request
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    // fill out the contact form
+    await contactPage.fillContactForm(
+      ACCTS_OIDC_EMAIL,
+      TEST_NAME,
+      TEST_SUBJECT,
+      MOCK_PRODUCT_VALUE,
+      MOCK_TYPE_VALUE,
+      TEST_DESC,
+    );
+
+    // submit the form, scroll back to top to capture message after submit (for screenshot if test fails)
+    await contactPage.submitForm();
+
+    // check for success message
+    await expect(contactPage.successMessage).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+  });
+
+  test('form validation prevents submission', async ({ page }) => {
+    // go to the contact / submit an issue form and wait for it to load
+    await contactPage.navigateToContactPage();
+    await contactPage.submitForm();
+    await expect(contactPage.successMessage).not.toBeVisible();
+  });
+
+  test('shows waitlist warning when email is not on allow list', async ({ page }) => {
+    await page.route('*/**/api/v1/contact/check-email-is-on-allow-list/', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ is_on_allow_list: false }),
+      });
+    });
+
+    await contactPage.navigateToContactPage();
+
+    // Trigger the debounced allow-list validation.
+    await contactPage.emailInput.fill('not-on-allow-list@example.com');
+
+    await expect(contactPage.allowListWarning).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(contactPage.joinWaitlistLink).toContainText('waitlist');
+    await expect(contactPage.submitButton).toBeEnabled();
+  });
+  
+  test('error handling works correctly', async ({ page }) => {
+    // go to the contact / submit an issue form and wait for it to load
+    await contactPage.navigateToContactPage();
+    // capture the POST /contact/submit and mock an error response
+    await page.route('*/**/contact/submit', async (route, _request) => {
+      // send an error response
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ 
+          success: false,
+          error: 'Failed to submit contact form. Please try again.'
+        }),
+      });
+    });
+
+    // fill out the contact form
+    await contactPage.fillContactForm(
+      ACCTS_OIDC_EMAIL,
+      TEST_NAME,
+      TEST_SUBJECT,
+      MOCK_PRODUCT_VALUE,
+      MOCK_TYPE_VALUE,
+      TEST_DESC,
+    );
+
+    // submit the form
+    await contactPage.submitForm();
+
+    // check for error message
+    await expect(contactPage.errorMessage).toBeVisible();
+  });
+
+  test('able to submit contact form with attachments', async ({ page }) => {
+    // go to the contact / submit an issue form and wait for it to load
+    await contactPage.navigateToContactPage();
+    // capture the POST /contact/submit and mock the response
+    await page.route('*/**/contact/submit', async (route, request) => {
+      const postData = request.postData();
+      expect(postData).not.toBeNull();
+
+      const contentType = request.headers()['content-type'];
+      expect(contentType).toContain('multipart/form-data');
+
+      // verify that the posted FormData contains the expected fields
+      await verifyFormPostData(postData);
+      expect(postData).toContain('attachments');
+      expect(postData).toContain('test-attachment.txt');
+
+      // send a fake response to the contact submit request
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      });
+    });
+
+    // fill out the contact form
+    await contactPage.fillContactForm(
+      ACCTS_OIDC_EMAIL,
+      TEST_NAME,
+      `${TEST_SUBJECT} with File Attachment`,
+      MOCK_PRODUCT_VALUE,
+      MOCK_TYPE_VALUE,
+      `${TEST_DESC} with File Attachment`,
+    );
+
+    // upload a test file
+    const testFilePath = path.join(__dirname, '../../test-files/test-attachment.txt');
+    await contactPage.uploadFile(testFilePath);
+
+    // submit the form
+    await contactPage.submitForm();
+
+    // check for success message
+    await expect(contactPage.successMessage).toBeVisible();
+  });
+
+  test('file upload UI works correctly', async ({ page }) => {
+    // go to the contact / submit an issue form and wait for it to load
+    await contactPage.navigateToContactPage();
+    // Upload a test file
+    const testFilePath = path.join(__dirname, '../../test-files/test-attachment.txt');
+    await contactPage.uploadFile(testFilePath);
+
+    // Check that the file appears in the attachment list
+    await expect(page.getByText('test-attachment.txt')).toBeVisible();
+    await expect(page.getByText('1 file(s) selected. Drag & drop more files here, or click to upload')).toBeVisible();
+
+    // Check that the remove button is present
+    const removeButton = page.locator('.remove-attachment-btn').first();
+    await expect(removeButton).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+
+    // Remove the attachment
+    await removeButton.click();
+    await page.waitForTimeout(TIMEOUT_2_SECONDS);
+
+    // Check that the file is removed from the list
+    await expect(page.getByText('test-attachment.txt')).not.toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(page.getByText('Drag & drop files here, or click to upload')).toBeVisible();
+  });
+});

--- a/test/e2e/tests/mobile/sign-up.spec.ts
+++ b/test/e2e/tests/mobile/sign-up.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { TbAcctsSignUpPage } from '../../pages/tb-accts-signup-page';
+import { isAllowListEnabled, waitForVueApp } from '../../utils/utils';
+
+import {
+  PLAYWRIGHT_TAG_E2E_SUITE_MOBILE,
+  PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY,
+  TB_PRO_WAIT_LIST_URL,
+  ACCTS_SIGN_UP_URL,
+} from '../../const/constants';
+
+let signUpPage: TbAcctsSignUpPage;
+
+test.beforeEach(async ({ page }, testInfo) => {
+  // Remove any authentication cookies before passing it to our page
+  await page.context().clearCookies();
+  // Ensure we're cookieless.
+  expect(await page.context().cookies()).toEqual([])
+
+  signUpPage = new TbAcctsSignUpPage(page, testInfo.project.name);
+  await signUpPage.navigateToPage();
+});
+
+test.describe('sign up form on mobile browser', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE_MOBILE, PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY],
+}, () => {
+  test('form successfully submits but is not on allow list', async ({ page }) => {
+    test.skip(!(await isAllowListEnabled(page)), 'Only enabled if backend\'s .env includes USE_ALLOW_LIST=True');
+    
+    const testUsername: string = crypto.randomUUID().replaceAll('-', '');
+    const testEmail: string = `${testUsername}@example.com`;
+    const testPassword: string = 'this-is-my-password-and-it-is-long';
+
+    await signUpPage.fillForm(testUsername, testPassword, testPassword, testEmail);
+    await signUpPage.submitForm();
+
+    // tb.pro may insert a locale prefix (e.g. /en-US/waitlist/) when redirecting
+    await page.waitForLoadState('domcontentloaded');
+    const waitListOrigin = new URL(TB_PRO_WAIT_LIST_URL).origin;
+    await page.waitForURL(
+      url => url.origin === waitListOrigin
+        && url.pathname.endsWith('/waitlist/')
+        && url.searchParams.get('email') === testEmail,
+    );
+  });
+
+  test('navigating to sign-up with query param pre-fills form', async ({ page }) => {
+    const testUsername: string = crypto.randomUUID().replaceAll('-', '');
+    const testPassword: string = 'this-is-my-password-and-it-is-long';
+
+    const verificationEmail = 'test@example.com';
+    await page.goto(`${ACCTS_SIGN_UP_URL}?email=${verificationEmail}`);
+    await waitForVueApp(page);
+
+    await signUpPage.fillForm(testUsername, testPassword, testPassword);
+    expect(signUpPage.verificationEmailInput).toBeTruthy();
+    
+    // locator.toHaveValue is not supported in iOS BrowserStack so must get value then verify it
+    await expect.poll(async () => {
+      return await signUpPage.verificationEmailInput?.inputValue();
+    }).toBe(verificationEmail);
+  });
+
+  test('step username fails with bad username', async ({ page }) => {
+    // Local part of an email address cannot contain the '@' character.
+    const testUsername: string = 'IM@A@BAD@LOCAL@PART@OF@AN@EMAIL';
+
+    await signUpPage.userNameInput?.fill(testUsername);
+    await signUpPage.submitForm();
+
+    // Make sure we're still on the first step
+    // locator.toHaveValue is not supported in iOS BrowserStack so must get value then verify it
+    await expect.poll(async () => {
+      return await signUpPage.stepId.inputValue();
+    }).toBe('step-username');
+
+    const errorText = page.getByText('This username is not valid. Try another one.');
+    await expect(errorText).toBeVisible();
+  });
+
+  test('step password fails with password length below minimum', async ({ page }) => {
+    const testUsername: string = crypto.randomUUID().replaceAll('-', '');
+    const testPassword: string = 'this-is-my-password-and-it-is-long';
+    const testConfirmPassword: string = 'yay';
+
+    await signUpPage.fillForm(testUsername, testPassword, testConfirmPassword);
+    await signUpPage.submitForm();
+
+    const errorText = page.getByText('12 characters');
+    await expect(errorText).toBeVisible();
+  });
+
+  test('step password fails with password mismatch', async ({ page }) => {
+    const testUsername: string = crypto.randomUUID().replaceAll('-', '');
+    const testPassword: string = 'this-is-my-password-and-it-is-long';
+    const testConfirmPassword: string = 'this-is-my-password-and-it-is-long-tpyo';
+
+    await signUpPage.fillForm(testUsername, testPassword, testConfirmPassword);
+    await signUpPage.submitForm();
+
+    const errorText = page.getByText('Password and confirm password must match.');
+    await expect(errorText).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What changed?

Adding Android mobile devices to the nightly E2E tests job that runs on BrowserStack.

## Why?

To expand the platforms that the nightly tests run on (currently they only run on desktop browsers).

## Limitations and Notes

Scheduled to run nightly via GHA. Added a single GHA workflow file for each platform so that we can easily manually trigger the test job on one single platform if need be.

## Applicable Issues

Fixes #740.

## Screenshots

BrowserStack links running the nightly test jobs (all tests passed):

- [Android Chrome](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Tests+Android+Chrome/19?tab=sessions&testListView=spec) on Google Pixel 10
- [Desktop Firefox](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Firefox+Desktop/101?tab=sessions) (regression test since moved the desktop tests to new location)