### PR TITLE
Prevent contact form's file input from opening twice. (Fixes #849)

### DIFF
--- a/assets/app/vue/views/ContactView/components/ContactSupportForm.vue
+++ b/assets/app/vue/views/ContactView/components/ContactSupportForm.vue
@@ -62,7 +62,11 @@ const nativeAttrsForField = (field: TicketField) => {
   }
 };
 
-const triggerFileSelect = () => {
+const triggerFileSelect = (event: PointerEvent) => {
+  // Do not target the fileInput if they've clicked on the fileInput.
+  if (event.target === fileInput.value) {
+    return;
+  }
   fileInput.value?.click();
 };
 


### PR DESCRIPTION
Fixes #849 

We wrap the fileInput with a div that has an on-click event. The on-click event (as seen in changes) calls the fileInput's click event. You can see why some browsers may get confused :smile:. 

So Chrome-based browsers seem to prioritize the least deep element's events while Firefox prioritizes the deepest element's events. Interesting distinction there. 