### PR TITLE
Allow fractional digits for plan pricing

### DIFF
--- a/assets/app/vue/views/DashboardView/utils.ts
+++ b/assets/app/vue/views/DashboardView/utils.ts
@@ -60,12 +60,14 @@ export const formatSubscriptionData = (
     priceInDollars = priceInDollars / 12;
   }
 
+  const fractionDigits = Number.isInteger(priceInDollars) ? 0 : 2;
+  
   // n is not doing a good job in letting us specify the actual currency...so use javascript
   const intlN = new Intl.NumberFormat(i18n.locale.value, {
     style: "currency",
     currency: subscriptionData.currency,
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 0
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits
   });
 
   const formattedPrice = intlN.format(priceInDollars);

--- a/assets/app/vue/views/DashboardView/utils.ts
+++ b/assets/app/vue/views/DashboardView/utils.ts
@@ -61,7 +61,13 @@ export const formatSubscriptionData = (
   }
 
   // n is not doing a good job in letting us specify the actual currency...so use javascript
-  const intlN = new Intl.NumberFormat(i18n.locale.value, { style: "currency", currency: subscriptionData.currency, maximumFractionDigits: 0 });
+  const intlN = new Intl.NumberFormat(i18n.locale.value, {
+    style: "currency",
+    currency: subscriptionData.currency,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 0
+  });
+
   const formattedPrice = intlN.format(priceInDollars);
 
   // Format autoRenewal date if it exists


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Updated the `Intl.NumberFormat` call to allow for m

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

Not showing the fractional values may cause confusion as either flooring, ceiling and truncating the value for the sake of showing a single digit would not be accurate.

## How to test

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

The easiest way to test this without having to tamper with the Paddle sandbox is: when running locally, update the `priceInDollars` variable here `assets/app/vue/views/DashboardView/utils.ts`

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/800

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

[if plan is 104 / month -> 104 / 12 = 8.66667]

<img width="372" height="569" alt="image" src="https://github.com/user-attachments/assets/8902a78e-76a9-4dc2-9508-e5ec2a84b49d" />

[if plan is 96 / month -> 96 / 12 = 8]

<img width="376" height="569" alt="image" src="https://github.com/user-attachments/assets/6cb579a7-eede-445d-b924-17ba2fa06276" />

[if plan is 28.8 / month ->  28.8 / 12 = 2.4 (adds a trailing 0)]

<img width="377" height="574" alt="image" src="https://github.com/user-attachments/assets/792dc855-761a-49a4-b05e-385023a7c7d3" />
