### PR TITLE
Re-verifying a custom domain should no longer blank the stalwart_id (Fixes #918)

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+from thunderbird_accounts.mail.exceptions import DomainNotFoundError
 from django.utils.crypto import get_random_string
 from thunderbird_accounts.subscription.models import Plan, Subscription
 import json
@@ -205,6 +207,9 @@ class VerifyCustomDomainTestCase(TestCase):
             'dns_records': [],
         }
         mock_instance.create_domain.return_value = 'domain-id'
+        mock_instance.get_domain.side_effect = DomainNotFoundError(
+            self.domain.name
+        )  # Make sure we don't actually have a domain here
         mock_check_stale_dns_records.return_value = []
         mock_mail_client_cls.return_value = mock_instance
 
@@ -220,6 +225,7 @@ class VerifyCustomDomainTestCase(TestCase):
         mock_instance.check_domain_dns.assert_called_once_with(self.domain.name)
         mock_check_stale_dns_records.assert_called_once_with(self.domain.name)
         mock_instance.create_domain.assert_called_once_with(self.domain.name)
+        mock_instance.get_domain.assert_called_once_with(self.domain.name)
         mock_instance.ensure_dkim.assert_called_once_with(self.domain.name)
         mock_instance.create_dkim.assert_not_called()
         mock_publish_hosted_dkim.assert_called_once_with(self.domain.name)
@@ -228,6 +234,161 @@ class VerifyCustomDomainTestCase(TestCase):
         self.domain.refresh_from_db()
         self.assertEqual(Domain.DomainStatus.VERIFIED, self.domain.status)
         self.assertEqual('domain-id', self.domain.stalwart_id)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.mail_tasks.publish_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.check_stale_dns_records')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_reverification_of_ok_domain_is_success(
+        self,
+        mock_mail_client_cls,
+        mock_check_stale_dns_records,
+        mock_publish_hosted_dkim,
+    ):
+        stalwart_id = self.domain.stalwart_id
+        self.domain.stalwart_id = stalwart_id
+        self.domain.status = Domain.DomainStatus.VERIFIED
+        self.domain.stalwart_created_at = datetime.datetime.now(datetime.UTC)
+        self.domain.save()
+
+        mock_instance = Mock()
+        mock_instance.check_domain_dns.return_value = {
+            'is_verified': True,
+            'critical_errors': [],
+            'warnings': [],
+            'dns_records': [],
+        }
+        mock_instance.create_domain.return_value = None
+        mock_instance.get_domain.side_effect = {'id': stalwart_id}
+        mock_check_stale_dns_records.return_value = []
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        data = json.loads(response.content.decode())
+        self.assertTrue(data['success'])
+        mock_instance.check_domain_dns.assert_called_once_with(self.domain.name)
+        mock_check_stale_dns_records.assert_called_once_with(self.domain.name)
+        mock_instance.create_domain.assert_not_called()
+        mock_instance.get_domain.assert_called_once_with(self.domain.name)
+
+        mock_instance.ensure_dkim.assert_not_called()
+        mock_instance.create_dkim.assert_not_called()
+        mock_publish_hosted_dkim.assert_not_called()
+        mock_instance.activate_pending_dkim_signatures.assert_not_called()
+
+        self.domain.refresh_from_db()
+        self.assertEqual(Domain.DomainStatus.VERIFIED, self.domain.status)
+        self.assertEqual(stalwart_id, self.domain.stalwart_id)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.mail_tasks.publish_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.check_stale_dns_records')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_reverification_of_bad_domain_is_success(
+        self,
+        mock_mail_client_cls,
+        mock_check_stale_dns_records,
+        mock_publish_hosted_dkim,
+    ):
+        """This test-case is a reverification of a VERIFIED domain that does not have a Stalwart entry"""
+        stalwart_id = self.domain.stalwart_id
+        self.domain.stalwart_id = stalwart_id
+        self.domain.status = Domain.DomainStatus.VERIFIED
+        self.domain.stalwart_created_at = datetime.datetime.now(datetime.UTC)
+        self.domain.save()
+
+        mock_instance = Mock()
+        mock_instance.check_domain_dns.return_value = {
+            'is_verified': True,
+            'critical_errors': [],
+            'warnings': [],
+            'dns_records': [],
+        }
+        mock_instance.create_domain.return_value = stalwart_id
+        mock_instance.get_domain.side_effect = DomainNotFoundError(self.domain.name)
+        mock_check_stale_dns_records.return_value = []
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        data = json.loads(response.content.decode())
+        self.assertTrue(data['success'])
+        mock_instance.check_domain_dns.assert_called_once_with(self.domain.name)
+        mock_check_stale_dns_records.assert_called_once_with(self.domain.name)
+        mock_instance.create_domain.assert_called_once_with(self.domain.name)
+        mock_instance.get_domain.assert_called_once_with(self.domain.name)
+
+        mock_instance.ensure_dkim.assert_called_once_with(self.domain.name)
+        mock_instance.create_dkim.assert_not_called()
+        mock_publish_hosted_dkim.assert_called_once_with(self.domain.name)
+        mock_instance.activate_pending_dkim_signatures.assert_not_called()
+
+        self.domain.refresh_from_db()
+        self.assertEqual(Domain.DomainStatus.VERIFIED, self.domain.status)
+        self.assertEqual(stalwart_id, self.domain.stalwart_id)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.mail_tasks.publish_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.check_stale_dns_records')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_reverification_of_unverified_domain_is_success(
+        self,
+        mock_mail_client_cls,
+        mock_check_stale_dns_records,
+        mock_publish_hosted_dkim,
+    ):
+        """This test-case is a reverification of a VERIFIED domain that does not have a Stalwart entry"""
+        stalwart_id = self.domain.stalwart_id
+        self.domain.stalwart_id = stalwart_id
+        self.domain.status = Domain.DomainStatus.FAILED
+        self.domain.stalwart_created_at = datetime.datetime.now(datetime.UTC)
+        self.domain.save()
+
+        mock_instance = Mock()
+        mock_instance.check_domain_dns.return_value = {
+            'is_verified': True,
+            'critical_errors': [],
+            'warnings': [],
+            'dns_records': [],
+        }
+        mock_instance.create_domain.return_value = None
+        mock_instance.get_domain.return_value = {'id': stalwart_id}
+        mock_check_stale_dns_records.return_value = []
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        data = json.loads(response.content.decode())
+        self.assertTrue(data['success'])
+        mock_instance.check_domain_dns.assert_called_once_with(self.domain.name)
+        mock_check_stale_dns_records.assert_called_once_with(self.domain.name)
+        mock_instance.create_domain.assert_not_called()
+        mock_instance.get_domain.assert_called_once_with(self.domain.name)
+
+        mock_instance.ensure_dkim.assert_called_once_with(self.domain.name)
+        mock_instance.create_dkim.assert_not_called()
+        mock_publish_hosted_dkim.assert_called_once_with(self.domain.name)
+        mock_instance.activate_pending_dkim_signatures.assert_not_called()
+
+        self.domain.refresh_from_db()
+        self.assertEqual(Domain.DomainStatus.VERIFIED, self.domain.status)
+        self.assertEqual(stalwart_id, self.domain.stalwart_id)
 
     @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
     @patch('thunderbird_accounts.mail.views.mail_tasks.publish_hosted_dkim_dns_records.delay')
@@ -710,7 +871,6 @@ class AddEmailAliasTestCase(TestCase):
             json.loads(response.content.decode()),
             {'success': False, 'error': _('This email is not valid. Try another one.')},
         )
-
 
     @override_settings(ALLOWED_EMAIL_DOMAINS=['example.org', 'example.com'])
     @override_settings(MIN_CUSTOM_DOMAIN_ALIAS_LENGTH=3)

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -28,7 +28,8 @@ from thunderbird_accounts.mail.exceptions import (
     AccessTokenNotFound,
     AccountNotFoundError,
     DomainAlreadyExistsError,
-    DomainNotFoundError, EmailNotValidError,
+    DomainNotFoundError,
+    EmailNotValidError,
 )
 from thunderbird_accounts.mail.utils import (
     check_stale_dns_records,
@@ -253,7 +254,7 @@ def verify_custom_domain(request: HttpRequest):
         else:
             is_verified = True
             critical_errors = []
-            warnings = ['Custom domain DNS verification disabled. Automatically verified domain.']
+            warnings = [_('Custom domain DNS verification disabled. Automatically verified domain.')]
 
         domain.last_verification_attempt = now
 
@@ -274,22 +275,38 @@ def verify_custom_domain(request: HttpRequest):
             'stale_dns_records': stale_dns_records,
         }
 
+        # If we're verified via dns check
         if is_verified:
-            domain.status = Domain.DomainStatus.VERIFIED
-            domain.verified_at = now
+            try:
+                stalwart_resp = stalwart_client.get_domain(domain_name)
+            except DomainNotFoundError:
+                stalwart_resp = None
 
-            # Now attach the stalwart domain id to the user domain object
-            domain_id = stalwart_client.create_domain(domain_name)
-            # Ensure missing DKIM selectors without replacing keys created at domain-add time.
-            stalwart_client.ensure_dkim(domain_name)
-            mail_tasks.publish_hosted_dkim_dns_records.delay(domain_name)
-            if settings.STALWART_DKIM_STAGE_MANAGEMENT_ENABLED:
-                stalwart_client.activate_pending_dkim_signatures(domain_name)
-            now = datetime.datetime.now(datetime.UTC)
+            # Only roll through these steps if we're not already verified OR stalwart doesn't have our domain
+            if domain.status != Domain.DomainStatus.VERIFIED or not stalwart_resp:
+                domain.status = Domain.DomainStatus.VERIFIED
+                domain.verified_at = now
 
-            domain.stalwart_id = domain_id
-            domain.stalwart_created_at = now
-            domain.save()
+                # Fetch or create a domain on Stalwart's end, and retrieve the domain_id
+                if stalwart_resp:
+                    domain_id = stalwart_resp.get('id')
+                else:
+                    domain_id = stalwart_client.create_domain(domain_name)
+
+                # Ensure missing DKIM selectors without replacing keys created at domain-add time.
+                stalwart_client.ensure_dkim(domain_name)
+
+                mail_tasks.publish_hosted_dkim_dns_records.delay(domain_name)
+                if settings.STALWART_DKIM_STAGE_MANAGEMENT_ENABLED:
+                    stalwart_client.activate_pending_dkim_signatures(domain_name)
+
+                if domain_id:
+                    domain.stalwart_id = domain_id
+                else:
+                    logging.error(f'There was a problem saving the domain id for {domain.name} / {domain.uuid}')
+
+                domain.stalwart_created_at = datetime.datetime.now(datetime.UTC)
+                domain.save()
 
             return JsonResponse({'success': True, **response_data})
         else:


### PR DESCRIPTION
Fixes #918 
Fixes #690 

This should fix the rest of the domains problems, we might have to run "Fix missing stalwart ids" on some existing domains though.

I believe that Stalwart is returning a 200 if a domain already exists which is weird? So if a domain is verified and does another round of verification create_domain returns None, and then we blindly set `stalwart_id = None` :I 

So this fixes the issue by checking if the domain already exists or if it's verified. If the domain is missing on stalwart ends a reverification will actually fix it for the user, and if the domain isn't verified but has a stalwart_id somehow we won't blank it out. 

I've updated the tests with the new test cases, we might want to look into #152 sooner than later hah.