### PR TITLE
Minor fixes and enable posthog secret (#164)

### DIFF
--- a/assets/app/vue/views/SignUpView/stores/signUpFlowStore.ts
+++ b/assets/app/vue/views/SignUpView/stores/signUpFlowStore.ts
@@ -8,7 +8,7 @@ export const enum SIGN_UP_STEPS {
   USERNAME = 10,
   PASSWORD = 20,
   VERIFY = 30,
-  DONE = 100, // Not currently used
+  DONE = 100,
 }
 
 export const SIGN_UP_STEPS_TO_STR = {

--- a/assets/app/vue/views/SignUpView/stores/signUpFlowStore.ts
+++ b/assets/app/vue/views/SignUpView/stores/signUpFlowStore.ts
@@ -67,10 +67,17 @@ export const useSignUpFlowStore = defineStore('signUpFlow', () => {
   
     if (response.status === 200) {
       $reset(false);
+      // Capture the done step. 
+      // The user will never be in this step but it's a good indicator that they've succeeded.
+      captureStep(SIGN_UP_STEPS.DONE);
       return true;
     } else if (response.status === 429) { // Throttled by rate limiter
       errorMessage.value = (await response.json())?.detail ?? null;
       console.log(errorMessage.value);
+
+      // Capture this short circuit error
+      captureError(errorMessage.value);
+
       return false;
     }  
 
@@ -84,6 +91,9 @@ export const useSignUpFlowStore = defineStore('signUpFlow', () => {
       errorMessage.value = error['error'] ?? 'Unknown Error';
       const type: string = error['type'] ?? 'unknown-error';
       if (type === 'go-to-wait-list') {
+        // Make sure we capture this error before we blank it out
+        captureError(errorMessage.value);
+
         // Don't show this error, just redirect!
         errorMessage.value = null;
         window.location.href = error['href'];

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -789,6 +789,7 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/mailchimp-list-id-OAj8yj
               - name: APPOINTMENT_CALDAV_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/appointment-caldav-secret-eJOI7y
+              - *SECRET_POSTHOG_API_KEY
             environment:
               - name: TIMES_I_NEED_TO_REDEPLOY_WITHOUT_CHANGING_IMAGE
                 value: '2'

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -779,6 +779,7 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/keycloak-admin-client-secret-z97o1p
               - name: APPOINTMENT_CALDAV_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/appointment-caldav-secret-CU7WNc
+              - *SECRET_POSTHOG_API_KEY
             environment:
               - name: ADMIN_WEBSITE
                 value: https://www.thunderbird.net


### PR DESCRIPTION
Additional fixes for #164, we were not capturing done state, and errors like request throttles or "this user is not in the allow list".

Finally the most erroriest of errors, we don't actually have posthog enabled on the web container. We do on the celery workers, but not web. So this should fix things up. 