### PR TITLE
Add recovery_email to User model for Mailchimp integration

### DIFF
--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -40,7 +40,10 @@ def sign_up(request: Request):
     from thunderbird_accounts.mail.utils import is_address_taken
 
     data = request.data
+
+    # This email is the recovery / verification email address at this point
     email = data.get('email')
+
     timezone = data.get('zoneinfo', 'UTC')
     locale = data.get('locale', 'en')
 
@@ -73,7 +76,17 @@ def sign_up(request: Request):
             status=400,
         )
 
-    user = User(username=username, email=email, display_name=username, language=locale, timezone=timezone)
+    # Email gets updated in the middleware's update_user function
+    # So we also save it to the recovery_email field here
+    # src/thunderbird_accounts/authentication/middleware.py#L126
+    user = User(
+        username=username,
+        email=email,
+        recovery_email=email,
+        display_name=username,
+        language=locale,
+        timezone=timezone,
+    )
 
     # Create the user on keycloak's end
     keycloak = KeycloakClient()

--- a/src/thunderbird_accounts/authentication/migrations/0014_user_recovery_email.py
+++ b/src/thunderbird_accounts/authentication/migrations/0014_user_recovery_email.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('authentication', '0013_alter_user_plan_allowlistentry'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='recovery_email',
+            field=models.CharField(help_text='The recovery email associated with this account', max_length=256, null=True),
+        ),
+    ]

--- a/src/thunderbird_accounts/authentication/models.py
+++ b/src/thunderbird_accounts/authentication/models.py
@@ -13,6 +13,7 @@ class User(AbstractUser, BaseModel):
     """
     :param username: The thundermail address, aligns with keycloak's usage of username.
     :param oidc_id: The ID of the connected oidc account
+    :param recovery_email: The recovery email associated with this account
     :param last_used_email: The last used email associated with this account
     :param language: The user's preferred language to view the ui/system emails in
     :param display_name: Display name from oidc profile
@@ -36,6 +37,9 @@ class User(AbstractUser, BaseModel):
     )
 
     oidc_id = models.CharField(max_length=256, null=True, help_text=_("OIDC's UID field"))
+    recovery_email = models.CharField(
+        max_length=256, null=True, help_text=_('The recovery email associated with this account')
+    )
     last_used_email = models.CharField(max_length=256, null=True, help_text=_('The email previously used to login'))
     language = models.CharField(
         max_length=16,

--- a/src/thunderbird_accounts/subscription/tasks.py
+++ b/src/thunderbird_accounts/subscription/tasks.py
@@ -542,7 +542,7 @@ def add_subscriber_to_mailchimp_list(self, user_uuid):
 
     # Loop through the thundermail and recovery email and attempt to update or add a new tag to the mailchimp entry.
     # It's a bit of a bit long and most of that is error catching.
-    for val in [(user.stalwart_primary_email, 'new_user'), (user.email, 'welcome')]:
+    for val in [(user.stalwart_primary_email, 'new_user'), (user.recovery_email, 'welcome')]:
         email, tag = val
         md5_hasher = hashlib.new('md5')
         md5_hasher.update(email.lower().encode())

--- a/src/thunderbird_accounts/subscription/tests/test_tasks.py
+++ b/src/thunderbird_accounts/subscription/tests/test_tasks.py
@@ -1000,7 +1000,9 @@ class AddSubscriberToMailchimpList(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.test_user = User.objects.create_user('test@example.com', 'test@example.org', '1234')
+        self.test_user = User.objects.create_user(
+            'test@example.com', 'test@example.org', '1234', recovery_email='test@example.org'
+        )
         models.Subscription.objects.create(
             paddle_id='pad123',
             status=models.Subscription.StatusValues.ACTIVE.value,
@@ -1046,7 +1048,7 @@ class AddSubscriberToMailchimpList(TestCase):
         self.assertEqual(request_mock.call_count, 4)
 
         # Reverse order because of .pop()
-        email_addresses = [self.test_user.email, self.test_user.stalwart_primary_email]
+        email_addresses = [self.test_user.recovery_email, self.test_user.stalwart_primary_email]
         for i in range(0, 4, 2):
             get_req = request_mock.call_args_list[i]
             update_tag_req = request_mock.call_args_list[i + 1]
@@ -1096,7 +1098,7 @@ class AddSubscriberToMailchimpList(TestCase):
         self.assertEqual(request_mock.call_count, 4)
 
         # Reverse order because of .pop()
-        email_addresses = [self.test_user.email, self.test_user.stalwart_primary_email]
+        email_addresses = [self.test_user.recovery_email, self.test_user.stalwart_primary_email]
         tags = ['welcome', 'new_user']
         for i in range(0, 4, 2):
             get_req = request_mock.call_args_list[i]


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- New migration to add `recovery_email` to `User` model
- Using `User.recovery_email` in the Mailchimp integration for proper tagging

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We recently made it so that the `User.email` field is remapped in Keycloak as the `username` which is the `thundermail.com` address. However, we were relying on that to be the `recovery_email` for the Mailchimp integration.

To avoid confusion between field names, and for solving this integration problem for now, adding a discrete `recovery_email` field in `User` should suffice. In case we want to further remove it, it would be a clean removal

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Solves https://github.com/thunderbird/thunderbird-accounts/issues/792