### PR TITLE
Check aliases on the debounced username check during sign-up. (Fixes #912)

### DIFF
--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -1,6 +1,6 @@
 from thunderbird_accounts.authentication.utils import is_email_reserved, is_email_in_allow_list
 from thunderbird_accounts.mail.exceptions import EmailNotValidError
-from thunderbird_accounts.mail.utils import validate_email
+from thunderbird_accounts.mail.utils import validate_email, is_address_taken
 from rest_framework.permissions import AllowAny
 from django.conf import settings
 from rest_framework.throttling import UserRateThrottle
@@ -42,8 +42,7 @@ def is_username_available(request: Request):
     except EmailNotValidError as ex:
         raise ValidationError(ex.error_message)
 
-    user = User.objects.filter(username=full_username).first()
-    if user:
+    if is_address_taken(full_username):
         raise ValidationError(_('This username is already taken. Try another one.'))
 
     return Response(status=200)

--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from django.utils.translation import gettext_lazy as _
 
 
-from thunderbird_accounts.authentication.models import User
 
 
 class UsernameAvailableThrottle(UserRateThrottle):

--- a/src/thunderbird_accounts/mail/tests/test_api.py
+++ b/src/thunderbird_accounts/mail/tests/test_api.py
@@ -1,3 +1,6 @@
+from thunderbird_accounts.mail.models import Account, Email
+from thunderbird_accounts.authentication.models import User
+from django.urls import reverse
 from unittest.mock import patch
 
 from django.test import override_settings, Client as RequestClient
@@ -49,3 +52,40 @@ class CheckEmailIsOnAllowListApiTestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'is_on_allow_list': True})
         mock_is_email_in_allow_list.assert_not_called()
+
+
+class IsUsernameAvailableTestCase(APITestCase):
+    def setUp(self):
+        self.client = RequestClient()
+        self.url = reverse('api_is_username_available')
+
+    def test_success(self):
+        """Use a username that no one else has"""
+        response = self.client.post(self.url, {'username': 'hello'})
+        self.assertEqual(response.status_code, 200)
+
+    def test_reserved_word(self):
+        """Fail on a reserved word like admin or thunderbird"""
+        response = self.client.post(self.url, {'username': 'thunderbird'})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()[0], 'This username is not valid. Try another one.')
+
+    def test_in_use_username(self):
+        """Fail on an in-use username"""
+        # Create a user with an in-use username
+        user = User.objects.create(username='fred@example.org')
+
+        response = self.client.post(self.url, {'username': user.username.split('@')[0]})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()[0], 'This username is already taken. Try another one.')
+
+    def test_in_use_alias(self):
+        """Fail on an alias that is already in-use"""
+        # Create a user with an in-use username
+        user = User.objects.create(username='fred@example.org')
+        account = Account.objects.create(name=user.username, user=user)
+        email = Email.objects.create(address='fred-is-cool@example.org', type=Email.EmailType.ALIAS, account=account)
+
+        response = self.client.post(self.url, {'username': email.address.split('@')[0]})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()[0], 'This username is already taken. Try another one.')


### PR DESCRIPTION
Fixes #912 

I've replaced the simple username check with how we check for in-use emails during sign-up. This affects the debounced api call during step 1 of sign-up.

I took the time to add tests as there weren't any for this route. (d'oh.)