### PR TITLE
Consolidate is_address_taken for sign-up and check alt domains. (Fixes #915)

### DIFF
--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -4,7 +4,12 @@ from rest_framework.throttling import UserRateThrottle
 from rest_framework.permissions import AllowAny
 import sentry_sdk
 from thunderbird_accounts.authentication.exceptions import InvalidDomainError, ImportUserError
-from thunderbird_accounts.authentication.utils import is_email_in_allow_list, KeycloakRequiredAction, is_email_reserved
+from thunderbird_accounts.authentication.utils import (
+    is_email_in_allow_list,
+    KeycloakRequiredAction,
+    is_email_reserved,
+    can_register_with_username,
+)
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.request import Request
@@ -29,7 +34,7 @@ def get_user_profile(request: Request):
 @permission_classes([AllowAny])
 @throttle_classes([SignUpThrottle])
 def sign_up(request: Request):
-    """The api endpoint for signing up a new user. 
+    """The api endpoint for signing up a new user.
 
     We create the Keycloak user and attach its uuid to the local Account's user object.
     We only create the local Accounts user object if the Keycloak user object was successfully created.
@@ -37,7 +42,6 @@ def sign_up(request: Request):
     # This file is loaded before models are ready, so we import locally here...for now.
     from thunderbird_accounts.authentication.clients import KeycloakClient
     from thunderbird_accounts.authentication.models import AllowListEntry, User
-    from thunderbird_accounts.mail.utils import is_address_taken
 
     data = request.data
 
@@ -67,12 +71,12 @@ def sign_up(request: Request):
         )
 
     # Make sure there's no email alias with this address
-    if is_address_taken(username) or is_email_reserved(username):
+    if not can_register_with_username(partial_username) or is_email_reserved(username):
         return Response({'error': generic_email_error, 'type': 'username-in-use'}, status=400)
 
     if not data.get('password'):
         return Response(
-            {'error': _("You need to enter a password to sign-up."), 'type': 'password-is-empty'},
+            {'error': _('You need to enter a password to sign-up.'), 'type': 'password-is-empty'},
             status=400,
         )
 

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -97,6 +97,28 @@ class SignUpTestcase(APITestCase):
         resp_data = response.json()
         self.assertEqual(resp_data.get('type'), 'username-in-use', msg=assert_fail_msg)
 
+    def test_user_alias_already_exists(self, mock_import_user: MagicMock):
+        """When signing up make sure we're not using a username on a shared domain"""
+
+        # Set a return value for oidc_id
+        mock_import_user.return_value = 1
+
+        username = f'hello@{settings.PRIMARY_EMAIL_DOMAIN}'
+        user = User.objects.create(email=self.wait_list[0], username=username)
+        account = Account.objects.create(name=user.username, user=user)
+        Email.objects.create(address=f'hello2@{settings.ALLOWED_EMAIL_DOMAINS[1]}', account=account)
+
+        response = self.client.post(
+            '/api/v1/auth/sign-up/',
+            self.make_sign_up_data(email=self.wait_list[0], partialUsername='hello2'),
+        )
+        assert_fail_msg = self.get_messages(response)
+
+        self.assertEqual(response.status_code, 400, msg=assert_fail_msg)
+
+        resp_data = response.json()
+        self.assertEqual(resp_data.get('type'), 'username-in-use', msg=assert_fail_msg)
+
     def test_user_using_reserved_emails(self, _mock_import_user: MagicMock):
         """Test to ensure that a user does not use a reserved username"""
         User(email=self.wait_list[0], username='hello@example.org').save()

--- a/src/thunderbird_accounts/authentication/utils.py
+++ b/src/thunderbird_accounts/authentication/utils.py
@@ -77,6 +77,22 @@ def is_email_reserved(email: str):
     return is_reserved(email)
 
 
+def can_register_with_username(username: str):
+    """Can a user register with this username.
+    This checks primary username and any mirrored aliases for our allowed domains
+
+    This does not check is_email_reserved, as we generally use a different error for that check."""
+    from thunderbird_accounts.mail.utils import is_address_taken
+
+    username_checks = (
+        [is_address_taken(f'{username}@{alt_domain}') for alt_domain in settings.ALLOWED_EMAIL_DOMAINS]
+        if len(settings.ALLOWED_EMAIL_DOMAINS) > 0
+        else []
+    )
+
+    return not any(username_checks)
+
+
 def create_aia_url(action: KeycloakRequiredAction):
     """Create a url for a user to start a keycloak flow.
     These flows are defined as actions in KeycloakRequiredAction."""

--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -1,6 +1,10 @@
-from thunderbird_accounts.authentication.utils import is_email_reserved, is_email_in_allow_list
+from thunderbird_accounts.authentication.utils import (
+    is_email_reserved,
+    is_email_in_allow_list,
+    can_register_with_username,
+)
 from thunderbird_accounts.mail.exceptions import EmailNotValidError
-from thunderbird_accounts.mail.utils import validate_email, is_address_taken
+from thunderbird_accounts.mail.utils import validate_email
 from rest_framework.permissions import AllowAny
 from django.conf import settings
 from rest_framework.throttling import UserRateThrottle
@@ -9,8 +13,6 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from django.utils.translation import gettext_lazy as _
-
-
 
 
 class UsernameAvailableThrottle(UserRateThrottle):
@@ -41,7 +43,7 @@ def is_username_available(request: Request):
     except EmailNotValidError as ex:
         raise ValidationError(ex.error_message)
 
-    if is_address_taken(full_username):
+    if not can_register_with_username(username):
         raise ValidationError(_('This username is already taken. Try another one.'))
 
     return Response(status=200)
@@ -52,14 +54,20 @@ def is_username_available(request: Request):
 @throttle_classes([CheckEmailIsOnAllowListThrottle])
 def check_email_is_on_allow_list(request: Request):
     if not settings.CONTACT_SUPPORT_ONLY_FOR_ALLOW_LISTED_USERS:
-        return Response({
-            'is_on_allow_list': True,
-        }, status=200)
+        return Response(
+            {
+                'is_on_allow_list': True,
+            },
+            status=200,
+        )
 
     email = request.data.get('email')
     if not email:
         raise ValidationError(_('You need to enter an email address.'))
 
-    return Response({
-        'is_on_allow_list': is_email_in_allow_list(email),
-    }, status=200)
+    return Response(
+        {
+            'is_on_allow_list': is_email_in_allow_list(email),
+        },
+        status=200,
+    )

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -276,7 +276,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_THROTTLE_RATES': {
         'is_username_available': '30/minute',
-        'sign_up': '10/minute',
+        'sign_up': '15/minute',
         'check_email_is_on_allow_list': '10/minute',
         'analytics': '1000/minute',  # Just in case
     },


### PR DESCRIPTION
Fixes #915 

Since we mirror the username against our shared aliases this will prevent a case where `hello@thundermail.com` is available but someone has already taken `hello@tb.pro`. 

