### PR TITLE
Additional documentation fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 # Configuration file for the Sphinx documentation builder.
+import datetime
 import importlib
+from importlib import metadata
 import inspect
 import logging
 import os
@@ -13,12 +15,13 @@ print(f'Adding to path: {os.path.abspath("../src")}')  # noqa: T201
 
 # -- Project information
 
-project = 'Thunderbird Accounts'
-copyright = '2025, MZLA Technologies Corporation'
-author = 'Thunderbird Services'
+year = datetime.datetime.now().year
 
-release = '0.4'
-version = '0.4.0'
+project = 'Thunderbird Accounts'
+author = 'Thunderbird Services'
+copyright = f'{year}, MZLA Technologies Corporation'
+
+version = release = metadata.version('thunderbird_accounts')
 
 # -- General configuration
 


### PR DESCRIPTION
* Year fix
* Pin version to thunderbird_account's pyproject.toml

Some minor fixes to go on top of  https://github.com/thunderbird/thunderbird-accounts/commit/0ee4515ba148f1b92f683b53a79c681c384c542b that finishes up the small documentation issues I found during one of my other tickets.

Docs are built from readthedocs, not our CI, and they live [here](https://pro-services-docs.thunderbird.net/en/latest/). 

You can build them locally with `uv run sphinx-build docs build` and then start a webserver in the build directory. The documentation build process should also build thunderbird_accounts as we have autodoc enabled, so I _think_ importlib.metadata.version usage will be fine, but please correct me if I seem wrong here.