### PR TITLE
Update E2E tests to accept tos if required

### DIFF
--- a/test/e2e/pages/tb-accts-hub-page.ts
+++ b/test/e2e/pages/tb-accts-hub-page.ts
@@ -3,6 +3,7 @@ import { type Page, type Locator } from '@playwright/test';
 export class TBAcctsHubPage {
   readonly page: Page;
   readonly userAvatar: Locator;
+  readonly acceptTOSButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -11,5 +12,6 @@ export class TBAcctsHubPage {
     // of its render modes (router-link on /mail, button elsewhere). Scoping to
     // the banner keeps this stable if we later land on a different view.
     this.userAvatar = this.page.getByRole('banner').locator('.avatar');
+    this.acceptTOSButton = this.page.getByRole('button', { name: 'Accept policies and continue' });
   }
 }

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -7,7 +7,6 @@ import path from 'path';
 import {
     ACCTS_TARGET_ENV,
     ACCTS_HUB_URL,
-    TIMEOUT_5_SECONDS,
     TIMEOUT_30_SECONDS,
 } from "../const/constants";
 
@@ -48,7 +47,6 @@ export const navigateToAccountsHubAndSignIn = async (page: Page) => {
     const tbAcctsHubPage = new TBAcctsHubPage(page);
     
     await page.goto(`${ACCTS_HUB_URL}`, { waitUntil: 'domcontentloaded' });
-    //await page.waitForTimeout(TIMEOUT_5_SECONDS);
     await waitForVueApp(page);
     
     // if we are already signed in then we can skip this
@@ -58,6 +56,14 @@ export const navigateToAccountsHubAndSignIn = async (page: Page) => {
 
 
     await waitForVueApp(page);
+
+    // if tests are running on a new local stack (or new account) the terms of service page might be
+    // displayed; if so we need to accept the terms of service and then continue
+    if (await tbAcctsHubPage.acceptTOSButton.isVisible()) {
+        console.log('accepting the TB Pro ToS');
+        await tbAcctsHubPage.acceptTOSButton.click();
+    }
+
     // Confirm the signed-in hub actually rendered by waiting for the banner's
     // UserAvatar (the stable signed-in signal after the nav overhaul in #695).
     await expect(tbAcctsHubPage.userAvatar).toBeVisible({ timeout: TIMEOUT_30_SECONDS });


### PR DESCRIPTION
## What changed?
Update the E2E tests to accept the TB Pro Terms of Service if prompted after sign-in.

## Why?
When the E2E tests run on a brand new local stack, after they sign-in to the TB Accounts dashboard the TB Pro Terms of Service agreement page is displayed, which must be accepted in order to continue.

## Applicable Issues
Fixes #870.

## Screenshots
In local E2E [tests job triggered by this actual PR ](https://github.com/thunderbird/thunderbird-accounts/actions/runs/26417375833/job/77764677246?pr=871)the tests successfully accepted the TOS and then continued on with the tests:

```
signing in to TB Accounts
accepting the tb pro tos
navigating to accounts hub dev (http://localhost:8087)
... (rest of the test logs)
  13 passed (1.3m)
```

Also ran locally against stage where the TOS was already accepted previously and the tests passed fine.