### PR TITLE
Enforce min-length username rule during sign-up flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,13 +248,13 @@ Make sure that the containers are already running.
 To run all tests:
 
 ```shell
-docker compose exec backend uv run python manage.py test
+docker compose exec accounts uv run python manage.py test thunderbird_accounts
 ```
 
 To run tests for a specific module:
 
 ```shell
-docker compose exec backend uv run manage.py test thunderbird_accounts.client.tests
+docker compose exec accounts uv run python manage.py test thunderbird_accounts.mail.tests
 ```
 
 ## Running the E2E tests

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -294,7 +294,9 @@
             "emailSuggestions": "Try one of these:",
             "usernamePlaceholder": "yourname",
             "usernameHelp": "This will become your email. e.g. yourname{domain}",
-            "unknownError": "There was a problem with your username. Please try another one."
+            "unknownError": "There was a problem with your username. Please try another one.",
+            "usernameTooShort": "Username must be at least {minLength} characters.",
+            "usernameTooLong": "Username must be no more than {maxLength} characters."
           },
           "step2": {
             "title": "Set a password",

--- a/assets/app/vue/views/SignUpView/index.vue
+++ b/assets/app/vue/views/SignUpView/index.vue
@@ -81,12 +81,12 @@ export default {
       </template>
     </component>
     <section v-else>
-    <sign-up-layout step-id="step-check-your-mail" :title="$t('views.mail.views.signUp.step4.title')"
-      :subtitle="$t('views.mail.views.signUp.step4.subtitle')" :hide-actions="true" :submit-disabled="false">
-      <template v-slot:notice-bars>
-        <slot name="notice-bars" />
-      </template>
-    </sign-up-layout>
+      <sign-up-layout step-id="step-check-your-mail" :title="$t('views.mail.views.signUp.step4.title')"
+        :subtitle="$t('views.mail.views.signUp.step4.subtitle')" :hide-actions="true" :submit-disabled="false">
+        <template v-slot:notice-bars>
+          <slot name="notice-bars" />
+        </template>
+      </sign-up-layout>
     </section>
   </base-template>
 </template>

--- a/assets/app/vue/views/SignUpView/views/Step1Username/index.vue
+++ b/assets/app/vue/views/SignUpView/views/Step1Username/index.vue
@@ -9,6 +9,9 @@ import { storeToRefs } from 'pinia';
 import { useSignUpFlowStore } from '../../stores/signUpFlowStore';
 import SignUpLayout from '../../components/SignUpLayout.vue';
 
+const USERNAME_MIN_LENGTH = 3;
+const USERNAME_MAX_LENGTH = 150;
+
 const { t } = useI18n();
 const tbProPrimaryDomain = `@${window._page.currentView?.tbProPrimaryDomain}`;
 const loading = ref(false);
@@ -21,8 +24,27 @@ const usernameOk = ref(false);
 const usernameError = ref(null);
 
 const usernameCheckDebounced = useDebounceFn(async () => {
-  const { success, error } = await isUsernameAvailable(username.value);
   loading.value = false;
+
+  const value = username.value ?? '';
+
+  if (value.length < USERNAME_MIN_LENGTH) {
+    usernameOk.value = false;
+    usernameError.value = t('views.mail.views.signUp.step1.usernameTooShort', {
+      minLength: USERNAME_MIN_LENGTH
+    });
+    return;
+  }
+
+  if (value.length > USERNAME_MAX_LENGTH) {
+    usernameOk.value = false;
+    usernameError.value = t('views.mail.views.signUp.step1.usernameTooLong', {
+      maxLength: USERNAME_MAX_LENGTH
+    });
+    return;
+  }
+
+  const { success, error } = await isUsernameAvailable(value);
 
   if (success === true) {
     usernameOk.value = true;
@@ -56,6 +78,14 @@ onMounted(() => {
   if (window._page.currentView?.attributes?.username) {
     username.value = window._page.currentView?.attributes?.username;
   }
+
+  // Validate any pre-filled username (from query param or session storage) since
+  // programmatic assignment doesn't set the input's dirty flag and therefore
+  // skips the browser's built-in minlength/maxlength constraint checks.
+  if (username.value) {
+    loading.value = true;
+    usernameCheckDebounced();
+  }
 });
 
 </script>
@@ -78,6 +108,7 @@ export default {
       data-testid="username-input" 
       name="partialUsername" 
       required
+      minlength="3"
       maxlength="150"
       autocomplete="username" 
       @input="usernameCheckDebounced"

--- a/src/thunderbird_accounts/authentication/models.py
+++ b/src/thunderbird_accounts/authentication/models.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 
 from django.conf import settings
+from django.core.validators import MinLengthValidator
 from django.db import models
 
 from django.contrib.auth.models import AbstractUser
@@ -20,6 +21,7 @@ class User(AbstractUser, BaseModel):
     :param avatar_url: Avatar URL from oidc profile
     :param timezone: The user's timezone
     """
+    USERNAME_MIN_LENGTH = 3
     USERNAME_MAX_LENGTH = 150
 
     class UserLanguageType(models.TextChoices):
@@ -30,7 +32,8 @@ class User(AbstractUser, BaseModel):
         _('username'),
         max_length=USERNAME_MAX_LENGTH,
         unique=True,
-        help_text=_(f'Required. {USERNAME_MAX_LENGTH} characters or fewer.'),
+        help_text=_(f'Required. {USERNAME_MIN_LENGTH}–{USERNAME_MAX_LENGTH} characters.'),
+        validators=[MinLengthValidator(USERNAME_MIN_LENGTH)],
         error_messages={
             'unique': _('A user with that username already exists.'),
         },

--- a/src/thunderbird_accounts/authentication/tests/test_models.py
+++ b/src/thunderbird_accounts/authentication/tests/test_models.py
@@ -12,6 +12,10 @@ class UserUsernameValidatorTestCase(TestCase):
     the validator is actually attached to the field.
     """
 
+    # Fields not relevant to username validation that are nullable without
+    # blank=True — exclude them so full_clean() only validates what we care about.
+    _EXCLUDE = ['password', 'oidc_id', 'recovery_email', 'last_used_email', 'display_name', 'avatar_url']
+
     def _make_user(self, username: str) -> User:
         return User(username=username, email='recovery@example.com')
 
@@ -19,23 +23,23 @@ class UserUsernameValidatorTestCase(TestCase):
         """A username of exactly USERNAME_MIN_LENGTH (3) characters is valid."""
         user = self._make_user('a' * User.USERNAME_MIN_LENGTH)
         # full_clean() runs all field validators; should not raise
-        user.full_clean(exclude=['password'])
+        user.full_clean(exclude=self._EXCLUDE)
 
     def test_username_below_min_length_raises(self):
         """A username shorter than USERNAME_MIN_LENGTH (3) fails validation."""
         user = self._make_user('a' * (User.USERNAME_MIN_LENGTH - 1))
         with self.assertRaises(ValidationError) as ctx:
-            user.full_clean(exclude=['password'])
+            user.full_clean(exclude=self._EXCLUDE)
         self.assertIn('username', ctx.exception.message_dict)
 
     def test_username_at_max_length_passes(self):
         """A username of exactly USERNAME_MAX_LENGTH (150) characters is valid."""
         user = self._make_user('a' * User.USERNAME_MAX_LENGTH)
-        user.full_clean(exclude=['password'])
+        user.full_clean(exclude=self._EXCLUDE)
 
     def test_username_above_max_length_raises(self):
         """A username longer than USERNAME_MAX_LENGTH (150) fails validation."""
         user = self._make_user('a' * (User.USERNAME_MAX_LENGTH + 1))
         with self.assertRaises(ValidationError) as ctx:
-            user.full_clean(exclude=['password'])
+            user.full_clean(exclude=self._EXCLUDE)
         self.assertIn('username', ctx.exception.message_dict)

--- a/src/thunderbird_accounts/authentication/tests/test_models.py
+++ b/src/thunderbird_accounts/authentication/tests/test_models.py
@@ -1,0 +1,41 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from thunderbird_accounts.authentication.models import User
+
+
+class UserUsernameValidatorTestCase(TestCase):
+    """Verify that the MinLengthValidator is wired to User.username.
+
+    max_length is enforced at the DB column level by Django's CharField.
+    min_length is enforced only via validators, so it is important to confirm
+    the validator is actually attached to the field.
+    """
+
+    def _make_user(self, username: str) -> User:
+        return User(username=username, email='recovery@example.com')
+
+    def test_username_at_min_length_passes(self):
+        """A username of exactly USERNAME_MIN_LENGTH (3) characters is valid."""
+        user = self._make_user('a' * User.USERNAME_MIN_LENGTH)
+        # full_clean() runs all field validators; should not raise
+        user.full_clean(exclude=['password'])
+
+    def test_username_below_min_length_raises(self):
+        """A username shorter than USERNAME_MIN_LENGTH (3) fails validation."""
+        user = self._make_user('a' * (User.USERNAME_MIN_LENGTH - 1))
+        with self.assertRaises(ValidationError) as ctx:
+            user.full_clean(exclude=['password'])
+        self.assertIn('username', ctx.exception.message_dict)
+
+    def test_username_at_max_length_passes(self):
+        """A username of exactly USERNAME_MAX_LENGTH (150) characters is valid."""
+        user = self._make_user('a' * User.USERNAME_MAX_LENGTH)
+        user.full_clean(exclude=['password'])
+
+    def test_username_above_max_length_raises(self):
+        """A username longer than USERNAME_MAX_LENGTH (150) fails validation."""
+        user = self._make_user('a' * (User.USERNAME_MAX_LENGTH + 1))
+        with self.assertRaises(ValidationError) as ctx:
+            user.full_clean(exclude=['password'])
+        self.assertIn('username', ctx.exception.message_dict)

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -9,8 +9,7 @@ class ValidateEmailTestCase(TestCase):
     """Tests for validate_email, focused on the local-part length check.
 
     USERNAME_MIN_LENGTH = 3  →  local parts shorter than 3 chars are rejected
-    USERNAME_MAX_LENGTH = 150 →  local parts of 150 chars or more are rejected
-                                 (note: the guard uses >=, so 150 is invalid)
+    USERNAME_MAX_LENGTH = 150 →  local parts longer than 150 chars are rejected
     """
 
     DOMAIN = 'example.com'

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -87,3 +87,16 @@ class ValidateEmailTestCase(TestCase):
         with self.assertRaises(EmailNotValidError) as ctx:
             validate_email(self._email(local_part), error_message=custom_msg)
         self.assertEqual(ctx.exception.error_message, custom_msg)
+
+    # ------------------------------------------------------------------
+    # min_length override
+    # ------------------------------------------------------------------
+
+    def test_min_length_override_allows_short_local_part(self):
+        """Callers can lower the minimum below USERNAME_MIN_LENGTH."""
+        self.assertTrue(validate_email(self._email('a'), min_length=1))
+
+    def test_min_length_override_still_rejects_below_override(self):
+        """The overridden minimum is still enforced."""
+        with self.assertRaises(EmailNotValidError):
+            validate_email(self._email(''), min_length=1)

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -1,0 +1,89 @@
+from django.test import TestCase
+
+from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.mail.exceptions import EmailNotValidError
+from thunderbird_accounts.mail.utils import validate_email
+
+
+class ValidateEmailTestCase(TestCase):
+    """Tests for validate_email, focused on the local-part length check.
+
+    USERNAME_MIN_LENGTH = 3  →  local parts shorter than 3 chars are rejected
+    USERNAME_MAX_LENGTH = 150 →  local parts of 150 chars or more are rejected
+                                 (note: the guard uses >=, so 150 is invalid)
+    """
+
+    DOMAIN = 'example.com'
+
+    def _email(self, local_part: str) -> str:
+        return f'{local_part}@{self.DOMAIN}'
+
+    # ------------------------------------------------------------------
+    # Boundary: minimum length
+    # ------------------------------------------------------------------
+
+    def test_local_part_at_min_length_is_valid(self):
+        """A local part of exactly USERNAME_MIN_LENGTH (3) characters is accepted."""
+        local_part = 'a' * User.USERNAME_MIN_LENGTH
+        self.assertTrue(validate_email(self._email(local_part)))
+
+    def test_local_part_one_below_min_raises(self):
+        """A local part of USERNAME_MIN_LENGTH - 1 (2) characters is rejected."""
+        local_part = 'a' * (User.USERNAME_MIN_LENGTH - 1)
+        with self.assertRaises(EmailNotValidError):
+            validate_email(self._email(local_part))
+
+    def test_local_part_single_char_raises(self):
+        """A single-character local part is rejected."""
+        with self.assertRaises(EmailNotValidError):
+            validate_email(self._email('a'))
+
+    def test_empty_local_part_raises(self):
+        """An empty local part (length 0) is rejected."""
+        with self.assertRaises(EmailNotValidError):
+            validate_email(self._email(''))
+
+    # ------------------------------------------------------------------
+    # Boundary: maximum length
+    # ------------------------------------------------------------------
+
+    def test_local_part_at_max_length_is_valid(self):
+        """A local part of exactly USERNAME_MAX_LENGTH (150) characters is accepted."""
+        local_part = 'a' * User.USERNAME_MAX_LENGTH
+        self.assertTrue(validate_email(self._email(local_part)))
+
+    def test_local_part_above_max_raises(self):
+        """A local part longer than USERNAME_MAX_LENGTH (150) is rejected."""
+        local_part = 'a' * (User.USERNAME_MAX_LENGTH + 1)
+        with self.assertRaises(EmailNotValidError):
+            validate_email(self._email(local_part))
+
+    # ------------------------------------------------------------------
+    # Format checks
+    # ------------------------------------------------------------------
+
+    def test_missing_at_sign_raises(self):
+        """An email without '@' is rejected before the length check."""
+        with self.assertRaises(EmailNotValidError):
+            validate_email('notanemail')
+
+    def test_invalid_email_format_raises(self):
+        """A string with '@' but an otherwise invalid format is rejected."""
+        with self.assertRaises(EmailNotValidError):
+            validate_email('abc@')
+
+    def test_valid_email_returns_true(self):
+        """A well-formed email within length bounds returns True."""
+        self.assertTrue(validate_email('validuser@example.com'))
+
+    # ------------------------------------------------------------------
+    # Custom error message
+    # ------------------------------------------------------------------
+
+    def test_custom_error_message_is_used(self):
+        """The caller-supplied error_message is propagated in the exception."""
+        custom_msg = 'Custom error for tests'
+        local_part = 'a' * (User.USERNAME_MIN_LENGTH - 1)
+        with self.assertRaises(EmailNotValidError) as ctx:
+            validate_email(self._email(local_part), error_message=custom_msg)
+        self.assertEqual(ctx.exception.error_message, custom_msg)

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -280,10 +280,10 @@ class AddEmailAliasTestCase(TestCase):
 
     @override_settings(ALLOWED_EMAIL_DOMAINS=['example.org', 'example.com'])
     def test_allowed_domains_alias_too_long(self):
-        """Test that email aliases shorter than 3 characters are rejected for ALLOWED_EMAIL_DOMAINS."""
+        """Test that email aliases longer than 150 characters are rejected for ALLOWED_EMAIL_DOMAINS."""
         email_alias_url = reverse('add_email_alias')
 
-        random_string = get_random_string(User.USERNAME_MAX_LENGTH)
+        random_string = get_random_string(User.USERNAME_MAX_LENGTH + 1)
 
         response = self.client.post(
             email_alias_url,

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -25,7 +25,8 @@ def validate_email(email: str, error_message: str | None = None) -> bool:
     local_part = email.split('@')[0]
 
     # EmailValidator allows for up to 350 characters, but username is defined with max_length of 150.
-    if len(local_part) >= User.USERNAME_MAX_LENGTH:
+    # We also need to validate the minimum length of the username.
+    if len(local_part) > User.USERNAME_MAX_LENGTH or len(local_part) < User.USERNAME_MIN_LENGTH:
         raise EmailNotValidError(email, not_valid_err_msg)
 
     email_validator = EmailValidator(not_valid_err_msg)

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -15,18 +15,23 @@ from thunderbird_accounts.mail.models import Account
 from thunderbird_accounts.mail import tasks
 
 
-def validate_email(email: str, error_message: str | None = None) -> bool:
-    """Validates the email and local part against Django's built-in email validation."""
+def validate_email(email: str, error_message: str | None = None, min_length: int | None = None) -> bool:
+    """Validates the email and local part against Django's built-in email validation.
+
+    min_length overrides User.USERNAME_MIN_LENGTH when the caller has already
+    enforced its own domain-specific minimum (e.g. the add_email_alias view).
+    """
     not_valid_err_msg = error_message or _('This email is not valid. Try another one.')
 
     if '@' not in email:
         raise EmailNotValidError(email, not_valid_err_msg)
 
     local_part = email.split('@')[0]
+    effective_min = min_length if min_length is not None else User.USERNAME_MIN_LENGTH
 
     # EmailValidator allows for up to 350 characters, but username is defined with max_length of 150.
     # We also need to validate the minimum length of the username.
-    if len(local_part) > User.USERNAME_MAX_LENGTH or len(local_part) < User.USERNAME_MIN_LENGTH:
+    if len(local_part) > User.USERNAME_MAX_LENGTH or len(local_part) < effective_min:
         raise EmailNotValidError(email, not_valid_err_msg)
 
     email_validator = EmailValidator(not_valid_err_msg)

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -320,9 +320,16 @@ def add_email_alias(request: HttpRequest):
 
     full_email_alias = f'{email_alias}@{domain}'
 
+    if domain in settings.ALLOWED_EMAIL_DOMAINS and len(email_alias) < settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH:
+        return JsonResponse(
+            {'success': False, 'error': _('Email alias must be at least 3 characters long.')},
+            status=400,
+        )
+
     if not is_catch_all:
+        # min_length=1 because the domain-specific minimum has already been checked above.
         try:
-            validate_email(full_email_alias)
+            validate_email(full_email_alias, min_length=1)
         except EmailNotValidError as ex:
             return JsonResponse({'success': False, 'error': ex.error_message}, status=400)
 
@@ -337,12 +344,6 @@ def add_email_alias(request: HttpRequest):
         and domain not in settings.ALLOWED_EMAIL_DOMAINS
     ):
         return JsonResponse({'success': False, 'error': _('Domain not found.')}, status=404)
-
-    if domain in settings.ALLOWED_EMAIL_DOMAINS and len(email_alias) < settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH:
-        return JsonResponse(
-            {'success': False, 'error': _('Email alias must be at least 3 characters long.')},
-            status=400,
-        )
 
     # Get the user's account
     try:


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

[Frontend changes]

- Added a check during `onMounted` of the first step in the sign-up process (username) in case we pre-fill the field programmatically

[Backend changes]

- Updated `validate_email` logic to enforce min_length
  - The min_length can be overridden since the `validate_email` is used for both the sign up flow and the email aliases. For the email aliases in custom domains, it should still allow for < 3 characters.
- Added a `MinLengthValidator` to the `username` field in the `User` model
- Updated logic to allow the upper bound of the max length (we could only do 149 instead of 150 characters for username) to be accepted
- Added tests

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

The HTML native `minlength` validation works well, except that it does not run when we pre-fill the field programmatically. When doing so, I needed to manually check for the length.

Just adding the `minlength` would still allow for folks to type a 1 character username, reload the page, and since the username gets stored in session storage and populated programatically, they would still be able to click the submit.

Added guards in the backend as well in case there are attempts to bypass that.


## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/807

## Screenshots / GIFs

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

[Normal cases]

https://github.com/user-attachments/assets/71c507dc-b39a-4303-bc85-564e4e7b8d5f

[Reload case / Username saved in session storage]

https://github.com/user-attachments/assets/7c9a2168-784b-4f51-9eeb-7e15c0bc5166



