### PR TITLE
Make admin pages easier to search and scan

### DIFF
--- a/src/thunderbird_accounts/authentication/admin/models.py
+++ b/src/thunderbird_accounts/authentication/admin/models.py
@@ -15,22 +15,24 @@ from thunderbird_accounts.authentication.utils import delete_user_data
 
 class CustomUserAdmin(UserAdmin):
     @admin.display(description='Plan')
-    def shorten_plan(user: User) -> str | None:
+    def shorten_plan(self, user: User) -> str | None:
         if not user.plan:
             return None
         return user.plan.name
 
     list_display = (
-        'uuid',
-        'oidc_id',
-        shorten_plan,
-        *UserAdmin.list_display,
-        'is_test_account',
-        'last_used_email',
+        'username',
+        'first_name',
+        'last_name',
         'recovery_email',
+        'shorten_plan',
         'created_at',
-        'updated_at',
+        'last_login',
+        'is_staff',
+        'is_test_account',
+        'is_active',
     )
+    list_display_links = ('username',)
     fieldsets = (
         (None, {'fields': ('uuid', 'username')}),
         (
@@ -84,7 +86,14 @@ class CustomUserAdmin(UserAdmin):
         admin_add_to_mailchimp_list,
     ]
     search_fields = ('email', 'recovery_email', 'last_used_email', 'username')
-    list_filter = ['is_staff', 'is_superuser', 'is_test_account', 'is_active', 'plan']
+    list_filter = [
+        'is_staff',
+        'is_superuser',
+        'is_test_account',
+        'is_active',
+        'is_awaiting_payment_verification',
+        'plan',
+    ]
 
     form = CustomUserChangeForm
     add_form = CustomNewUserForm

--- a/src/thunderbird_accounts/mail/admin/models.py
+++ b/src/thunderbird_accounts/mail/admin/models.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 
 from thunderbird_accounts.mail.admin.actions import admin_fix_stalwart_ids
@@ -22,16 +23,23 @@ class AccountAdmin(admin.ModelAdmin):
     inlines = (EmailInline,)
     readonly_fields = ('uuid', 'stalwart_id', 'stalwart_created_at', 'stalwart_updated_at')
 
-    search_fields = ('name',)
-    search_help_text = _('Search accounts by name.')
+    search_fields = ('name', 'email__address')
+    search_help_text = _('Search accounts by primary email or alias.')
     list_filter = ['created_at', 'updated_at']
     list_display = (
         'name',
         'quota',
-        'user',
+        'email_count',
         'created_at',
         'updated_at',
     )
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).annotate(email_count=Count('email'))
+
+    @admin.display(description=_('Email Count'), ordering='email_count')
+    def email_count(self, obj):
+        return obj.email_count
 
 
 class DomainAdmin(admin.ModelAdmin):
@@ -40,8 +48,8 @@ class DomainAdmin(admin.ModelAdmin):
     model = Domain
     readonly_fields = ('uuid', 'stalwart_id', 'stalwart_created_at', 'stalwart_updated_at')
 
-    search_fields = ('name',)
-    search_help_text = _('Search domains by name.')
+    search_fields = ('name', 'user__username')
+    search_help_text = _('Search domains by name or user email.')
     list_filter = ['created_at', 'updated_at']
     list_display = (
         'name',

--- a/src/thunderbird_accounts/subscription/admin.py
+++ b/src/thunderbird_accounts/subscription/admin.py
@@ -81,15 +81,125 @@ class CustomReadonlyAdmin(ReadOnlyAdminMixin, admin.ModelAdmin):
 
         return None
 
+
+class CustomPlanAdmin(admin.ModelAdmin):
+    list_display = (
+        'name',
+        'product_name',
+        'mail_address_count',
+        'mail_domain_count',
+        'mail_storage_bytes',
+        'send_storage_bytes',
+    )
+    list_select_related = ('product',)
+
+    @admin.display(description=_('Product Name'), ordering='product__name')
+    def product_name(self, obj):
+        if obj.product:
+            return obj.product.name
+        return None
+
+
+class CustomPriceAdmin(CustomReadonlyAdmin):
+    list_display = (
+        'name',
+        'formatted_amount',
+        'status',
+        'billing_cycle',
+    )
+
+    @admin.display(description=_('Amount'), ordering='amount')
+    def formatted_amount(self, obj):
+        try:
+            amount = int(obj.amount) / 100
+        except (TypeError, ValueError):
+            return obj.amount
+        return f'{obj.currency} {amount:,.2f}'
+
+    @admin.display(description=_('Billing Cycle'), ordering='billing_cycle_interval')
+    def billing_cycle(self, obj):
+        if not obj.billing_cycle_frequency or not obj.billing_cycle_interval:
+            return None
+        return f'{obj.billing_cycle_frequency} per {obj.get_billing_cycle_interval_display()}'
+
+
+class CustomProductAdmin(CustomReadonlyAdmin):
+    list_display = ('name', 'description', 'paddle_id', 'status')
+
+
 class CustomSubscriptionAdmin(CustomReadonlyAdmin):
     actions = [admin_retrieve_missing_localized_pricing_and_discounts]
+    search_fields = ('paddle_id', 'paddle_customer_id', 'user__username')
+    search_help_text = _('Search subscriptions by Paddle subscription ID, Paddle customer ID, or email.')
+    list_display = ('paddle_id', 'paddle_customer_id', 'username', 'status', 'next_billed_at')
+    list_select_related = ('user',)
+
+    @admin.display(description=_('Username'), ordering='user__username')
+    def username(self, obj):
+        if obj.user:
+            return obj.user.username
+        return None
+
+
+class CustomSubscriptionItemAdmin(CustomReadonlyAdmin):
+    search_fields = ('subscription__user__username',)
+    search_help_text = _('Search subscription items by email.')
+    list_display = (
+        'uuid',
+        'subscription_username',
+        'price_name',
+        'price_amount',
+        'product_name',
+    )
+    list_select_related = ('subscription__user', 'price', 'product')
+
+    @admin.display(description=_('Username'), ordering='subscription__user__username')
+    def subscription_username(self, obj):
+        if obj.subscription and obj.subscription.user:
+            return obj.subscription.user.username
+        return None
+
+    @admin.display(description=_('Price Name'), ordering='price__name')
+    def price_name(self, obj):
+        if obj.price:
+            return obj.price.name
+        return None
+
+    @admin.display(description=_('Price Amount'), ordering='price__amount')
+    def price_amount(self, obj):
+        if obj.price:
+            try:
+                amount = int(obj.price.amount) / 100
+            except (TypeError, ValueError):
+                return obj.price.amount
+            return f'{obj.price.currency} {amount:,.2f}'
+        return None
+
+    @admin.display(description=_('Product Name'), ordering='product__name')
+    def product_name(self, obj):
+        if obj.product:
+            return obj.product.name
+        return None
+
+
+class CustomTransactionAdmin(CustomReadonlyAdmin):
+    search_fields = ('paddle_id', 'paddle_subscription_id', 'subscription__user__username')
+    search_help_text = _('Search transactions by Paddle transaction ID, Paddle subscription ID, or email.')
+    list_display = ('paddle_id', 'paddle_subscription_id', 'subscription_username', 'status', 'billed_at')
+    list_select_related = ('subscription__user',)
+
+    @admin.display(description=_('Username'), ordering='subscription__user__username')
+    def subscription_username(self, obj):
+        if obj.subscription and obj.subscription.user:
+            return obj.subscription.user.username
+        return None
 
 
 # Data stores for Paddle information
 admin.site.register(Subscription, admin_class=CustomSubscriptionAdmin)
-admin.site.register(SubscriptionItem, admin_class=CustomReadonlyAdmin)
-admin.site.register(Transaction, admin_class=CustomReadonlyAdmin)
-admin.site.register(Price, admin_class=CustomReadonlyAdmin)
-admin.site.register(Product, admin_class=CustomReadonlyAdmin)
+admin.site.register(SubscriptionItem, admin_class=CustomSubscriptionItemAdmin)
+admin.site.register(Transaction, admin_class=CustomTransactionAdmin)
+admin.site.register(Price, admin_class=CustomPriceAdmin)
+admin.site.register(Product, admin_class=CustomProductAdmin)
 
-admin.site.register(Plan)
+admin.site.register(Plan, admin_class=CustomPlanAdmin)


### PR DESCRIPTION
## What changed?

Updated Django admin search and list views so support-relevant fields are easier to find and scan across users, mail accounts/domains, and subscription records.

Agent-written with human direction for each admin change. Human reviewed code before submitting.

## Why?

Support and payment investigations often start from an email address, alias, Paddle ID, or subscription/customer context. The previous admin views made those lookups harder than necessary.

## Applicable Issues

Fixes #906

## Screenshots

<details>
<summary>Show Screenshots</summary>
<img width="2315" height="1132" src="https://github.com/user-attachments/assets/5e016b09-5168-4e33-a739-3a1033f2941a" />

<img width="1026" height="508" alt="image" src="https://github.com/user-attachments/assets/c86ee47e-07cf-4ca3-b33c-0c58e47204e5" />

<img width="1017" height="584" alt="image" src="https://github.com/user-attachments/assets/ef0d8160-4c38-4475-9919-cf61bc81d786" />

<img width="1152" height="336" alt="image" src="https://github.com/user-attachments/assets/ac8c045b-fc67-4eeb-8d70-78e09d08ea6f" />

<img width="1224" height="724" alt="image" src="https://github.com/user-attachments/assets/872d4625-20f0-42d1-96fd-3bd22e1461c8" />



<img width="1239" height="474" alt="image" src="https://github.com/user-attachments/assets/643d121b-35e9-45b0-96d7-4d7f47def44e" />




<img width="1404" height="548" alt="image" src="https://github.com/user-attachments/assets/b2d77783-894e-491b-88f5-8e911cc4bb90" />

<img width="1625" height="646" alt="image" src="https://github.com/user-attachments/assets/cd3dba77-4bc8-488e-8512-9eeb331b4b1c" />

<img width="1232" height="442" alt="image" src="https://github.com/user-attachments/assets/d75c71bd-934b-46db-b44d-48d2ea6cd965" />



</details>
