### PR TITLE
Add function name prefixes to delete_hosted_dkim_records logging.

### DIFF
--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -271,6 +271,7 @@ def delete_hosted_dkim_dns_records(self, domain_name: str):
         else:
             for record in hosted_records:
                 logging.info(
+                    '[delete_hosted_dkim_dns_records] '
                     'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
                     f'"{record["type"]} {record["name"]}"'
                 )

--- a/src/thunderbird_accounts/mail/tests/test_tasks.py
+++ b/src/thunderbird_accounts/mail/tests/test_tasks.py
@@ -179,16 +179,19 @@ class DeleteHostedDkimDNSRecordsTestCase(TaskTestCase):
         )
         cloudflare_client_mock.assert_not_called()
         self.assertIn(
+            '[delete_hosted_dkim_dns_records] '
             'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
             '"TXT tm1.example.com.dkim.example.net"',
             logs.output[0],
         )
         self.assertIn(
+            '[delete_hosted_dkim_dns_records] '
             'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
             '"TXT tm2.example.com.dkim.example.net"',
             logs.output[1],
         )
         self.assertIn(
+            '[delete_hosted_dkim_dns_records] '
             'HOSTED_DKIM_CLOUDFLARE_ENABLED=false: skipping DNS delete for '
             '"TXT tm3.example.com.dkim.example.net"',
             logs.output[2],


### PR DESCRIPTION
## What changed?

- This was a "nit" to improve logging that was intended to be included in a prior PR.

## QA Log

- Tests pass.

