### PR TITLE
Fix domain used in Cloudflare DNS updates

### DIFF
--- a/src/thunderbird_accounts/mail/dkim.py
+++ b/src/thunderbird_accounts/mail/dkim.py
@@ -224,13 +224,10 @@ def dkim_signatures_to_dns_records(domain_name: str, signatures: list[dict]) -> 
     return records
 
 
-def publish_hosted_dkim_txt_records(
-    domain_name: str, dkim_dns_records: list[dict], dns_client=None
-) -> list[dict[str, str]]:
-    """Publishes dkim txt records
+def publish_hosted_dkim_txt_records(hosted_records: list[dict[str, str]], dns_client=None) -> list[dict[str, str]]:
+    """Publishes hosted DKIM TXT records.
     If dns_client is not specified it falls back on ``CloudflareDNSClient``"""
     dns_client = dns_client or CloudflareDNSClient()
-    hosted_records = build_hosted_dkim_txt_records(domain_name, dkim_dns_records)
 
     for record in hosted_records:
         dns_client.upsert_txt_record(record['name'], record['content'])

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -182,11 +182,13 @@ def publish_hosted_dkim_dns_records(self, domain_name: str):
         stalwart = MailClient()
         dkim_dns_records = stalwart.get_dkim_dns_records(domain_name)
 
+        phase = 'build_hosted_txt_records'
+        hosted_records = build_hosted_dkim_txt_records(domain_name, dkim_dns_records)
+
         if settings.HOSTED_DKIM_CLOUDFLARE_ENABLED:
             phase = 'publish_cloudflare_txt_records'
             hosted_records = publish_hosted_dkim_txt_records(
-                domain_name,
-                dkim_dns_records,
+                hosted_records,
                 dns_client=CloudflareDNSClient(),
             )
             phase = 'validate_hosted_record_count'
@@ -204,8 +206,6 @@ def publish_hosted_dkim_dns_records(self, domain_name: str):
             skipped = False
         # Building and logging the full records is still useful for development.
         else:
-            phase = 'build_hosted_txt_records'
-            hosted_records = build_hosted_dkim_txt_records(domain_name, dkim_dns_records)
             for record in hosted_records:
                 logging.info(
                     'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS update to set '

--- a/src/thunderbird_accounts/mail/tests/test_tasks.py
+++ b/src/thunderbird_accounts/mail/tests/test_tasks.py
@@ -1,5 +1,5 @@
 from thunderbird_accounts.celery.exceptions import TaskFailed
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, call
 
 from django.conf import settings
 from django.test import TestCase, override_settings
@@ -104,11 +104,12 @@ class PublishHostedDkimDNSRecordsTestCase(TaskTestCase):
         HOSTED_DKIM_CLOUDFLARE_ENABLED=True,
         HOSTED_DKIM_CLOUDFLARE_ZONE_ID='zone-id',
         HOSTED_DKIM_CLOUDFLARE_API_TOKEN='secret',
+        HOSTED_DKIM_DOMAIN='dkim.example.net',
+        HOSTED_DKIM_SELECTORS=['tm1', 'tm2', 'tm3'],
     )
-    @patch('thunderbird_accounts.mail.tasks.publish_hosted_dkim_txt_records')
     @patch('thunderbird_accounts.mail.tasks.CloudflareDNSClient')
     @patch('thunderbird_accounts.mail.tasks.MailClient')
-    def test_publishes_stalwart_dkim_records(self, mail_client_mock, cloudflare_client_mock, publish_mock):
+    def test_publishes_stalwart_dkim_records_to_hosted_domain(self, mail_client_mock, cloudflare_client_mock):
         dkim_records = [
             {'type': 'TXT', 'name': 'tm1._domainkey.example.com.', 'content': 'v=DKIM1; p=rsa'},
             {'type': 'TXT', 'name': 'tm2._domainkey.example.com.', 'content': 'v=DKIM1; p=ed25519'},
@@ -118,16 +119,21 @@ class PublishHostedDkimDNSRecordsTestCase(TaskTestCase):
             {'type': 'TXT', 'name': 'tm2.example.com.dkim.example.net', 'content': 'v=DKIM1; p=ed25519'},
         ]
         mail_client_mock.return_value.get_dkim_dns_records.return_value = dkim_records
-        publish_mock.return_value = hosted_records
 
         results = tasks.publish_hosted_dkim_dns_records.run(domain_name='example.com')
 
         mail_client_mock.return_value.get_dkim_dns_records.assert_called_once_with('example.com')
-        publish_mock.assert_called_once_with(
-            'example.com',
-            dkim_records,
-            dns_client=cloudflare_client_mock.return_value,
+        cloudflare_client_mock.return_value.upsert_txt_record.assert_has_calls(
+            [
+                call('tm1.example.com.dkim.example.net', 'v=DKIM1; p=rsa'),
+                call('tm2.example.com.dkim.example.net', 'v=DKIM1; p=ed25519'),
+            ]
         )
+        published_names = [
+            args[0] for args, _kwargs in cloudflare_client_mock.return_value.upsert_txt_record.call_args_list
+        ]
+        self.assertNotIn('tm1._domainkey.example.com.', published_names)
+        self.assertFalse(any('._domainkey.' in name for name in published_names))
         self.assertEqual(results['task_status'], 'success')
         self.assertFalse(results['skipped'])
         self.assertEqual(hosted_records, results['records'])


### PR DESCRIPTION
The task now explicitly builds hosted_records first, then passes only that hosted list into the
Cloudflare publisher. That makes the boundary clear: Cloudflare
publication receives tm1.example.com.dkim.example.net, not Stalwart’s
source tm1._domainkey.example.com.

Also, tighted up related tests

Fixes: https://thunderbird.sentry.io/issues/7522167784/events/67accfa67d834bec908605aaf331d689/

## QA Log

Tested locally, logging shows correct domain name. Not "dkim.thunderhosted.com" in output.

```
celery-1      | [2026-06-02 21:42:35,144: INFO/ForkPoolWorker-16] Task thunderbird_accounts.mail.tasks.publish_hosted_dkim_dns_records[8e597003-5cae-4501-94dc-340de519a466] succeeded in 0.003786254001170164s: {'domain_name': 'tb.stosberg.com', 'records': [{'type': 'TXT', 'name': 'tm2.tb.stosberg.com.dkim.thunderhosted.com', 'content': 'v=DKIM1; k=ed25519; h=sha256; p=FCrFz71n5Pn6iOdCyhg6ypFXgckcJJSn/EDJX/AhZuU='}, {'type': 'TXT', 'name': 'tm1.tb.stosberg.com.dkim.thunderhosted.com', 'content': 'v=DKIM1; k=rsa; h=sha256; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3YLGnzXbvuC/Kc/Kz9AWHT99MhWUhlMU5jwPTRNt+YL2dapIckhKwKP6lJ/w/W158vLobWcIqnC/yZBUwMAH16TwfrYd1wtvXC1Ne3xgJOXbNB5DcPArdf8GvA2j9Nx6wOd3WGcF7Gix3Q37QDYGEYgyWwj48DUMQRU+ANaJYakVn1TwGTrwsab/9moXEIDl+U9fREBUS4VkHw5KjsphJRLWDTUw8vMxj2P4zlIl5WF8pIXzD9zDH1x/ozxhTdCiwZVNhXJ0eGnOuyjPyNNPFw5QeAuSb1JMnc1Zvi5Y00Qq9fUs5StmiizPzmN1vLolap8T9BqMNMZ/9LTIq4SmgQIDAQAB'}], 'skipped': True, 'task_status': 'success'}
```
