### PR TITLE
Enable QR Code TfA setup on Thundermail Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,6 @@ Feature flags are stored in `localStorage` and read at runtime to toggle UI beha
 | Key | Values | Description |
 | --- | ------ | ----------- |
 | `feature.show-connect-now` | `true` | Shows the "Connect Now" action card on the desktop panel, which launches Thunderbird Desktop via a custom protocol URL. |
-| `feature.phase` | `2` | Enables phase 2 UI: QR code setup flow on mobile and the "Connect Now" card on desktop, replacing the auto-config placeholders. |
 
 ## Running tests
 

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -113,8 +113,6 @@
               "downloadTitle": "Download Thunderbird for Android",
               "downloadDescription": "Install the mobile app on your phone or tablet.",
               "downloadButton": "Download",
-              "autoConfigTitle": "Automatic Configuration",
-              "autoConfigDescription": "Add a new account in Thunderbird for Android using your Thundermail email and password.",
               "iosTitle": "Need iOS Help?",
               "iosDescription": "Read our step-by-step guide for connecting popular email applications.",
               "iosSupportButtonLabel": "Visit Support Article"

--- a/assets/app/vue/types.ts
+++ b/assets/app/vue/types.ts
@@ -14,12 +14,10 @@ export type ServerMessage = {
 
 export enum FeatureFlag {
   SHOW_CONNECT_NOW = 'feature.show-connect-now',
-  PHASE = 'feature.phase',
 };
 
 export enum FeatureFlagValue {
   TRUE = 'true',
-  PHASE_TWO = '2',
 };
 
 export enum TELEMETRY_EVENTS {

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -10,7 +10,6 @@ import { isFeatureFlagEnabled } from '@/utils';
 const { t } = useI18n();
 
 const showConnectNow = isFeatureFlagEnabled(FeatureFlag.SHOW_CONNECT_NOW, FeatureFlagValue.TRUE);
-const isPhaseTwo = isFeatureFlagEnabled(FeatureFlag.PHASE, FeatureFlagValue.PHASE_TWO);
 
 // TODO: Update this when the full URL is ready
 const tbDesktopCustomProtocolUrl = 'net.thunderbird://replay';
@@ -24,9 +23,8 @@ export default {
 
 <template>
   <div class="action-cards">
-    <template v-if="isPhaseTwo">
+    <template v-if="showConnectNow">
       <action-card
-        v-if="showConnectNow"
         :title="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectTitle')"
         :description="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectDescription')"
       >

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
@@ -11,14 +11,10 @@ import {
   AUTHENTICATION_TYPE,
 } from 'thunderbird-account-qr-code';
 import { DOWNLOAD_THUNDERBIRD_MOBILE_URL, IOS_SUPPORT_URL } from '@/defines';
-import { FeatureFlag, FeatureFlagValue } from '@/types';
-import { isFeatureFlagEnabled } from '@/utils';
 import ActionCard from '@/components/ActionCard.vue';
 import DetailsSummary from '@/components/DetailsSummary.vue';
 
 const { t } = useI18n();
-
-const isPhaseTwo = isFeatureFlagEnabled(FeatureFlag.PHASE, FeatureFlagValue.PHASE_TWO);
 
 const primaryEmail = computed(() => window._page?.emailAddresses?.[0] || '');
 const connectionInfo = computed(() => window._page?.connectionInfo);
@@ -51,40 +47,32 @@ export default {
 
 <template>
   <div class="action-cards">
-    <template v-if="isPhaseTwo">
-      <div class="qr-code-container">
-        <i18n-t
-          keypath="views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription"
-          class="qr-code-description"
-          tag="p"
-        >
-          <template #thunderbirdForAndroid>
-            <strong>
-              {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.thunderbirdForAndroid') }}
-            </strong>
-          </template>
-        </i18n-t>
-        <details-summary
-          :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeTitle')"
-          class="qr-code-details-summary"
-        >
-          <template #icon>
-            <ph-qr-code :size="20" />
-          </template>
-          <img
-            class="qr-code"
-            :src="`data:image/svg+xml,${qrCode}`"
-            :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeAlt')"
-          />
-        </details-summary>
-      </div>
-    </template>
-    <template v-else>
-      <action-card
-        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.autoConfigTitle')"
-        :description="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.autoConfigDescription')"
-      />
-    </template>
+    <div class="qr-code-container">
+      <i18n-t
+        keypath="views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeDescription"
+        class="qr-code-description"
+        tag="p"
+      >
+        <template #thunderbirdForAndroid>
+          <strong>
+            {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.thunderbirdForAndroid') }}
+          </strong>
+        </template>
+      </i18n-t>
+      <details-summary
+        :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeTitle')"
+        class="qr-code-details-summary"
+      >
+        <template #icon>
+          <ph-qr-code :size="20" />
+        </template>
+        <img
+          class="qr-code"
+          :src="`data:image/svg+xml,${qrCode}`"
+          :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.qrCodeAlt')"
+        />
+      </details-summary>
+    </div>
 
     <action-card
       :title="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.downloadTitle')"


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Since the mobile team is ready for the QR code setup, this PR removes the `feature.phase` feature flag as this was primarily gating the QR code from being displayed (we are still keeping the `feature.show-connect-now` for hiding / showing the "Connect Now" for TB Desktop).

Zeplin file for reference: https://zpl.io/Rmogz0N

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

Per [this comment](https://github.com/thunderbird/thunderbird-accounts/issues/880#issuecomment-4600032169), we are ready to remove the feature flag and show the QR code without a feature flag.

## Limitations & Notes

Please note that [per the comments in Zeplin](https://zpl.io/Rmogz0N), the QR code is only shown when expanding the "Scan QR Code" section dropdown.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/880

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

Before

<img width="1006" height="437" alt="image" src="https://github.com/user-attachments/assets/a24ade3d-3999-4cc7-8165-172c8b8c6216" />


After

<img width="1008" height="663" alt="image" src="https://github.com/user-attachments/assets/e9797cdb-fee4-479d-b6fa-f1c01573f61a" />
