### PR TITLE
Set Cloudflare secret data for DKIM functions

### DIFF
--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -79,3 +79,7 @@ config:
     secure: AAABADpuLw71MLJ5RyYEN7G47RC88uj8dznCXUo3JS4p8Mwnvw+FG3j19+CyhM6jnpdtGGbSnc3QGQwMlBrrxA==
   accounts:stalwart-webhook-secret:
     secure: AAABABaIJ/x287l9pyLW3HzJ5f7mCJv/o/96+jaI0KFU9VfIj6O+4OtFq5vfVJqqKH1LPOnkpMk0bneC3m/6TU/cmGdIPu2B/+U/qb6odlegj2TO1Gzu45wrGd2Qgthl
+  accounts:hosted-dkim-cloudflare-zone-id:
+    secure: AAABANBKKCmFU9bVj65f5giqgQ95B+HTFfo4CJIWE6gjxwL6fhCmAJpsPQny7dtlWkD97CS4iUVhZxb3IYiplg==
+  accounts:hosted-dkim-cloudflare-api-token:
+    secure: AAABAHpI/ed/wL0C7g9f9AL8qmeKyqK8ryeBsLSxMq5Mq/VUfVRPTrfFuFFOxmLcLKi7mR8b2nALjIznhtMNN9/ZePulKSQvCTh3zRQR6mVkb9f8Ig==

--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -74,3 +74,7 @@ config:
     secure: AAABAPXX4cm62Agkc0pob1MUB1c7qYxWgJeAFm1051m+Pe3uhZh9KA5qG9ZuTVCbj0i38CCkrefveMpxja23CQ==
   accounts:stalwart-webhook-secret:
     secure: AAABAE1N1CyUZ9eTZ+mr2lzvFJp3+i5mSKkK9jStUzamU+uwev45bZZfSh2EIJofNHj5Zyi1VOtqFnE6tmKMvlwLdaSvvV+Uje2eClEJ7KpT28IZA1Ad5GlR6r6BmZ8v
+  accounts:hosted-dkim-cloudflare-api-token:
+    secure: AAABAG/M9PEQLSK5ybOaYspp1TEle7+cqNYuGTEBVmRzIqEHrkj4Znc0mUxEjAyuMVlOfDMVOENYqtFPzd7WlwT/aKqh3XkoU+OR72Z3dD9o/hKLLA==
+  accounts:hosted-dkim-cloudflare-zone-id:
+    secure: AAABANUaXjYvUkpuCZjrCOWu+ZEAHpJjf85ASuKGaUVV7af7x70t8StIPvLD7KzieM2agKZwbAQ2SVA2UjpR1g==

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -97,8 +97,8 @@
 .sentry_dsn: &SECRET_SENTRY_DSN {name: "SENTRY_DSN", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/sentry-dsn-aEWFMV"}
 .stalwart_api_auth_method: &SECRET_STALWART_API_AUTH_METHOD {name: "STALWART_API_AUTH_METHOD", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-method-ErlvTR"}
 .stalwart_api_auth_string: &SECRET_STALWART_API_AUTH_STRING {name: "STALWART_API_AUTH_STRING", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-key-cnGrUN"}
-.hosted_dkim_cloudflare_api_token: &SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN {name: "HOSTED_DKIM_CLOUDFLARE_API_TOKEN", valueFrom: "accounts/prod/hosted-dkim-cloudflare-api-token"}
-.hosted_dkim_cloudflare_zone_id: &SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", valueFrom: "accounts/prod/hosted-dkim-cloudflare-zone-id"}
+.hosted_dkim_cloudflare_api_token: &SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN {name: "HOSTED_DKIM_CLOUDFLARE_API_TOKEN", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/hosted-dkim-cloudflare-api-token-3rY2yV"}
+.hosted_dkim_cloudflare_zone_id: &SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/hosted-dkim-cloudflare-zone-id-dnPjOo"}
 # Shared HMAC secret that Stalwart uses to sign outgoing webhook payloads. Must match the
 # `webhook.posthog.signature-key` value configured in Stalwart's admin API on mailstrom-prod.
 .stalwart_webhook_secret: &SECRET_STALWART_WEBHOOK_SECRET {name: "STALWART_WEBHOOK_SECRET", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-webhook-secret-t8yGzq"}

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -805,10 +805,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-method-ErlvTR
               - name: STALWART_WEBHOOK_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-webhook-secret-t8yGzq
-              - name: HOSTED_DKIM_CLOUDFLARE_API_TOKEN
-                valueFrom: accounts/prod/hosted-dkim-cloudflare-api-token
-              - name: HOSTED_DKIM_CLOUDFLARE_ZONE_ID
-                valueFrom: accounts/prod/hosted-dkim-cloudflare-zone-id
               - name: MAILCHIMP_DC
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/mailchimp-dc-SyLAUO
               - name: MAILCHIMP_API_KEY
@@ -818,6 +814,9 @@ resources:
               - name: APPOINTMENT_CALDAV_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/appointment-caldav-secret-eJOI7y
               - *SECRET_POSTHOG_API_KEY
+              - *SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN
+              - *SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
+
             environment:
               - name: TIMES_I_NEED_TO_REDEPLOY_WITHOUT_CHANGING_IMAGE
                 value: '2'

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -3,7 +3,7 @@
 ### Special variables used throughout this file
 
 # Update this value to update all containers based on this thunderbird/accounts image
-.accounts_image: &ACCOUNTS_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:dc8d8ea6e76d8c7f25b260e964bada9d38a38e4b
+.accounts_image: &ACCOUNTS_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:59fe695cef7f94721b34ab37cd00338890f79d6a
 
 # Update this value to update all containers based on this Keycloak image
 .keycloak_image: &KEYCLOAK_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-dc8d8ea6e76d8c7f25b260e964bada9d38a38e4b
@@ -92,8 +92,8 @@
 .sentry_dsn: &SECRET_SENTRY_DSN {name: "SENTRY_DSN", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/sentry-dsn-rgui8C"}
 .stalwart_api_auth_method: &SECRET_STALWART_API_AUTH_METHOD {name: "STALWART_API_AUTH_METHOD", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/stalwart-api-auth-method-OeouRm"}
 .stalwart_api_auth_string: &SECRET_STALWART_API_AUTH_STRING {name: "STALWART_API_AUTH_STRING", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/stalwart-api-auth-key-9Vlhwc"}
-.hosted_dkim_cloudflare_api_token: &SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN {name: "HOSTED_DKIM_CLOUDFLARE_API_TOKEN", valueFrom: "accounts/stage/hosted-dkim-cloudflare-api-token"}
-.hosted_dkim_cloudflare_zone_id: &SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", valueFrom: "accounts/stage/hosted-dkim-cloudflare-zone-id"}
+.hosted_dkim_cloudflare_api_token: &SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN {name: "HOSTED_DKIM_CLOUDFLARE_API_TOKEN", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/hosted-dkim-cloudflare-api-token-2Lwjs0"}
+.hosted_dkim_cloudflare_zone_id: &SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/hosted-dkim-cloudflare-zone-id-jWKJt6"}
 # Shared HMAC secret that Stalwart uses to sign outgoing webhook payloads. Must match the
 # `webhook.posthog.signature-key` value configured in Stalwart's admin API on mailstrom-stage.
 .stalwart_webhook_secret: &SECRET_STALWART_WEBHOOK_SECRET {name: "STALWART_WEBHOOK_SECRET", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/stalwart-webhook-secret-poF35r"}

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -808,6 +808,8 @@ resources:
               - name: APPOINTMENT_CALDAV_SECRET
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/appointment-caldav-secret-CU7WNc
               - *SECRET_POSTHOG_API_KEY
+              - *SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN
+              - *SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
             environment:
               - name: ADMIN_WEBSITE
                 value: https://www.thunderbird.net


### PR DESCRIPTION
I created two different Cloudflare API tokens, one per environment, and set them in the Pulumi config with `pulumi config set --secret` commands. I ran a targeted `pulumi up` on the secrets manager to create the AWS Secrets Manager entries referenced in the secrets section. I updated the mapping of secrets we apply to most task definitions so they would reference these secrets. I also updated the old task defintion where we don't apply this.