### PR TITLE
Don't raise an error if we pop a session key that doesn't exist on paddle complete (Fixes #925)

### DIFF
--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -122,11 +122,12 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     in our db via webhooks.
     """
     user = request.user
-    transaction_id = request.session.pop(SESSION_PADDLE_TRANSACTION_ID)
-    payment_type = request.session.pop(SESSION_PADDLE_PAYMENT_TYPE)
+    transaction_id = request.session.pop(SESSION_PADDLE_TRANSACTION_ID, None)
+    payment_type = request.session.pop(SESSION_PADDLE_PAYMENT_TYPE, None)
     redirect_response = HttpResponseRedirect('/subscribe')
 
-    # Hmm this shouldn't happen...
+    # This can happen if their browser isn't storing our functional session cookie. 
+    # This will be a small UX pain, but it won't brick their payment progress.
     if not transaction_id or not payment_type:
         return redirect_response
 


### PR DESCRIPTION
Fixes #925 

I can only guess that this is caused by blocking our functional session cookie. (Note: We store session data in the database as is django's default method, but the session cookie contains the id to retrieve the session data. We do not store session data in the cookie itself!)

Important to note that nothing about this bug affects the payment transaction. The user still gets an account once we get the webhook from paddle. This is a UX issue and while still a little awkward if they're paying with paypal, this should fix the 500 error.