### PR TITLE
Cloudflare Zone ID not Secret / Delete DKIM keys on teardown

### DIFF
--- a/pulumi/Pulumi.prod.yaml
+++ b/pulumi/Pulumi.prod.yaml
@@ -79,7 +79,5 @@ config:
     secure: AAABADpuLw71MLJ5RyYEN7G47RC88uj8dznCXUo3JS4p8Mwnvw+FG3j19+CyhM6jnpdtGGbSnc3QGQwMlBrrxA==
   accounts:stalwart-webhook-secret:
     secure: AAABABaIJ/x287l9pyLW3HzJ5f7mCJv/o/96+jaI0KFU9VfIj6O+4OtFq5vfVJqqKH1LPOnkpMk0bneC3m/6TU/cmGdIPu2B/+U/qb6odlegj2TO1Gzu45wrGd2Qgthl
-  accounts:hosted-dkim-cloudflare-zone-id:
-    secure: AAABANBKKCmFU9bVj65f5giqgQ95B+HTFfo4CJIWE6gjxwL6fhCmAJpsPQny7dtlWkD97CS4iUVhZxb3IYiplg==
   accounts:hosted-dkim-cloudflare-api-token:
     secure: AAABAMYcS63m9YrFGLN7OEqyawkd3nbImI4NuBZrbbijsMr2EAXV0eezUFY9FH/CnOpRRAjU25lCQxjtEEWwp0IHaf5GRV2Ea5+JzCN6/P2c/srrgA==

--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -75,10 +75,4 @@ config:
   accounts:stalwart-webhook-secret:
     secure: AAABAE1N1CyUZ9eTZ+mr2lzvFJp3+i5mSKkK9jStUzamU+uwev45bZZfSh2EIJofNHj5Zyi1VOtqFnE6tmKMvlwLdaSvvV+Uje2eClEJ7KpT28IZA1Ad5GlR6r6BmZ8v
   accounts:hosted-dkim-cloudflare-api-token:
-<<<<<<< HEAD
-    secure: AAABAJ/Ditu8A0PWEq0lgffMUFRyUStPWn+43CPYOpTS/0oLKLYA1E9olA2e+o4NbMt3R1hnHoKePLHRoja11FHnt7Gf/vkl7CuzS6RCGNf4/VAzbw==
-  accounts:hosted-dkim-cloudflare-zone-id:
-    secure: AAABANUaXjYvUkpuCZjrCOWu+ZEAHpJjf85ASuKGaUVV7af7x70t8StIPvLD7KzieM2agKZwbAQ2SVA2UjpR1g==
-=======
     secure: AAABAG/M9PEQLSK5ybOaYspp1TEle7+cqNYuGTEBVmRzIqEHrkj4Znc0mUxEjAyuMVlOfDMVOENYqtFPzd7WlwT/aKqh3XkoU+OR72Z3dD9o/hKLLA==
->>>>>>> b51e2f7 (Convert zone-id from secret to public)

--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -75,4 +75,4 @@ config:
   accounts:stalwart-webhook-secret:
     secure: AAABAE1N1CyUZ9eTZ+mr2lzvFJp3+i5mSKkK9jStUzamU+uwev45bZZfSh2EIJofNHj5Zyi1VOtqFnE6tmKMvlwLdaSvvV+Uje2eClEJ7KpT28IZA1Ad5GlR6r6BmZ8v
   accounts:hosted-dkim-cloudflare-api-token:
-    secure: AAABAG/M9PEQLSK5ybOaYspp1TEle7+cqNYuGTEBVmRzIqEHrkj4Znc0mUxEjAyuMVlOfDMVOENYqtFPzd7WlwT/aKqh3XkoU+OR72Z3dD9o/hKLLA==
+    secure: AAABAJ/Ditu8A0PWEq0lgffMUFRyUStPWn+43CPYOpTS/0oLKLYA1E9olA2e+o4NbMt3R1hnHoKePLHRoja11FHnt7Gf/vkl7CuzS6RCGNf4/VAzbw==

--- a/pulumi/Pulumi.stage.yaml
+++ b/pulumi/Pulumi.stage.yaml
@@ -75,6 +75,10 @@ config:
   accounts:stalwart-webhook-secret:
     secure: AAABAE1N1CyUZ9eTZ+mr2lzvFJp3+i5mSKkK9jStUzamU+uwev45bZZfSh2EIJofNHj5Zyi1VOtqFnE6tmKMvlwLdaSvvV+Uje2eClEJ7KpT28IZA1Ad5GlR6r6BmZ8v
   accounts:hosted-dkim-cloudflare-api-token:
+<<<<<<< HEAD
     secure: AAABAJ/Ditu8A0PWEq0lgffMUFRyUStPWn+43CPYOpTS/0oLKLYA1E9olA2e+o4NbMt3R1hnHoKePLHRoja11FHnt7Gf/vkl7CuzS6RCGNf4/VAzbw==
   accounts:hosted-dkim-cloudflare-zone-id:
     secure: AAABANUaXjYvUkpuCZjrCOWu+ZEAHpJjf85ASuKGaUVV7af7x70t8StIPvLD7KzieM2agKZwbAQ2SVA2UjpR1g==
+=======
+    secure: AAABAG/M9PEQLSK5ybOaYspp1TEle7+cqNYuGTEBVmRzIqEHrkj4Znc0mUxEjAyuMVlOfDMVOENYqtFPzd7WlwT/aKqh3XkoU+OR72Z3dD9o/hKLLA==
+>>>>>>> b51e2f7 (Convert zone-id from secret to public)

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -38,6 +38,7 @@
 .hosted_dkim_selectors: &VAR_HOSTED_DKIM_SELECTORS {name: "HOSTED_DKIM_SELECTORS", value: "tm1,tm2,tm3"}
 .hosted_dkim_cloudflare_enabled: &VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED {name: "HOSTED_DKIM_CLOUDFLARE_ENABLED", value: "True"}
 .hosted_dkim_cloudflare_ttl: &VAR_HOSTED_DKIM_CLOUDFLARE_TTL {name: "HOSTED_DKIM_CLOUDFLARE_TTL", value: "3600"}
+.hosted_dkim_cloudflare_zone_id: &VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", value: "c62211cc60fe5ed1bca1d600ddfd341f"}
 .oidc_fallback_match_by_email: &VAR_OIDC_FALLBACK_MATCH_BY_EMAIL {name: "OIDC_FALLBACK_MATCH_BY_EMAIL", value: "True"}
 .oidc_url_auth: &VAR_OIDC_URL_AUTH {name: "OIDC_URL_AUTH", value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth/"}
 .oidc_url_jwks: &VAR_OIDC_URL_JWKS {name: "OIDC_URL_JWKS", value: "https://auth.tb.pro/realms/tbpro/protocol/openid-connect/certs/"}
@@ -98,7 +99,6 @@
 .stalwart_api_auth_method: &SECRET_STALWART_API_AUTH_METHOD {name: "STALWART_API_AUTH_METHOD", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-method-ErlvTR"}
 .stalwart_api_auth_string: &SECRET_STALWART_API_AUTH_STRING {name: "STALWART_API_AUTH_STRING", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-api-auth-key-cnGrUN"}
 .hosted_dkim_cloudflare_api_token: &SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN {name: "HOSTED_DKIM_CLOUDFLARE_API_TOKEN", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/hosted-dkim-cloudflare-api-token-3rY2yV"}
-.hosted_dkim_cloudflare_zone_id: &SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/hosted-dkim-cloudflare-zone-id-dnPjOo"}
 # Shared HMAC secret that Stalwart uses to sign outgoing webhook payloads. Must match the
 # `webhook.posthog.signature-key` value configured in Stalwart's admin API on mailstrom-prod.
 .stalwart_webhook_secret: &SECRET_STALWART_WEBHOOK_SECRET {name: "STALWART_WEBHOOK_SECRET", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/stalwart-webhook-secret-t8yGzq"}
@@ -161,7 +161,6 @@
     - *SECRET_STALWART_API_AUTH_METHOD
     - *SECRET_STALWART_API_AUTH_STRING
     - *SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN
-    - *SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
     - *SECRET_ZENDESK_API_TOKEN
     - *SECRET_ZENDESK_SUBDOMAIN
     - *SECRET_ZENDESK_USER_EMAIL
@@ -315,7 +314,6 @@ resources:
         - stalwart-api-auth-method
         - stalwart-api-auth-key
         - hosted-dkim-cloudflare-api-token
-        - hosted-dkim-cloudflare-zone-id
         - stalwart-webhook-secret
         - keycloak-admin-client-id
         - keycloak-admin-client-secret
@@ -411,6 +409,7 @@ resources:
                 - *VAR_HOSTED_DKIM_SELECTORS
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_TTL
+                - *VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
                 - *VAR_SUPPORT_CONTACT
                 - *VAR_TB_PRO_APPOINTMENT_URL
                 - *VAR_TB_PRO_SEND_URL
@@ -494,6 +493,7 @@ resources:
                 - *VAR_HOSTED_DKIM_SELECTORS
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_TTL
+                - *VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
                 - *VAR_SUPPORT_CONTACT
                 - *VAR_TB_PRO_APPOINTMENT_URL
                 - *VAR_TB_PRO_SEND_URL
@@ -815,7 +815,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/prod/appointment-caldav-secret-eJOI7y
               - *SECRET_POSTHOG_API_KEY
               - *SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN
-              - *SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
 
             environment:
               - name: TIMES_I_NEED_TO_REDEPLOY_WITHOUT_CHANGING_IMAGE
@@ -910,6 +909,8 @@ resources:
                 value: 'True'
               - name: HOSTED_DKIM_CLOUDFLARE_TTL
                 value: '3600'
+              - name: HOSTED_DKIM_CLOUDFLARE_ZONE_ID
+                value: 'c62211cc60fe5ed1bca1d600ddfd341f'
               - name: TB_PRO_APPOINTMENT_URL
                 value: 'https://appointment.tb.pro/'
               - name: TB_PRO_SEND_URL

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -37,6 +37,7 @@
 .hosted_dkim_selectors: &VAR_HOSTED_DKIM_SELECTORS {name: "HOSTED_DKIM_SELECTORS", value: "tm1,tm2,tm3"}
 .hosted_dkim_cloudflare_enabled: &VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED {name: "HOSTED_DKIM_CLOUDFLARE_ENABLED", value: "True"}
 .hosted_dkim_cloudflare_ttl: &VAR_HOSTED_DKIM_CLOUDFLARE_TTL {name: "HOSTED_DKIM_CLOUDFLARE_TTL", value: "3600"}
+.hosted_dkim_cloudflare_zone_id: &VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", value: "c6e8d56e54e126edb68c1e8f1bbafe49"}
 .oidc_url_auth: &VAR_OIDC_URL_AUTH {name: "OIDC_URL_AUTH", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/auth"}
 .oidc_url_jwks: &VAR_OIDC_URL_JWKS {name: "OIDC_URL_JWKS", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/certs"}
 .oidc_url_logout: &VAR_OIDC_URL_LOGOUT {name: "OIDC_URL_LOGOUT", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/logout"}
@@ -93,7 +94,6 @@
 .stalwart_api_auth_method: &SECRET_STALWART_API_AUTH_METHOD {name: "STALWART_API_AUTH_METHOD", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/stalwart-api-auth-method-OeouRm"}
 .stalwart_api_auth_string: &SECRET_STALWART_API_AUTH_STRING {name: "STALWART_API_AUTH_STRING", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/stalwart-api-auth-key-9Vlhwc"}
 .hosted_dkim_cloudflare_api_token: &SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN {name: "HOSTED_DKIM_CLOUDFLARE_API_TOKEN", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/hosted-dkim-cloudflare-api-token-2Lwjs0"}
-.hosted_dkim_cloudflare_zone_id: &SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/hosted-dkim-cloudflare-zone-id-jWKJt6"}
 # Shared HMAC secret that Stalwart uses to sign outgoing webhook payloads. Must match the
 # `webhook.posthog.signature-key` value configured in Stalwart's admin API on mailstrom-stage.
 .stalwart_webhook_secret: &SECRET_STALWART_WEBHOOK_SECRET {name: "STALWART_WEBHOOK_SECRET", valueFrom: "arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/stalwart-webhook-secret-poF35r"}
@@ -153,7 +153,6 @@
     - *SECRET_STALWART_API_AUTH_METHOD
     - *SECRET_STALWART_API_AUTH_STRING
     - *SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN
-    - *SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
     - *SECRET_ZENDESK_API_TOKEN
     - *SECRET_ZENDESK_SUBDOMAIN
     - *SECRET_ZENDESK_USER_EMAIL
@@ -317,7 +316,6 @@ resources:
         - stalwart-api-auth-method
         - stalwart-api-auth-key
         - hosted-dkim-cloudflare-api-token
-        - hosted-dkim-cloudflare-zone-id
         - stalwart-webhook-secret
         - keycloak-admin-client-id
         - keycloak-admin-client-secret
@@ -407,6 +405,7 @@ resources:
                 - *VAR_HOSTED_DKIM_SELECTORS
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_TTL
+                - *VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
                 - *VAR_SUPPORT_CONTACT
                 - *VAR_TB_PRO_APPOINTMENT_URL
                 - *VAR_TB_PRO_SEND_URL
@@ -488,6 +487,7 @@ resources:
                 - *VAR_HOSTED_DKIM_SELECTORS
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED
                 - *VAR_HOSTED_DKIM_CLOUDFLARE_TTL
+                - *VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
                 - *VAR_SUPPORT_CONTACT
                 - *VAR_TB_PRO_APPOINTMENT_URL
                 - *VAR_TB_PRO_SEND_URL
@@ -805,7 +805,6 @@ resources:
                 valueFrom: arn:aws:secretsmanager:eu-central-1:768512802988:secret:accounts/stage/appointment-caldav-secret-CU7WNc
               - *SECRET_POSTHOG_API_KEY
               - *SECRET_HOSTED_DKIM_CLOUDFLARE_API_TOKEN
-              - *SECRET_HOSTED_DKIM_CLOUDFLARE_ZONE_ID
             environment:
               - name: ADMIN_WEBSITE
                 value: https://www.thunderbird.net
@@ -897,6 +896,8 @@ resources:
                 value: 'True'
               - name: HOSTED_DKIM_CLOUDFLARE_TTL
                 value: '3600'
+              - name: HOSTED_DKIM_CLOUDFLARE_ZONE_ID
+                value: 'c6e8d56e54e126edb68c1e8f1bbafe49'
               - name: TB_PRO_APPOINTMENT_URL
                 value: 'https://appointment-stage.tb.pro/'
               - name: TB_PRO_SEND_URL

--- a/src/thunderbird_accounts/mail/dkim.py
+++ b/src/thunderbird_accounts/mail/dkim.py
@@ -72,6 +72,20 @@ class CloudflareDNSClient:
             comment=HOSTED_DKIM_RECORD_COMMENT,
         )
 
+    def delete_txt_records(self, name: str) -> list[str]:
+        records = self._list_txt_records(name)
+        deleted_record_ids = []
+
+        for record in records:
+            record_id = _record_value(record, 'id')
+            if not record_id:
+                continue
+
+            self.client.dns.records.delete(record_id, zone_id=self.zone_id)
+            deleted_record_ids.append(record_id)
+
+        return deleted_record_ids
+
 
 @cache
 def _normalize_domain(domain_name: str) -> str:
@@ -171,6 +185,19 @@ def build_customer_dkim_cname_records(domain_name: str, hosted_domain: str | Non
     ]
 
 
+def build_hosted_dkim_txt_record_names(domain_name: str, hosted_domain: str | None = None) -> list[str]:
+    """Builds hosted DKIM TXT record names for a given domain name.
+    If hosted domain is not specified it falls back on ``settings.HOSTED_DKIM_DOMAIN``"""
+    hosted_domain = hosted_domain or settings.HOSTED_DKIM_DOMAIN
+    if not hosted_domain:
+        return []
+
+    domain_name = _normalize_domain(domain_name)
+    return [
+        hosted_dkim_record_name(selector, domain_name, hosted_domain) for selector in settings.HOSTED_DKIM_SELECTORS
+    ]
+
+
 def build_hosted_dkim_txt_records(domain_name: str, dkim_dns_records: list[dict]) -> list[dict[str, str]]:
     """Builds dkim TXT dns records for a given domain name.
     If hosted domain is not specified it falls back on ``settings.HOSTED_DKIM_DOMAIN``"""
@@ -233,3 +260,21 @@ def publish_hosted_dkim_txt_records(hosted_records: list[dict[str, str]], dns_cl
         dns_client.upsert_txt_record(record['name'], record['content'])
 
     return hosted_records
+
+
+def delete_hosted_dkim_txt_records(domain_name: str, dns_client=None) -> list[dict[str, str | list[str]]]:
+    """Deletes hosted DKIM TXT records for a given domain name.
+    If dns_client is not specified it falls back on ``CloudflareDNSClient``"""
+    dns_client = dns_client or CloudflareDNSClient()
+
+    deleted_records = []
+    for name in build_hosted_dkim_txt_record_names(domain_name):
+        deleted_records.append(
+            {
+                'type': 'TXT',
+                'name': name,
+                'deleted_record_ids': dns_client.delete_txt_records(name),
+            }
+        )
+
+    return deleted_records

--- a/src/thunderbird_accounts/mail/exceptions.py
+++ b/src/thunderbird_accounts/mail/exceptions.py
@@ -96,6 +96,26 @@ class HostedDkimPublishRetry(Exception):
         return f'HostedDkimPublishRetry: {self.phase} failed for {self.domain}: {self.reason}'
 
 
+class HostedDkimDeleteRetry(Exception):
+    """Raise when hosted DKIM deletion should be retried."""
+
+    domain: str
+    phase: str  # Phase of delete where exception happened.
+    reason: str
+    context: dict
+
+    def __init__(self, domain: str, phase: str, reason: str = 'Unknown', error_type: str | None = None):
+        self.domain = domain
+        self.phase = phase
+        self.reason = reason or 'Unknown'
+        self.error_type = error_type
+        self.context = {key: getattr(self, key) for key in ('domain', 'phase', 'reason', 'error_type')}
+        super().__init__(self.context)
+
+    def __str__(self):
+        return f'HostedDkimDeleteRetry: {self.phase} failed for {self.domain}: {self.reason}'
+
+
 class EmailNotValidError(RuntimeError):
     """Raises in utils.validate_email"""
 

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -11,10 +11,17 @@ from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.clients import MailClient
 from thunderbird_accounts.mail.dkim import (
     CloudflareDNSClient,
+    build_hosted_dkim_txt_record_names,
     build_hosted_dkim_txt_records,
+    delete_hosted_dkim_txt_records,
     publish_hosted_dkim_txt_records,
 )
-from thunderbird_accounts.mail.exceptions import AccountNotFoundError, DomainNotFoundError, HostedDkimPublishRetry
+from thunderbird_accounts.mail.exceptions import (
+    AccountNotFoundError,
+    DomainNotFoundError,
+    HostedDkimDeleteRetry,
+    HostedDkimPublishRetry,
+)
 from thunderbird_accounts.mail.models import Account, Email
 from thunderbird_accounts.celery.exceptions import TaskFailed
 from thunderbird_accounts.core.types import TaskReturnStatus
@@ -228,6 +235,62 @@ def publish_hosted_dkim_dns_records(self, domain_name: str):
         )
         sentry_sdk.set_context('hosted_dkim_publish_retry', retry_error.context)
         logging.warning(f'[publish_hosted_dkim_dns_records] Error publishing hosted DKIM records: {retry_error}')
+        raise retry_error from ex
+
+    return {
+        'domain_name': domain_name,
+        'records': hosted_records,
+        'skipped': skipped,
+        'task_status': TaskReturnStatus.SUCCESS,
+    }
+
+
+@shared_task(
+    bind=True,
+    autoretry_for=(HostedDkimDeleteRetry,),
+    retry_backoff=True,
+    retry_backoff_max=60 * 60,  # 1 hour
+    retry_jitter=True,
+    max_retries=24,
+)
+def delete_hosted_dkim_dns_records(self, domain_name: str):
+    phase = 'initialize'
+    hosted_records = []
+
+    try:
+        phase = 'build_hosted_txt_record_names'
+        hosted_records = [{'type': 'TXT', 'name': name} for name in build_hosted_dkim_txt_record_names(domain_name)]
+
+        if settings.HOSTED_DKIM_CLOUDFLARE_ENABLED:
+            phase = 'delete_cloudflare_txt_records'
+            hosted_records = delete_hosted_dkim_txt_records(
+                domain_name,
+                dns_client=CloudflareDNSClient(),
+            )
+            skipped = False
+        else:
+            for record in hosted_records:
+                logging.info(
+                    'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
+                    f'"{record["type"]} {record["name"]}"'
+                )
+            skipped = True
+    except ImproperlyConfigured as ex:
+        logging.error(f'[delete_hosted_dkim_dns_records] Hosted DKIM is misconfigured: {ex}')
+        raise TaskFailed(str(ex), {'domain': domain_name})
+    except HostedDkimDeleteRetry as ex:
+        sentry_sdk.set_context('hosted_dkim_delete_retry', ex.context)
+        logging.warning(f'[delete_hosted_dkim_dns_records] Error deleting hosted DKIM records: {ex}')
+        raise
+    except Exception as ex:
+        retry_error = HostedDkimDeleteRetry(
+            domain_name,
+            phase,
+            str(ex),
+            error_type=type(ex).__name__,
+        )
+        sentry_sdk.set_context('hosted_dkim_delete_retry', retry_error.context)
+        logging.warning(f'[delete_hosted_dkim_dns_records] Error deleting hosted DKIM records: {retry_error}')
         raise retry_error from ex
 
     return {

--- a/src/thunderbird_accounts/mail/tests/test_dkim.py
+++ b/src/thunderbird_accounts/mail/tests/test_dkim.py
@@ -1,5 +1,5 @@
 import base64
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
@@ -8,7 +8,9 @@ from django.test import SimpleTestCase, override_settings
 from thunderbird_accounts.mail.dkim import (
     CloudflareDNSClient,
     build_customer_dkim_cname_records,
+    build_hosted_dkim_txt_record_names,
     build_hosted_dkim_txt_records,
+    delete_hosted_dkim_txt_records,
     dkim_signatures_to_dns_records,
 )
 
@@ -78,6 +80,52 @@ class HostedDkimRecordBuilderTestCase(SimpleTestCase):
 
         self.assertEqual(
             [{'type': 'TXT', 'name': 'tm1.example.com.dkim.example.net', 'content': 'v=DKIM1; k=rsa; p=example'}],
+            records,
+        )
+
+    def test_builds_hosted_txt_record_names_for_all_selectors(self):
+        records = build_hosted_dkim_txt_record_names('Example.COM.')
+
+        self.assertEqual(
+            [
+                'tm1.example.com.dkim.example.net',
+                'tm2.example.com.dkim.example.net',
+                'tm3.example.com.dkim.example.net',
+            ],
+            records,
+        )
+
+    def test_deletes_hosted_txt_records_for_all_selectors(self):
+        dns_client = Mock()
+        dns_client.delete_txt_records.side_effect = [['record-1'], [], ['record-3']]
+
+        records = delete_hosted_dkim_txt_records('Example.COM.', dns_client=dns_client)
+
+        dns_client.delete_txt_records.assert_has_calls(
+            [
+                call('tm1.example.com.dkim.example.net'),
+                call('tm2.example.com.dkim.example.net'),
+                call('tm3.example.com.dkim.example.net'),
+            ]
+        )
+        self.assertEqual(
+            [
+                {
+                    'type': 'TXT',
+                    'name': 'tm1.example.com.dkim.example.net',
+                    'deleted_record_ids': ['record-1'],
+                },
+                {
+                    'type': 'TXT',
+                    'name': 'tm2.example.com.dkim.example.net',
+                    'deleted_record_ids': [],
+                },
+                {
+                    'type': 'TXT',
+                    'name': 'tm3.example.com.dkim.example.net',
+                    'deleted_record_ids': ['record-3'],
+                },
+            ],
             records,
         )
 
@@ -188,6 +236,7 @@ class DkimSignatureConversionTestCase(SimpleTestCase):
             )
 
 
+@override_settings(HOSTED_DKIM_CLOUDFLARE_ZONE_ID='zone-id')
 class CloudflareDNSClientTestCase(SimpleTestCase):
     def test_creates_txt_record_when_missing(self):
         cloudflare_client = Mock()
@@ -235,3 +284,38 @@ class CloudflareDNSClientTestCase(SimpleTestCase):
 
         cloudflare_client.dns.records.update.assert_not_called()
         cloudflare_client.dns.records.create.assert_not_called()
+
+    def test_deletes_all_txt_records_for_name(self):
+        cloudflare_client = Mock()
+        cloudflare_client.dns.records.list.return_value = _cloudflare_page(
+            [
+                {'id': 'record-1', 'name': 'tm1.example.com.dkim.example.net', 'content': 'one'},
+                {'id': 'record-2', 'name': 'tm1.example.com.dkim.example.net', 'content': 'two'},
+            ]
+        )
+        dns_client = CloudflareDNSClient(api_token='secret', client=cloudflare_client)
+
+        deleted_record_ids = dns_client.delete_txt_records('tm1.example.com.dkim.example.net')
+
+        cloudflare_client.dns.records.list.assert_called_once_with(
+            zone_id='zone-id',
+            type='TXT',
+            name={'exact': 'tm1.example.com.dkim.example.net'},
+        )
+        cloudflare_client.dns.records.delete.assert_has_calls(
+            [
+                call('record-1', zone_id='zone-id'),
+                call('record-2', zone_id='zone-id'),
+            ]
+        )
+        self.assertEqual(['record-1', 'record-2'], deleted_record_ids)
+
+    def test_delete_txt_records_returns_empty_list_when_missing(self):
+        cloudflare_client = Mock()
+        cloudflare_client.dns.records.list.return_value = _cloudflare_page([])
+        dns_client = CloudflareDNSClient(api_token='secret', client=cloudflare_client)
+
+        deleted_record_ids = dns_client.delete_txt_records('tm1.example.com.dkim.example.net')
+
+        cloudflare_client.dns.records.delete.assert_not_called()
+        self.assertEqual([], deleted_record_ids)

--- a/src/thunderbird_accounts/mail/tests/test_tasks.py
+++ b/src/thunderbird_accounts/mail/tests/test_tasks.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail import tasks
-from thunderbird_accounts.mail.exceptions import AccountNotFoundError, HostedDkimPublishRetry
+from thunderbird_accounts.mail.exceptions import AccountNotFoundError, HostedDkimDeleteRetry, HostedDkimPublishRetry
 from thunderbird_accounts.mail.models import Account, Email
 from thunderbird_accounts.core.tests.utils import build_mail_get_account
 
@@ -154,6 +154,113 @@ class PublishHostedDkimDNSRecordsTestCase(TaskTestCase):
         self.assertEqual('fetch_stalwart_dkim_dns_records', cm.exception.context['phase'])
         self.assertEqual('RuntimeError', cm.exception.context['error_type'])
         set_sentry_context_mock.assert_called_once_with('hosted_dkim_publish_retry', cm.exception.context)
+
+
+class DeleteHostedDkimDNSRecordsTestCase(TaskTestCase):
+    @override_settings(
+        HOSTED_DKIM_CLOUDFLARE_ENABLED=False,
+        HOSTED_DKIM_DOMAIN='dkim.example.net',
+        HOSTED_DKIM_SELECTORS=['tm1', 'tm2', 'tm3'],
+    )
+    @patch('thunderbird_accounts.mail.tasks.CloudflareDNSClient')
+    def test_logs_records_when_cloudflare_deletion_disabled(self, cloudflare_client_mock):
+        with self.assertLogs(level='INFO') as logs:
+            results = tasks.delete_hosted_dkim_dns_records.run(domain_name='example.com')
+
+        self.assertEqual(results['task_status'], 'success')
+        self.assertTrue(results['skipped'])
+        self.assertEqual(
+            [
+                {'type': 'TXT', 'name': 'tm1.example.com.dkim.example.net'},
+                {'type': 'TXT', 'name': 'tm2.example.com.dkim.example.net'},
+                {'type': 'TXT', 'name': 'tm3.example.com.dkim.example.net'},
+            ],
+            results['records'],
+        )
+        cloudflare_client_mock.assert_not_called()
+        self.assertIn(
+            'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
+            '"TXT tm1.example.com.dkim.example.net"',
+            logs.output[0],
+        )
+        self.assertIn(
+            'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
+            '"TXT tm2.example.com.dkim.example.net"',
+            logs.output[1],
+        )
+        self.assertIn(
+            'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
+            '"TXT tm3.example.com.dkim.example.net"',
+            logs.output[2],
+        )
+
+    @override_settings(
+        HOSTED_DKIM_CLOUDFLARE_ENABLED=True,
+        HOSTED_DKIM_CLOUDFLARE_ZONE_ID='zone-id',
+        HOSTED_DKIM_CLOUDFLARE_API_TOKEN='secret',
+        HOSTED_DKIM_DOMAIN='dkim.example.net',
+        HOSTED_DKIM_SELECTORS=['tm1', 'tm2', 'tm3'],
+    )
+    @patch('thunderbird_accounts.mail.tasks.CloudflareDNSClient')
+    def test_deletes_hosted_dkim_records_from_cloudflare(self, cloudflare_client_mock):
+        cloudflare_client_mock.return_value.delete_txt_records.side_effect = [['record-1'], ['record-2'], []]
+
+        results = tasks.delete_hosted_dkim_dns_records.run(domain_name='example.com')
+
+        cloudflare_client_mock.return_value.delete_txt_records.assert_has_calls(
+            [
+                call('tm1.example.com.dkim.example.net'),
+                call('tm2.example.com.dkim.example.net'),
+                call('tm3.example.com.dkim.example.net'),
+            ]
+        )
+        self.assertEqual(results['task_status'], 'success')
+        self.assertFalse(results['skipped'])
+        self.assertEqual(
+            [
+                {
+                    'type': 'TXT',
+                    'name': 'tm1.example.com.dkim.example.net',
+                    'deleted_record_ids': ['record-1'],
+                },
+                {
+                    'type': 'TXT',
+                    'name': 'tm2.example.com.dkim.example.net',
+                    'deleted_record_ids': ['record-2'],
+                },
+                {
+                    'type': 'TXT',
+                    'name': 'tm3.example.com.dkim.example.net',
+                    'deleted_record_ids': [],
+                },
+            ],
+            results['records'],
+        )
+
+    @override_settings(
+        HOSTED_DKIM_CLOUDFLARE_ENABLED=True,
+        HOSTED_DKIM_CLOUDFLARE_ZONE_ID='zone-id',
+        HOSTED_DKIM_CLOUDFLARE_API_TOKEN='secret',
+        HOSTED_DKIM_DOMAIN='dkim.example.net',
+        HOSTED_DKIM_SELECTORS=['tm1'],
+    )
+    @patch('thunderbird_accounts.mail.tasks.sentry_sdk.set_context')
+    @patch('thunderbird_accounts.mail.tasks.CloudflareDNSClient')
+    def test_retries_with_context_when_cloudflare_delete_fails(
+        self, cloudflare_client_mock, set_sentry_context_mock
+    ):
+        cloudflare_client_mock.return_value.delete_txt_records.side_effect = RuntimeError('Cloudflare unavailable')
+
+        with self.assertRaises(HostedDkimDeleteRetry) as cm:
+            tasks.delete_hosted_dkim_dns_records.run(domain_name='example.com')
+
+        self.assertEqual('example.com', cm.exception.domain)
+        self.assertEqual('delete_cloudflare_txt_records', cm.exception.phase)
+        self.assertEqual('Cloudflare unavailable', cm.exception.reason)
+        self.assertEqual('example.com', cm.exception.context['domain'])
+        self.assertEqual('delete_cloudflare_txt_records', cm.exception.context['phase'])
+        self.assertEqual('RuntimeError', cm.exception.context['error_type'])
+        set_sentry_context_mock.assert_called_once_with('hosted_dkim_delete_retry', cm.exception.context)
 
 
 class CreateStalwartAccountTestCase(TaskTestCase):

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.clients import DomainVerificationErrors, StaleDNSRecordCode
 from thunderbird_accounts.mail.models import Account, Domain, Email
-from thunderbird_accounts.mail.views import get_dns_records
+from thunderbird_accounts.mail.views import get_dns_records, remove_custom_domain
 
 
 class AppPasswordApiTestCase(TestCase):
@@ -318,6 +318,87 @@ class VerifyCustomDomainTestCase(TestCase):
 
         self.domain.refresh_from_db()
         self.assertEqual(Domain.DomainStatus.FAILED, self.domain.status)
+
+
+class RemoveCustomDomainTestCase(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+        self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        self.account = Account.objects.create(name=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', user=self.user)
+        self.domain = Domain.objects.create(
+            name='example.com',
+            user=self.user,
+            stalwart_id='domain-id',
+            status=Domain.DomainStatus.VERIFIED,
+        )
+        self.url = reverse('remove_custom_domain')
+
+    def _delete_domain(self):
+        request = self.request_factory.delete(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+        request.user = self.user
+        return remove_custom_domain(request)
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_success_deletes_stalwart_dkim_cloudflare_records_and_local_domain(
+        self,
+        mock_mail_client_cls,
+        mock_delete_hosted_dkim_dns_records,
+    ):
+        mock_instance = Mock()
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self._delete_domain()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode()), {'success': True})
+        mock_instance.delete_domain.assert_called_once_with(self.domain.name)
+        mock_instance.delete_dkim.assert_called_once_with(self.domain.name)
+        mock_delete_hosted_dkim_dns_records.assert_called_once_with(self.domain.name)
+        self.assertFalse(Domain.objects.filter(name=self.domain.name).exists())
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_pending_domain_still_deletes_dkim_and_cloudflare_records(
+        self,
+        mock_mail_client_cls,
+        mock_delete_hosted_dkim_dns_records,
+    ):
+        self.domain.stalwart_id = None
+        self.domain.status = Domain.DomainStatus.PENDING
+        self.domain.save()
+        mock_instance = Mock()
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self._delete_domain()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode()), {'success': True})
+        mock_instance.delete_domain.assert_not_called()
+        mock_instance.delete_dkim.assert_called_once_with(self.domain.name)
+        mock_delete_hosted_dkim_dns_records.assert_called_once_with(self.domain.name)
+        self.assertFalse(Domain.objects.filter(name=self.domain.name).exists())
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_domain_with_alias_cannot_be_removed(
+        self,
+        mock_mail_client_cls,
+        mock_delete_hosted_dkim_dns_records,
+    ):
+        Email.objects.create(address=f'alias@{self.domain.name}', type=Email.EmailType.ALIAS, account=self.account)
+
+        response = self._delete_domain()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(json.loads(response.content.decode())['success'])
+        mock_mail_client_cls.assert_not_called()
+        mock_delete_hosted_dkim_dns_records.assert_not_called()
+        self.assertTrue(Domain.objects.filter(name=self.domain.name).exists())
 
 
 class AddEmailAliasTestCase(TestCase):

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -353,14 +353,18 @@ def remove_custom_domain(request: HttpRequest):
             if _domain.stalwart_id:
                 try:
                     cleanup_phase = 'delete_stalwart_domain'
-                    stalwart_client.delete_domain(domain.name)
+                    stalwart_client.delete_domain(_domain.name)
                 except DomainNotFoundError as ex:
                     # While it's not in Stalwart we seem to have a local reference,
                     # so try deleting dkim and then local ref
                     _capture_domain_exception(ex, domain, phase='delete_stalwart_domain_not_found')
-                cleanup_phase = 'delete_dkim'
-                stalwart_client.delete_dkim(domain.name)
-                break
+
+            cleanup_phase = 'delete_dkim'
+            stalwart_client.delete_dkim(_domain.name)
+
+            cleanup_phase = 'delete_hosted_dkim_dns_records'
+            mail_tasks.delete_hosted_dkim_dns_records.delay(_domain.name)
+            break
 
         cleanup_phase = 'delete_local_domain'
         domain.delete()


### PR DESCRIPTION
- **Convert zone-id from secret to public**
- **Delete DKIM records from Cloudflare when they are deleted from accounts.**

## QA Log

- Tested locally
