### PR TITLE
Fix blank spf host for local development

### DIFF
--- a/src/thunderbird_accounts/mail/clients.py
+++ b/src/thunderbird_accounts/mail/clients.py
@@ -536,19 +536,24 @@ class MailClient:
 
         # 2. Check SPF Record
         try:
-            txt_answers = dns.resolver.resolve(domain_name, 'TXT')
-            has_spf = False
-            expected_spf_include = f'include:spf.{expected_host}'
+            # Skip SPF check when expected host is not a fully-qualified domain
+            # (e.g. localhost, or None from missing .env config)
+            if not expected_host or '.' not in expected_host:
+                logging.info(f'Skipping SPF check: expected_host={expected_host!r} is not a FQDN')
+            else:
+                txt_answers = dns.resolver.resolve(domain_name, 'TXT')
+                has_spf = False
+                expected_spf_include = f'include:spf.{expected_host}'
 
-            for rdata in txt_answers:
-                # rdata.strings is a list of bytes
-                txt_content = b''.join(rdata.strings).decode('utf-8')
-                if txt_content.startswith('v=spf1') and expected_spf_include in txt_content:
-                    has_spf = True
-                    break
+                for rdata in txt_answers:
+                    # rdata.strings is a list of bytes
+                    txt_content = b''.join(rdata.strings).decode('utf-8')
+                    if txt_content.startswith('v=spf1') and expected_spf_include in txt_content:
+                        has_spf = True
+                        break
 
-            if not has_spf:
-                warnings.append(DomainVerificationErrors.SPF_RECORD_NOT_FOUND)
+                if not has_spf:
+                    warnings.append(DomainVerificationErrors.SPF_RECORD_NOT_FOUND)
         except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN, dns.resolver.NoNameservers):
             warnings.append(DomainVerificationErrors.SPF_RECORD_NOT_FOUND)
         except Exception as e:


### PR DESCRIPTION
## What

Skips the SPF DNS check when `expected_host` is not a fully-qualified domain name (e.g. `localhost` or `None` from missing `.env` config).

## Why

When `SMTP_HOST` is set to `localhost` (common for local development) or is `None` (unset in `.env`), the SPF include string becomes `include:spf.localhost` or `include:spf.None` — both invalid. This causes a blank SPF host and produces warnings/nonsense DNS lookups.

## Testing

- Verified manually: when `expected_host` is `localhost`, the SPF check is skipped with an info log
- When `expected_host` has a dot (e.g. `mail.test.com`), existing SPF behavior is unchanged
- Existing tests pass unchanged