### PR TITLE
Add QA Log to Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,12 @@
   Using the "Closes #123" format will link pull request and issue.
 -->
 
+## QA Log
+
+<!--
+Bulleted list of any steps taken to validate correctness beyond automated tests.
+-->
+
 ## Screenshots
 
 <!--


### PR DESCRIPTION
Communicating testing details helps the reviewer to understand
what's been tested so far so they might either ask for additional
QA steps or focus their own review to avoid duplicate work.

