### PR TITLE
Restrict some words on sign up

### DIFF
--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -4,7 +4,7 @@ from rest_framework.throttling import UserRateThrottle
 from rest_framework.permissions import AllowAny
 import sentry_sdk
 from thunderbird_accounts.authentication.exceptions import InvalidDomainError, ImportUserError
-from thunderbird_accounts.authentication.utils import is_email_in_allow_list, KeycloakRequiredAction
+from thunderbird_accounts.authentication.utils import is_email_in_allow_list, KeycloakRequiredAction, is_email_reserved
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.request import Request
@@ -64,7 +64,7 @@ def sign_up(request: Request):
         )
 
     # Make sure there's no email alias with this address
-    if is_address_taken(username):
+    if is_address_taken(username) or is_email_reserved(username):
         return Response({'error': generic_email_error, 'type': 'username-in-use'}, status=400)
 
     if not data.get('password'):

--- a/src/thunderbird_accounts/authentication/reserved.py
+++ b/src/thunderbird_accounts/authentication/reserved.py
@@ -1,7 +1,7 @@
 import re
 
 # brand related names, and also help/support
-brands = '(thunderbird|thunderbirdpro|mzla|mozilla|firefox)?'
+brands = '(thunderbird|tbpro|thundermail|thunderbirdpro|mzla|mozilla|firefox)?'
 
 # Brand names plus common tokens
 names_with_brands = [

--- a/src/thunderbird_accounts/authentication/reserved.py
+++ b/src/thunderbird_accounts/authentication/reserved.py
@@ -6,6 +6,7 @@ brands = '(thunderbird|thunderbirdpro|mzla|mozilla|firefox)?'
 # Brand names plus common tokens
 names_with_brands = [
     brands + '?',
+    brands + '[_|-]?admin?',
     brands + '[_|-]?support?',
     brands + '[_|-]?customer[_|-]?support?',
     brands + '[_|-]?help?',

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -97,19 +97,15 @@ class SignUpTestcase(APITestCase):
         resp_data = response.json()
         self.assertEqual(resp_data.get('type'), 'username-in-use', msg=assert_fail_msg)
 
-    def test_user_using_reserved_emails(self, mock_import_user: MagicMock):
-        """Test that we check if a user exists before creating a user"""
-
-        # Set a return value for oidc_id
-        mock_import_user.return_value = 1
-
+    def test_user_using_reserved_emails(self, _mock_import_user: MagicMock):
+        """Test to ensure that a user does not use a reserved username"""
         User(email=self.wait_list[0], username='hello@example.org').save()
 
         # All examples from reserved.py
         for local_part in ['thunderbird_admin', 'admin', 'postmaster', 'root']:
             response = self.client.post(
                 '/api/v1/auth/sign-up/',
-                self.make_sign_up_data(email=self.wait_list[0], partialUsername='thunderbird_admin'),
+                self.make_sign_up_data(email=self.wait_list[0], partialUsername=local_part),
             )
             assert_fail_msg = self.get_messages(response)
 

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -97,6 +97,28 @@ class SignUpTestcase(APITestCase):
         resp_data = response.json()
         self.assertEqual(resp_data.get('type'), 'username-in-use', msg=assert_fail_msg)
 
+    def test_user_using_reserved_emails(self, mock_import_user: MagicMock):
+        """Test that we check if a user exists before creating a user"""
+
+        # Set a return value for oidc_id
+        mock_import_user.return_value = 1
+
+        User(email=self.wait_list[0], username='hello@example.org').save()
+
+        # All examples from reserved.py
+        for local_part in ['thunderbird_admin', 'admin', 'postmaster', 'root']:
+            response = self.client.post(
+                '/api/v1/auth/sign-up/',
+                self.make_sign_up_data(email=self.wait_list[0], partialUsername='thunderbird_admin'),
+            )
+            assert_fail_msg = self.get_messages(response)
+
+            self.assertEqual(response.status_code, 400, msg=assert_fail_msg)
+
+            resp_data = response.json()
+            self.assertEqual(resp_data.get('type'), 'username-in-use', msg=assert_fail_msg)
+
+
     def test_alias_already_exists(self, mock_import_user: MagicMock):
         """Test that we check if a alias exists before creating a user"""
 

--- a/src/thunderbird_accounts/authentication/tests/test_utils.py
+++ b/src/thunderbird_accounts/authentication/tests/test_utils.py
@@ -6,7 +6,7 @@ from thunderbird_accounts.authentication.reserved import is_reserved, servers, s
 
 class IsReservedUnitTests(TestCase):
     def test_brand_names(self):
-        for brand in ['thunderbird', 'mozilla', 'firefox', 'help', 'support', 'mzla']:
+        for brand in ['thunderbird', 'thundermail', 'tbpro', 'mozilla', 'firefox', 'help', 'support', 'mzla']:
             self.assertTrue(is_reserved(brand))
 
     def test_brand_plus_variants(self):

--- a/src/thunderbird_accounts/authentication/utils.py
+++ b/src/thunderbird_accounts/authentication/utils.py
@@ -65,6 +65,9 @@ def is_email_in_allow_list(email: str):
 
 
 def is_email_reserved(email: str):
+    # Retrieve just the local part if we passed an entire email
+    if '@' in email:
+        email = email.split('@')[0]
     return is_reserved(email)
 
 

--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -1,3 +1,4 @@
+from thunderbird_accounts.authentication.utils import is_email_reserved
 from thunderbird_accounts.mail.exceptions import EmailNotValidError
 from thunderbird_accounts.mail.utils import validate_email
 from rest_framework.permissions import AllowAny
@@ -27,6 +28,10 @@ def is_username_available(request: Request):
 
     full_username = f'{username}@{settings.PRIMARY_EMAIL_DOMAIN}'
     username_not_valid_err = _('This username is not valid. Try another one.')
+
+    # Make sure they don't use a reserved word in their email
+    if is_email_reserved(full_username):
+        raise ValidationError(username_not_valid_err)
 
     try:
         validate_email(full_username, username_not_valid_err)

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -208,6 +208,25 @@ class AddEmailAliasTestCase(TestCase):
                 {'success': False, 'error': _('You cannot use this email address.')},
             )
 
+    def test_reserved_with_custom_domain(self):
+        email_alias_url = reverse('add_email_alias')
+        domain = Domain.objects.create(
+            name='customdomain.com',
+            user=self.user,
+            status=Domain.DomainStatus.VERIFIED,
+        )
+
+        with patch('thunderbird_accounts.mail.views.MailClient', Mock()) as mock:
+            instance = Mock()
+            mock.save_email_addresses = instance
+            response = self.client.post(
+                email_alias_url,
+                data={'email-alias': 'admin', 'domain': domain.name},
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(json.loads(response.content.decode()), {'success': True})
+
     def test_already_used_alias(self):
         """Ensure that creating an email alias that is already in-use will error out."""
         email_alias_url = reverse('add_email_alias')

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -209,6 +209,7 @@ class AddEmailAliasTestCase(TestCase):
             )
 
     def test_reserved_with_custom_domain(self):
+        """Ensure that creating an email alias with a reserved word for a custom domain is ok."""
         email_alias_url = reverse('add_email_alias')
         domain = Domain.objects.create(
             name='customdomain.com',

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -329,7 +329,7 @@ def add_email_alias(request: HttpRequest):
     if (not is_catch_all and not email_alias) or not domain:
         return JsonResponse({'success': False, 'error': _('Email alias and domain are required.')}, status=400)
 
-    if (not is_catch_all and is_reserved(email_alias)) or is_address_taken(full_email_alias):
+    if (not is_catch_all and not is_custom_domain and is_reserved(email_alias)) or is_address_taken(full_email_alias):
         return JsonResponse({'success': False, 'error': _('You cannot use this email address.')}, status=403)
 
     if (


### PR DESCRIPTION
Fixes #780 

Further clean up items:
* Normalize http status codes (alias uses 403, sign up uses 400)
* Swap alias to use is_email_reserved  