### PR TITLE
Change App Password / Display name to API routes (Fixes #359)

### DIFF
--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/api.ts
@@ -1,3 +1,35 @@
+interface SettingsApiResponse {
+  success: boolean;
+  message?: string;
+  error?: string;
+}
+
+export const setAppPassword = async (name: string, password: string): Promise<SettingsApiResponse> => {
+  const response = await fetch('/api/v1/mail/app-passwords/set/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': window._page.csrfToken,
+    },
+    body: JSON.stringify({ name, password }),
+  });
+
+  return await response.json();
+};
+
+export const setDisplayName = async (displayName: string): Promise<SettingsApiResponse> => {
+  const response = await fetch('/api/v1/mail/display-name/set/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': window._page.csrfToken,
+    },
+    body: JSON.stringify({ 'display-name': displayName }),
+  });
+
+  return await response.json();
+};
+
 export const addEmailAlias = async (emailAlias: string, domain: string) => {
   const response = await fetch(`/email-aliases/add`, {
     method: 'POST',

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -13,6 +13,7 @@ import {
 } from '@thunderbirdops/services-ui';
 import { PhX, PhInfo } from '@phosphor-icons/vue';
 import { APP_PASSWORD_SUPPORT_URL } from '@/defines';
+import { setAppPassword } from '../api';
 
 const { t } = useI18n();
 
@@ -51,19 +52,7 @@ const onSetPasswordSubmit = async () => {
   const label = userEmail.value;
 
   try {
-    const response = await fetch('/app-passwords/set', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': window._page.csrfToken,
-      },
-      body: JSON.stringify({
-        name: label,
-        password: appPassword.value,
-      }),
-    });
-
-    const data = await response.json();
+    const data = await setAppPassword(label, appPassword.value);
 
     if (data.success) {
       // Reset form and close
@@ -143,7 +132,7 @@ const onCancelSetPassword = () => {
     </notice-bar>
 
     <template v-if="showPasswordForm">
-      <form ref="appPasswordFormRef" method="post" action="/app-passwords/set">
+      <form ref="appPasswordFormRef" @submit.prevent="onSetPasswordSubmit">
         <input type="hidden" name="name" :value="userEmail" />
 
         <text-input v-model="appPassword" name="password" type="password"
@@ -167,12 +156,12 @@ const onCancelSetPassword = () => {
         </notice-bar>
 
         <div class="set-password-buttons-container">
-          <primary-button @click="onSetPasswordSubmit" :disabled="isSubmitting" data-testid="app-passwords-add-btn">
+          <primary-button type="button" @click="onSetPasswordSubmit" :disabled="isSubmitting" data-testid="app-passwords-add-btn">
             {{
               isSubmitting ? t('views.mail.sections.emailSettings.saving') : t('views.mail.sections.emailSettings.save')
             }}
           </primary-button>
-          <link-button @click="onCancelSetPassword" :disabled="isSubmitting">{{
+          <link-button type="button" @click="onCancelSetPassword" :disabled="isSubmitting">{{
             t('views.mail.sections.emailSettings.cancel') }}
           </link-button>
         </div>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/UserInfoSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/UserInfoSide.vue
@@ -8,6 +8,7 @@ import {
   TextInput,
   LinkButton,
 } from '@thunderbirdops/services-ui';
+import { setDisplayName } from '../api';
 
 const { t } = useI18n();
 
@@ -15,10 +16,10 @@ const showDisplayNameForm = ref(false);
 const displayName = ref<string>(null);
 const errorMessageDisplayName = ref(window._page?.formError || '');
 const isSubmittingDisplayName = ref(false);
+const userDisplayName = ref(window._page?.userDisplayName || '');
 
 // From Stalwart, primary email is always the first email address in the list
 const primaryEmail = computed(() => window._page?.emailAddresses?.[0] || '');
-const userDisplayName = computed(() => window._page?.userDisplayName);
 
 const onSetDisplayNameSubmit = async () => {
   if (isSubmittingDisplayName.value) return;
@@ -27,26 +28,15 @@ const onSetDisplayNameSubmit = async () => {
   isSubmittingDisplayName.value = true;
 
   try {
-    const response = await fetch('/display-name/set', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': window._page.csrfToken,
-      },
-      body: JSON.stringify({
-        'display-name': displayName.value,
-      }),
-    });
-
-    const data = await response.json();
+    const data = await setDisplayName(displayName.value);
 
     if (data.success) {
+      userDisplayName.value = displayName.value;
+      window._page.userDisplayName = displayName.value;
+
       // Reset form and close
       displayName.value = '';
       showDisplayNameForm.value = false;
-
-      // Reload the page to reflect changes
-      window.location.reload();
     } else {
       errorMessageDisplayName.value = data.error || t('views.mail.sections.emailSettings.anErrorOccurred');
     }
@@ -74,10 +64,7 @@ const onCancelSetDisplayName = () => {
 
     <div class="display-name-content">
       <template v-if="showDisplayNameForm">
-        <form
-          method="post"
-          action="/display-name/set"
-        >
+        <form @submit.prevent="onSetDisplayNameSubmit">
           <text-input v-model="displayName" name="display-name" data-testid="display-name-input">
             {{ t('views.mail.sections.emailSettings.newDisplayName') }}:
           </text-input>
@@ -85,8 +72,8 @@ const onCancelSetDisplayName = () => {
           <notice-bar :type="NoticeBarTypes.Critical" v-if="errorMessageDisplayName">{{ errorMessageDisplayName }}</notice-bar>
 
           <div class="set-display-name-buttons-container">
-            <primary-button variant="outline" @click="onCancelSetDisplayName" :disabled="isSubmittingDisplayName">{{ t('views.mail.sections.emailSettings.cancel') }}</primary-button>
-            <primary-button @click="onSetDisplayNameSubmit" :disabled="isSubmittingDisplayName" data-testid="display-name-set-btn">
+            <primary-button type="button" variant="outline" @click="onCancelSetDisplayName" :disabled="isSubmittingDisplayName">{{ t('views.mail.sections.emailSettings.cancel') }}</primary-button>
+            <primary-button type="button" @click="onSetDisplayNameSubmit" :disabled="isSubmittingDisplayName" data-testid="display-name-set-btn">
               {{ isSubmittingDisplayName ? t('views.mail.sections.emailSettings.saving') : t('views.mail.sections.emailSettings.save') }}
             </primary-button>
           </div>

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -1,5 +1,5 @@
 from django.utils.crypto import get_random_string
-from thunderbird_accounts.subscription.models import Plan
+from thunderbird_accounts.subscription.models import Plan, Subscription
 import json
 from unittest.mock import patch, Mock
 
@@ -10,6 +10,105 @@ from django.utils.translation import gettext_lazy as _
 
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.models import Account, Domain, Email
+
+
+class AppPasswordApiTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+        self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        self.primary_email = f'test@{settings.PRIMARY_EMAIL_DOMAIN}'
+        self.account = Account.objects.create(name=self.primary_email, user=self.user)
+        Email.objects.create(address=self.primary_email, type=Email.EmailType.PRIMARY, account=self.account)
+        self.subscription = Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
+        self.client.force_login(self.user)
+        self.url = reverse('api_app_password_set')
+
+    @patch('thunderbird_accounts.mail.views.utils.save_app_password')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_success(self, mock_mail_client_cls, mock_save_app_password):
+        existing_app_password = f'$app${self.primary_email}$hashed-password'
+        new_hash = f'$app${self.primary_email}$new-hashed-password'
+
+        mock_instance = Mock()
+        mock_instance.get_account.return_value = {'secrets': [existing_app_password]}
+        mock_mail_client_cls.return_value = mock_instance
+        mock_save_app_password.return_value = new_hash
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'name': self.primary_email, 'password': 'new-password'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.content.decode())['success'])
+        mock_instance.get_account.assert_called_once_with(self.primary_email)
+        mock_instance.delete_app_password.assert_called_once_with(self.primary_email, existing_app_password)
+        mock_save_app_password.assert_called_once_with(self.primary_email, 'new-password')
+        mock_instance.save_app_password.assert_called_once_with(self.primary_email, new_hash)
+
+    def test_name_and_password_are_required(self):
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'name': self.primary_email}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(json.loads(response.content.decode())['success'])
+
+    @patch('thunderbird_accounts.mail.views.utils.save_app_password')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_requires_active_subscription(self, mock_mail_client_cls, mock_save_app_password):
+        self.subscription.status = Subscription.StatusValues.CANCELED
+        self.subscription.save()
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'name': self.primary_email, 'password': 'new-password'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertFalse(json.loads(response.content.decode())['success'])
+        mock_mail_client_cls.assert_not_called()
+        mock_save_app_password.assert_not_called()
+
+
+class DisplayNameApiTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+        self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        self.primary_email = f'test@{settings.PRIMARY_EMAIL_DOMAIN}'
+        self.account = Account.objects.create(name=self.primary_email, user=self.user)
+        Email.objects.create(address=self.primary_email, type=Email.EmailType.PRIMARY, account=self.account)
+        self.client.force_login(self.user)
+        self.url = reverse('api_display_name_set')
+
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_success(self, mock_mail_client_cls):
+        mock_instance = Mock()
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'display-name': 'New Name'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.content.decode())['success'])
+        mock_instance.update_individual.assert_called_once_with(self.primary_email, full_name='New Name')
+
+    def test_display_name_is_required(self):
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'display-name': ''}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(json.loads(response.content.decode())['success'])
 
 
 class AddEmailAliasTestCase(TestCase):

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -41,6 +41,12 @@ from thunderbird_accounts.mail import utils
 def app_password_set(request: HttpRequest):
     """Sets an app password for a remote Stalwart account"""
 
+    if not request.user.has_active_subscription:
+        return JsonResponse(
+            {'success': False, 'error': str(_('An active subscription is required to set an app password.'))},
+            status=403,
+        )
+
     try:
         data = json.loads(request.body)
         new_password = data.get('password')

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -72,6 +72,8 @@ urlpatterns = [
     path(
         'api/v1/subscription/plan/info/', subscription_views.get_subscription_plan_info, name='subscription_plan_info'
     ),
+    path('api/v1/mail/app-passwords/set/', mail_views.app_password_set, name='api_app_password_set'),
+    path('api/v1/mail/display-name/set/', mail_views.display_name_set, name='api_display_name_set'),
     path('api/v1/mail/is-username-available/', mail_api.is_username_available, name='api_is_username_available'),
     # Stalwart telemetry webhook
     path('api/v1/telemetry/stalwart/webhook/', telemetry_views.stalwart_webhook, name='stalwart_webhook'),


### PR DESCRIPTION
Before, these were form submissions, causing full-page reloads.

An additional check was added to app-password changes to make sure the
user has a current subscription.

## QA Log

 - Added automated test coverage
 - Manually tested before / after behavior for both cases in a browser 

## Review notes

- Is there a way to further simplify the test coverage that's still sufficient?
