### PR TITLE
Use recovery_email in Django Admin User forms

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { TextInput, PrimaryButton, NoticeBar, NoticeBarTypes } from "@thunderbirdops/services-ui";
 import { ref, computed, useTemplateRef } from 'vue';
 import MessageBar from '@kc/vue/components/MessageBar.vue';
@@ -22,7 +22,7 @@ const usernameError = computed(() => {
 
 </script>
 
-<script>
+<script lang="ts">
 export default {
   name: 'ForgotPasswordView'
 };
@@ -33,11 +33,27 @@ export default {
   <message-bar v-else/>
 
   <h2>{{ $t('emailForgotTitle') }}</h2>
-  <form id="kc-reset-password-form" ref="reset-password-form" method="POST" :action="formAction"
-        @submit.prevent="onSubmit" @keyup.enter="onSubmit">
+  <form
+    v-if="formAction"
+    id="kc-reset-password-form"
+    ref="reset-password-form"
+    method="POST"
+    :action="formAction"
+    @submit.prevent="onSubmit" @keyup.enter="onSubmit"
+  >
     <div class="form-elements">
-      <text-input id="username" name="username" required autocomplete="username" autofocus v-model="usernameRef"
-                  :help="$t('emailInstruction')" :error="usernameError">{{ $t('email') }}
+      <text-input
+        data-testid="username-input"
+        id="username"
+        name="username"
+        required
+        autocomplete="username"
+        autofocus
+        v-model="usernameRef"
+        :help="$t('emailInstruction')"
+        :error="usernameError"
+      >
+        {{ $t('email') }}
       </text-input>
     </div>
     <div class="buttons">

--- a/src/thunderbird_accounts/authentication/admin/forms.py
+++ b/src/thunderbird_accounts/authentication/admin/forms.py
@@ -34,7 +34,7 @@ class CustomUserFormBase(forms.ModelForm):
             f'This must be unique!'
         ),
     )
-    email = forms.CharField(
+    recovery_email = forms.CharField(
         label=_('Recovery Email Address'),
         required=True,
         strip=False,
@@ -66,8 +66,8 @@ class CustomUserFormBase(forms.ModelForm):
         if not self.data.get('username', '').endswith(f'@{settings.PRIMARY_EMAIL_DOMAIN}'):
             self.add_error('username', _(f'Thundermail address must end with {settings.PRIMARY_EMAIL_DOMAIN}'))
 
-        if not self.data.get('email'):
-            self.add_error('email', _('A recovery email is required.'))
+        if not self.data.get('recovery_email'):
+            self.add_error('recovery_email', _('A recovery email is required.'))
 
         if not self.data.get('timezone'):
             self.add_error('timezone', _('A timezone (e.g. America/Vancouver or UTC) is required.'))
@@ -97,7 +97,7 @@ class CustomNewUserForm(CustomUserFormBase):
             name = f'{self.cleaned_data.get("first_name", "")} {self.cleaned_data.get("last_name", "")}'.strip()
             keycloak_pkid = keycloak.import_user(
                 self.cleaned_data.get('username'),
-                self.cleaned_data.get('email'),
+                self.cleaned_data.get('recovery_email'),
                 self.cleaned_data.get('timezone'),
                 name=name,
             )
@@ -119,6 +119,12 @@ class CustomNewUserForm(CustomUserFormBase):
     def save(self, commit=True):
         user = super().save(commit=False)
         user.oidc_id = self.cleaned_data.get('oidc_id')
+        user.recovery_email = self.cleaned_data.get('recovery_email')
+
+        # The email field will be updated via the middleware's update_user function
+        # to be the @thundermail.com address but during the User creation we want to copy
+        # the recovery_email to the email field.
+        user.email = self.cleaned_data.get('recovery_email')
 
         # Actually save the user
         if commit:
@@ -151,7 +157,7 @@ class CustomUserChangeForm(CustomUserFormBase):
             keycloak.update_user(
                 self.cleaned_data.get('oidc_id'),
                 username=username,
-                email=self.cleaned_data.get('email'),
+                email=self.cleaned_data.get('recovery_email'),
                 enabled=self.cleaned_data.get('is_active'),
                 timezone=self.cleaned_data.get('timezone'),
                 locale=self.cleaned_data.get('language'),

--- a/src/thunderbird_accounts/authentication/admin/models.py
+++ b/src/thunderbird_accounts/authentication/admin/models.py
@@ -52,7 +52,7 @@ class CustomUserAdmin(UserAdmin):
             },
         ),
         (_('Profile Info'), {'fields': ('display_name', 'avatar_url', 'timezone')}),
-        (_('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),
+        (_('Personal info'), {'fields': ('first_name', 'last_name', 'recovery_email', 'email')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
         (_('Timestamps'), {'fields': ('created_at', 'updated_at')}),
         (
@@ -71,6 +71,7 @@ class CustomUserAdmin(UserAdmin):
     )
     readonly_fields = UserAdmin.readonly_fields + (
         'uuid',
+        'email',
         'display_name',
         'avatar_url',
         'created_at',
@@ -93,7 +94,7 @@ class CustomUserAdmin(UserAdmin):
             _('Required Fields'),
             {
                 'classes': ('wide',),
-                'fields': ('username', 'email', 'timezone'),
+                'fields': ('username', 'recovery_email', 'timezone'),
             },
         ),
         (

--- a/src/thunderbird_accounts/authentication/clients.py
+++ b/src/thunderbird_accounts/authentication/clients.py
@@ -235,10 +235,10 @@ class KeycloakClient:
         if update_attribute_data:
             update_data['attributes'] = update_attribute_data
 
-        # Merge the two dicts together, update data being above existing data
+        # Merge the two dicts together, update data taking precedence over existing data
         update_data = {
-            **update_data,
             **user_data,
+            **update_data,
         }
 
         try:

--- a/src/thunderbird_accounts/authentication/clients.py
+++ b/src/thunderbird_accounts/authentication/clients.py
@@ -233,7 +233,10 @@ class KeycloakClient:
         )
 
         if update_attribute_data:
-            update_data['attributes'] = update_attribute_data
+            update_data['attributes'] = {
+                **(user_data.get('attributes') or {}),
+                **update_attribute_data,
+            }
 
         # Merge the two dicts together, update data taking precedence over existing data
         update_data = {

--- a/src/thunderbird_accounts/authentication/tests/test_admin.py
+++ b/src/thunderbird_accounts/authentication/tests/test_admin.py
@@ -40,7 +40,7 @@ class AdminCreateUserTestCase(TestCase):
         # Bad username
         form_data = {
             'username': 'frog',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Toronto',
         }
 
@@ -55,7 +55,7 @@ class AdminCreateUserTestCase(TestCase):
         # Bad username
         form_data = {
             'username': 'support@thundermail.com',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Toronto',
         }
 
@@ -70,7 +70,7 @@ class AdminCreateUserTestCase(TestCase):
         # Bad email domain
         form_data = {
             'username': 'frog@badexample.com',
-            'email': 'frog@badexample.com',
+            'recovery_email': 'frog@badexample.com',
             'timezone': 'America/Toronto',
         }
 
@@ -84,7 +84,7 @@ class AdminCreateUserTestCase(TestCase):
         self.assertTrue(len(form.errors) > 0)
         self.assertIn('Thundermail address must end with', str(form.errors))
 
-        # No email
+        # No recovery email
         form_data = {
             'username': 'frog@example.com',
             'timezone': 'America/Toronto',
@@ -93,7 +93,7 @@ class AdminCreateUserTestCase(TestCase):
         form = self._build_form(form_data)
 
         self.assertTrue(len(form.errors) > 0)
-        self.assertIn('email', form.errors)
+        self.assertIn('recovery_email', form.errors)
 
         mock_requests.assert_not_called()
 
@@ -101,7 +101,7 @@ class AdminCreateUserTestCase(TestCase):
         # Bad username
         form_data = {
             'username': 'frog',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Victoria',
         }
 
@@ -115,7 +115,7 @@ class AdminCreateUserTestCase(TestCase):
     def test_success(self, mock_requests: MagicMock):
         form_data = {
             'username': f'frog@{self.subdomain}',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Toronto',
         }
 
@@ -142,7 +142,7 @@ class AdminCreateUserTestCase(TestCase):
     def test_success_with_reserved_username(self, mock_requests: MagicMock):
         form_data = {
             'username': f'admin@{self.subdomain}',
-            'email': 'admin@example.com',
+            'recovery_email': 'admin@example.com',
             'timezone': 'America/Toronto',
         }
 
@@ -192,7 +192,7 @@ class AdminUpdateUserTestcase(TestCase):
     def test_failed_invalid_timezone(self, mock_requests: MagicMock, mock_update_principal: MagicMock):
         form_data = {
             'username': f'frog@{self.subdomain}',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Victoria',  # Bad timezone!
             'oidc_id': self.user.oidc_id,
             # This is dumb, the fields are split into 2 and are populated via existing data
@@ -215,7 +215,7 @@ class AdminUpdateUserTestcase(TestCase):
     def test_failed_empty_username(self, mock_requests: MagicMock, mock_update_principal: MagicMock):
         form_data = {
             'username': '',
-            'email': self.user.email,
+            'recovery_email': self.user.email,
             'timezone': self.user.timezone,
             'oidc_id': self.user.oidc_id,
             # This is dumb, the fields are split into 2 and are populated via existing data
@@ -238,7 +238,7 @@ class AdminUpdateUserTestcase(TestCase):
     def test_failed_empty_email(self, mock_requests: MagicMock, mock_update_principal: MagicMock):
         form_data = {
             'username': self.user.username,
-            'email': '',
+            'recovery_email': '',
             'timezone': self.user.timezone,
             'oidc_id': self.user.oidc_id,
             # This is dumb, the fields are split into 2 and are populated via existing data
@@ -254,7 +254,7 @@ class AdminUpdateUserTestcase(TestCase):
             form.save(True)
 
         self.assertTrue(len(form.errors) > 0)
-        self.assertIn('email', form.errors)
+        self.assertIn('recovery_email', form.errors)
 
         self.assertEqual(mock_update_principal.call_count, 0)
 
@@ -270,7 +270,7 @@ class AdminUpdateUserTestcase(TestCase):
 
         form_data = {
             'username': f'frog@{self.subdomain}',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Toronto',
             'oidc_id': self.user.oidc_id,
             # This is dumb, the fields are split into 2 and are populated via existing data
@@ -309,7 +309,7 @@ class AdminUpdateUserTestcase(TestCase):
     def test_success_without_stalwart_account(self, mock_requests: MagicMock, mock_update_principal: MagicMock):
         form_data = {
             'username': f'frog@{self.subdomain}',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Toronto',
             'oidc_id': self.user.oidc_id,
             # This is dumb, the fields are split into 2 and are populated via existing data
@@ -354,7 +354,7 @@ class AdminUpdateUserTestcase(TestCase):
 
         form_data = {
             'username': f'internaltest@{self.subdomain}',
-            'email': 'frog@example.com',
+            'recovery_email': 'frog@example.com',
             'timezone': 'America/Toronto',
             'oidc_id': self.user.oidc_id,
             # This is dumb, the fields are split into 2 and are populated via existing data


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Updated Django Admin's User to use `recovery_email` instead of `email`
- Fixed a bug on merging two dicts while updating a Keycloak user
- No changes in `ForgotPasswordView` other than lint

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We've recently added `recovery_email` for unblocking the Mailchimp integration for Early Bird and also to serve as a stable reference for a recovery email in a way that is less disruptive for the rest of the application [[PR link](https://github.com/thunderbird/thunderbird-accounts/pull/793)].
 
However, Support received a request to update the recovery_email for a user. This was already possible by updating the `email` field in the Django Admin User form but that would be overridden upon the next login (see Limitation and Notes below).

To keep a clear separation of recovery_email vs email and avoid confusion, the Django Admin User form now uses the same `recovery_email` introduced in the PR mentioned. There was a bug though that we were not applying the changed from Django Admin -> Keycloak since when merging two dicts, the ordering of the dicts were favouring the existing data instead of the updated data (this has been fixed in this PR too).


## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

We are using a Keycloak Client Scope Mapper for the `email` field to be the `username` which overrides the `email` field in the Keycloak User upon login. This was done on purpose as a way to not store the recovery email in the long term (at least as far as I'm aware) and this hasn't changed.

Since we now have a separate `recovery_email`, this is a non-problem. However, if we don't want to have a separate recovery email field and want to roll back the changes (go back to using `email` as `recovery email`), we could revert this PR and [the recovery_email PR](https://github.com/thunderbird/thunderbird-accounts/pull/793)), and remove the Keycloak Client Scope Mapper.

IMHO, I think it is less confusing to have a clearly separated recovery email field though!

## How to test locally

[Pre-requisites]

- Login in Keycloak [[link](http://keycloak:8999/admin/master/console/#/master/realms)] as `admin / admin`
- Change the realm to `tbpro`
- Navigate to the Realm Settings, Login tab and change the User Registration to be `OFF` so we can sign-up using the same flow as stage / prod [[link](http://keycloak:8999/admin/master/console/#/master/realm-settings/login)]
- In `Client Scopes` [[link](http://keycloak:8999/admin/master/console/#/master/client-scopes)], select `email` -> `Mappers` tab -> `email`, and change the User Attribute to be `username` so that we have the same setup as stage / prod (this is what overrides the email field mentioned above btw)
- Login into Django Admin [[link](http://localhost:8087/admin/)] as `admin@example.org` / `admin`
- Create a Plan [[link](http://localhost:8087/admin/subscription/plan/)]
- Logout

[Test steps]

- Navigate to `http://localhost:8087/sign-up` and go through the sign-up flow as usual (your verification email will go to [Mailpit](http://localhost:8025/))
- Click in the verification link in the email and complete your account (for payment in Paddle sandbox, use the [test cards](https://developer.paddle.com/concepts/payment-methods/credit-debit-card#test-payment-method)).
- Logout & Login as `admin@example.org / admin`
- Go to Django Admin, find the user you've just signed up with and see the Recovery Email field being populated correctly

From here, you can test the Forgot Password flow, updating the user's recovery email in Django admin and trying again and verifying in Mailpit that the email is sent to the recovery email address correctly

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/821