### PR TITLE
Allow importing discounts per person with CSV

### DIFF
--- a/src/thunderbird_accounts/authentication/models.py
+++ b/src/thunderbird_accounts/authentication/models.py
@@ -1,13 +1,18 @@
 from functools import cached_property
 
 from django.conf import settings
-from django.core.validators import MinLengthValidator
+from django.core.validators import MinLengthValidator, RegexValidator
 from django.db import models
 
 from django.contrib.auth.models import AbstractUser
 from django.utils.translation import gettext_lazy as _
 
 from thunderbird_accounts.core.models import BaseModel
+
+DISCOUNT_ID_VALIDATOR = RegexValidator(
+    regex=r'^dsc_[a-z0-9]{26}$',
+    message=_('Enter a full Paddle discount id in the format dsc_ followed by 26 lowercase letters or numbers.'),
+)
 
 
 class User(AbstractUser, BaseModel):
@@ -117,6 +122,7 @@ class AllowListEntry(BaseModel):
         null=True,
         blank=True,
         help_text=_('Optional Paddle discount id to apply during checkout.'),
+        validators=[DISCOUNT_ID_VALIDATOR],
     )
     user = models.ForeignKey(
         User,

--- a/src/thunderbird_accounts/authentication/templates/admin/authentication/allowlistentry/import.html
+++ b/src/thunderbird_accounts/authentication/templates/admin/authentication/allowlistentry/import.html
@@ -5,12 +5,15 @@
   <section>
       <h1>Allow List Entry Bulk Importer</h1>
       <form id="bulk-form" name="bulk-form" method="POST" action="{{ submit_url|safe }}">
-        <label for="bulk-entry">Enter email addresses below. <strong>Each new line will be a separate entry</strong>, duplicates will be
-          ignored and spaces will be removed.</label>
+        <label for="bulk-entry">
+          Enter allow list entries below. <strong>Each line is one CSV row</strong>. Use
+          <code>email@example.com</code> or <code>email@example.com,dsc_...</code>. Discount ids are optional, but
+          when supplied they must be full Paddle discount ids: <code>dsc_</code> followed by 26 lowercase letters or
+          numbers.
+          Duplicates will be ignored and spaces around values will be removed.
+        </label>
         <textarea id="bulk-entry" name="bulk-entry" rows="20"></textarea>
-        <label for="discount-id">Optional discount id (applies to all imported entries)</label>
-        <input id="discount-id" name="discount-id" type="text" />
-        <button id="submit" class="addlink" type="submit">Import</button>
+        <input id="submit" class="addlink" type="submit" value="Import" />
         {% csrf_token %}
       </form>
   </section>
@@ -22,6 +25,10 @@
     }
     #submit {
       max-width: 10rem;
+      padding-inline-start: 1.625rem;
+      background-image: url("{% static 'admin/img/tooltag-add.svg' %}");
+      background-position: 0.625rem center;
+      background-repeat: no-repeat;
     }
   </style>
 {% endblock content %}

--- a/src/thunderbird_accounts/authentication/tests/test_views.py
+++ b/src/thunderbird_accounts/authentication/tests/test_views.py
@@ -1,12 +1,16 @@
 from django.contrib.auth.models import Permission
+from django.contrib.messages import get_messages
 from django.test import Client as RequestClient, TestCase
 from django.urls import reverse
+from django.utils.crypto import get_random_string
 
 from thunderbird_accounts.authentication.models import AllowListEntry, User
 from thunderbird_accounts.core.tests.utils import oidc_force_login
 
 
 class BulkImportAllowListTestCase(TestCase):
+    _DISCOUNT_ID_CHARS = 'abcdefghijklmnopqrstuvwxyz0123456789'
+
     def setUp(self):
         self.client = RequestClient()
         self.user = User.objects.create(
@@ -19,17 +23,80 @@ class BulkImportAllowListTestCase(TestCase):
         self.user.user_permissions.add(permission)
         oidc_force_login(self.client, self.user)
 
-    def test_bulk_import_sets_discount_id_for_new_entries(self):
+    def _make_discount_id(self):
+        return f'dsc_{get_random_string(26, allowed_chars=self._DISCOUNT_ID_CHARS)}'
+
+    def test_bulk_import_sets_row_discount_ids_for_new_entries(self):
+        discount_id = self._make_discount_id()
+        discount_id_2 = self._make_discount_id()
+
         response = self.client.post(
             reverse('allow_list_entry_import_submit'),
             {
-                'bulk-entry': 'hello@example.com\nhello2@example.com',
-                'discount-id': 'dsc_123',
+                'bulk-entry': f'hello@example.com,{discount_id}\nhello2@example.com,{discount_id_2}',
             },
             follow=False,
         )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(AllowListEntry.objects.count(), 2)
-        self.assertEqual(AllowListEntry.objects.get(email='hello@example.com').discount_id, 'dsc_123')
-        self.assertEqual(AllowListEntry.objects.get(email='hello2@example.com').discount_id, 'dsc_123')
+        self.assertEqual(
+            AllowListEntry.objects.get(email='hello@example.com').discount_id,
+            discount_id,
+        )
+        self.assertEqual(
+            AllowListEntry.objects.get(email='hello2@example.com').discount_id,
+            discount_id_2,
+        )
+
+    def test_bulk_import_allows_rows_without_discount_ids(self):
+        response = self.client.post(
+            reverse('allow_list_entry_import_submit'),
+            {
+                'bulk-entry': 'hello@example.com\nhello2@example.com,',
+            },
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(AllowListEntry.objects.count(), 2)
+        self.assertIsNone(AllowListEntry.objects.get(email='hello@example.com').discount_id)
+        self.assertIsNone(AllowListEntry.objects.get(email='hello2@example.com').discount_id)
+
+    def test_bulk_import_rejects_discount_ids_without_dsc_prefix(self):
+        response = self.client.post(
+            reverse('allow_list_entry_import_submit'),
+            {
+                'bulk-entry': 'hello@example.com,coupon_123',
+            },
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(AllowListEntry.objects.count(), 0)
+        messages = [str(message) for message in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any(
+                message.startswith('coupon_123 is not a valid discount id. Use the full Paddle id')
+                for message in messages
+            )
+        )
+
+    def test_bulk_import_rejects_short_dsc_discount_ids(self):
+        response = self.client.post(
+            reverse('allow_list_entry_import_submit'),
+            {
+                'bulk-entry': 'hello@example.com,dsc_123',
+            },
+            follow=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(AllowListEntry.objects.count(), 0)
+        messages = [str(message) for message in get_messages(response.wsgi_request)]
+        self.assertTrue(
+            any(
+                message.startswith('dsc_123 is not a valid discount id. Use the full Paddle id')
+                for message in messages
+            )
+        )

--- a/src/thunderbird_accounts/authentication/views.py
+++ b/src/thunderbird_accounts/authentication/views.py
@@ -1,3 +1,6 @@
+import csv
+import re
+
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import logout as django_logout
@@ -17,6 +20,8 @@ from django.views.generic import TemplateView
 
 from thunderbird_accounts.authentication.utils import create_aia_url, KeycloakRequiredAction
 from thunderbird_accounts.core.utils import get_absolute_url
+
+DISCOUNT_ID_PATTERN = re.compile(r'^dsc_[a-z0-9]{26}$')
 
 
 @login_required
@@ -75,30 +80,37 @@ def bulk_import_allow_list(request: HttpRequest):
     from thunderbird_accounts.authentication.models import AllowListEntry
 
     entries: str = request.POST.get('bulk-entry', '')
-    discount_id: str | None = request.POST.get('discount-id', None)
-    if discount_id:
-        discount_id = discount_id.strip()
-    if not discount_id:
-        discount_id = None
     # Normalize new lines (I'm not sure if this is actually needed but best to be safe here.)
     entries = entries.replace('\r\n', '\n').replace('\r', '\n')
-    # Now split on new line
-    split_entries: list[str] = entries.split('\n')
 
     dupes = []
     errors = []
     add_amount = 0
 
-    for entry in split_entries:
-        # Remove spaces
-        entry = entry.strip()
-        if not entry:
+    for row in csv.reader(entries.splitlines()):
+        if not row or all(not column.strip() for column in row):
+            continue
+
+        entry = row[0].strip()
+        discount_id = row[1].strip() if len(row) > 1 else None
+        if not discount_id:
+            discount_id = None
+
+        if len(row) > 2 and any(column.strip() for column in row[2:]):
+            errors.append(f'{entry} has too many columns. Use email or email,discount_id.')
             continue
 
         try:
             validate_email(entry)
         except ValidationError:
             errors.append(f'{entry} is not a valid email address.')
+            continue
+
+        if discount_id and not DISCOUNT_ID_PATTERN.fullmatch(discount_id):
+            errors.append(
+                f'{discount_id} is not a valid discount id. '
+                'Use the full Paddle id in the format dsc_ followed by 26 lowercase letters or numbers.'
+            )
             continue
 
         try:


### PR DESCRIPTION
Fixes #900

## What changed?

In the allow list admin, allow importing users with a discount id per user by entering CSV with the email and discount id. Discount id is optional.

Also added some validation to the discount id on the single entry form.

## Why?

Doing this manually is very annoying and error prone

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

## Screenshots

<img width="823" height="333" alt="image" src="https://github.com/user-attachments/assets/722b6455-6699-48d4-b19e-a512a8fef312" />
<img width="561" height="511" alt="image" src="https://github.com/user-attachments/assets/6dccca41-ffd5-41a4-a420-a9f93769be78" />
