### PR TITLE
Add email fields and username field as search_fields for UserAdmin

### DIFF
--- a/src/thunderbird_accounts/authentication/admin/models.py
+++ b/src/thunderbird_accounts/authentication/admin/models.py
@@ -82,6 +82,7 @@ class CustomUserAdmin(UserAdmin):
         admin_manual_activate_subscription_features,
         admin_add_to_mailchimp_list,
     ]
+    search_fields = ('email', 'recovery_email', 'last_used_email', 'username')
     list_filter = ['is_staff', 'is_superuser', 'is_test_account', 'is_active', 'plan']
 
     form = CustomUserChangeForm


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added a `search_fields` [[Django docs reference](https://docs.djangoproject.com/en/6.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields)] with the various email related fields for UserAdmin

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- It is already becoming difficult to search through existing users in Django Admin and the existing search field wouldn't match with recovery_email or last_used_email

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/820
