### PR TITLE
feat(mail): lower MIN_CUSTOM_DOMAIN_ALIAS_LENGTH default to 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ PUBLIC_BASE_URL=http://localhost:8087
 
 # Comma separated list of tlds (e.g. ALLOWED_EMAIL_DOMAINS=example.com,example.org)
 ALLOWED_EMAIL_DOMAINS=example.org
-MIN_CUSTOM_DOMAIN_ALIAS_LENGTH=3
+MIN_CUSTOM_DOMAIN_ALIAS_LENGTH=2
 
 ADMIN_WEBSITE=https://www.thunderbird.net
 ADMIN_CONTACT=dummy@example.org

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -105,7 +105,9 @@ class AddEmailAliasTestCase(TestCase):
                 self.assertEqual(
                     json.loads(response.content.decode()),
                     {
-                        'error': f'Email alias must be at least {settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH} characters long.',
+                        'error': _(
+                            'Email alias must be at least %(min_length)d characters long.'
+                        ) % {'min_length': settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH},
                         'success': False,
                     },
                 )

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -104,7 +104,10 @@ class AddEmailAliasTestCase(TestCase):
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
                     json.loads(response.content.decode()),
-                    {'error': 'Email alias must be at least 3 characters long.', 'success': False},
+                    {
+                        'error': f'Email alias must be at least {settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH} characters long.',
+                        'success': False,
+                    },
                 )
 
             # Remove all emails so we can try the next alias
@@ -381,7 +384,7 @@ class AddEmailAliasTestCase(TestCase):
             self.assertEqual(response.status_code, 400)
             self.assertEqual(
                 json.loads(response.content.decode()),
-                {'success': False, 'error': _('Email alias must be at least 3 characters long.')},
+                {'success': False, 'error': _('Email alias must be at least 2 characters long.')},
             )
 
             # Test ALLOWED_EMAIL_DOMAINS: 2 characters should be accepted

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -322,7 +322,11 @@ def add_email_alias(request: HttpRequest):
 
     if domain in settings.ALLOWED_EMAIL_DOMAINS and len(email_alias) < settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH:
         return JsonResponse(
-            {'success': False, 'error': _('Email alias must be at least 3 characters long.')},
+            {
+                'success': False,
+                'error': _('Email alias must be at least %(min_length)d characters long.')
+                % {'min_length': settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH},
+            },
             status=400,
         )
 

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -471,7 +471,7 @@ ALLOWED_EMAIL_DOMAINS: list[str] = (
     else []
 )
 
-MIN_CUSTOM_DOMAIN_ALIAS_LENGTH = int(os.getenv('MIN_CUSTOM_DOMAIN_ALIAS_LENGTH', '3'))
+MIN_CUSTOM_DOMAIN_ALIAS_LENGTH = int(os.getenv('MIN_CUSTOM_DOMAIN_ALIAS_LENGTH', '2'))
 
 # The email domain that will be used for account creation and login
 PRIMARY_EMAIL_DOMAIN = (


### PR DESCRIPTION
## Summary

Lowers the default minimum length for custom-domain email aliases from 3 to 2 characters, and makes the validation error message dynamic so it always reflects the configured `MIN_CUSTOM_DOMAIN_ALIAS_LENGTH` value.

## Why

The current default rejects 2-letter aliases (e.g. initials like `ns@`), even though the `MIN_CUSTOM_DOMAIN_ALIAS_LENGTH` setting introduced in #465 already exists to make this tunable. Two-letter aliases are a common request from users who own short custom domains. Additionally, when an admin lowered the env var, users still saw a misleading 'must be at least 3 characters long' error because the message was hardcoded.

## Changes

- `.env.example`: example value 3 -> 2
- `src/thunderbird_accounts/settings.py`: default 3 -> 2
- `src/thunderbird_accounts/mail/views.py`: error message now interpolates `settings.MIN_CUSTOM_DOMAIN_ALIAS_LENGTH`
- `src/thunderbird_accounts/mail/tests/test_views.py`: `test_alias_input_invalid` uses the dynamic value; `test_custom_domain_alias_length_minimum_2` now expects the correct '2 characters' message

## Backwards compatibility

Deployments that want a stricter limit can keep `MIN_CUSTOM_DOMAIN_ALIAS_LENGTH=3` (or higher) in their environment. The existing `test_allowed_domain_alias_too_short` pins 3 via `override_settings` and continues to pass.