### PR TITLE
Raise anonymous rate limit to work around Stalwart bug

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -24,6 +24,9 @@ protocol = "http"
 bind = ["[::]:8080"]
 protocol = "http"
 
+[http.rate-limit]
+anonymous = "10000/1m"
+
 [storage]
 data = "rocksdb"
 fts = "rocksdb"


### PR DESCRIPTION
Until 0.16, the anon rate limit is applied to all JMAP requests no matter if authenticated or not.

Lets just use this workaround for now.