### PR TITLE
Lowercase alias and domain names, and switch is_address_taken to iexact. (Fixes #927)

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -797,14 +797,34 @@ class AddEmailAliasTestCase(TestCase):
         """Ensure that creating an email alias that is already in-use will error out."""
         email_alias_url = reverse('add_email_alias')
 
-        Email(address=f'admin@{settings.PRIMARY_EMAIL_DOMAIN}').save()
+        Email(address=f'cool_dude_99@{settings.PRIMARY_EMAIL_DOMAIN}').save()
 
         with patch('thunderbird_accounts.mail.views.MailClient', Mock()) as mock:
             instance = Mock()
             mock.save_email_addresses = instance
             response = self.client.post(
                 email_alias_url,
-                data={'email-alias': 'admin', 'domain': settings.PRIMARY_EMAIL_DOMAIN},
+                data={'email-alias': 'cool_dude_99', 'domain': settings.PRIMARY_EMAIL_DOMAIN},
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                json.loads(response.content.decode()),
+                {'success': False, 'error': _('You cannot use this email address.')},
+            )
+
+    def test_already_used_alias_case_sensitive(self):
+        """Ensure that creating an email alias with differing case that is already in-use will error out."""
+        email_alias_url = reverse('add_email_alias')
+
+        Email(address=f'cool_dude_00@{settings.PRIMARY_EMAIL_DOMAIN}').save()
+
+        with patch('thunderbird_accounts.mail.views.MailClient', Mock()) as mock:
+            instance = Mock()
+            mock.save_email_addresses = instance
+            response = self.client.post(
+                email_alias_url,
+                data={'email-alias': 'COOL_dude_00', 'domain': settings.PRIMARY_EMAIL_DOMAIN},
                 content_type='application/json',
             )
             self.assertEqual(response.status_code, 403)

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -600,7 +600,7 @@ def is_address_taken(email_address: str) -> bool:
         return True
 
     # Make sure there's no email alias with this address
-    aliases = Email.objects.filter(address=email_address).exists()
+    aliases = Email.objects.filter(address__iexact=email_address).exists()
     if aliases:
         return True
 

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -149,6 +149,8 @@ def create_custom_domain(request: HttpRequest):
     if not domain_name:
         return JsonResponse({'success': False, 'error': _('Domain name is required')}, status=400)
 
+    domain_name = domain_name.lower()
+
     custom_domain_count = request.user.domains.count()
 
     if custom_domain_count >= request.user.plan.mail_domain_count:
@@ -236,6 +238,8 @@ def verify_custom_domain(request: HttpRequest):
     domain_name = data.get('domain-name')
     if not domain_name:
         return JsonResponse({'success': False, 'error': _('Domain name is required')}, status=400)
+
+    domain_name = domain_name.lower()
 
     domain = request.user.domains.get(name=domain_name)
     if not domain:
@@ -335,6 +339,7 @@ def remove_custom_domain(request: HttpRequest):
     if not domain_name:
         return JsonResponse({'success': False, 'error': _('Domain name is required')}, status=400)
 
+    domain_name = domain_name.lower()
     domain = request.user.domains.get(name=domain_name)
     if not domain:
         return JsonResponse({'success': False, 'error': _('Domain not found')}, status=404)
@@ -364,7 +369,7 @@ def remove_custom_domain(request: HttpRequest):
     stalwart_client = MailClient()
     cleanup_phase = 'load_local_domains'
     try:
-        domains = request.user.domains.filter(name=domain_name).all()
+        domains = request.user.domains.filter(name__iexact=domain_name).all()
         # There should only be one here, but just in case...
         for _domain in domains:
             if _domain.stalwart_id:
@@ -413,6 +418,8 @@ def add_email_alias(request: HttpRequest):
     # We don't need to specify the asterisk for catch-all on stalwart's end.
     if is_catch_all:
         email_alias = ''
+
+    email_alias = email_alias.lower()
 
     full_email_alias = f'{email_alias}@{domain}'
 
@@ -518,6 +525,8 @@ def remove_email_alias(request: HttpRequest):
     if not email_alias:
         return JsonResponse({'success': False, 'error': _('Email alias is required.')}, status=400)
 
+    email_alias = email_alias.lower()
+
     # Get the account
     try:
         account = Account.objects.get(user=request.user)
@@ -530,7 +539,7 @@ def remove_email_alias(request: HttpRequest):
 
     # Get the local Email object
     try:
-        email_obj = Email.objects.get(address=email_alias, type=Email.EmailType.ALIAS, account=account)
+        email_obj = Email.objects.get(address__iexact=email_alias, type=Email.EmailType.ALIAS, account=account)
     except Email.DoesNotExist:
         logging.error(f'Email alias not found for user {request.user.uuid} and email {email_alias}')
         return JsonResponse(


### PR DESCRIPTION
Fixes #927 

This might need some deeper thought than I've put in it so far, but I think this captures all the footguns. 

is_address_taken is used in sign-up flow, and the aliases/custom domain ones should cover those user inputs on the dashboard. I've added a single test case that should cover is_address_taken. 

Nit away!