### PR TITLE
Disable server side cursors (Fixes #931)

### DIFF
--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -223,7 +223,7 @@ WSGI_APPLICATION = 'thunderbird_accounts.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 AVAILABLE_DATABASES = {
-    'dev': {
+    'main': {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': os.getenv('DATABASE_NAME'),
@@ -231,6 +231,7 @@ AVAILABLE_DATABASES = {
             'PASSWORD': os.getenv('DATABASE_PASSWORD'),
             'HOST': os.getenv('DATABASE_HOST', '127.0.0.1'),
             'PORT': os.getenv('DATABASE_PORT', '5432'),
+            'DISABLE_SERVER_SIDE_CURSORS': True, # Disable server-side cursors due to db pooling issues
         },
     },
     'test': {
@@ -241,7 +242,7 @@ AVAILABLE_DATABASES = {
     },
 }
 
-DATABASES = AVAILABLE_DATABASES['test'] if IS_TEST else AVAILABLE_DATABASES['dev']
+DATABASES = AVAILABLE_DATABASES['test'] if IS_TEST else AVAILABLE_DATABASES['main']
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -231,7 +231,9 @@ AVAILABLE_DATABASES = {
             'PASSWORD': os.getenv('DATABASE_PASSWORD'),
             'HOST': os.getenv('DATABASE_HOST', '127.0.0.1'),
             'PORT': os.getenv('DATABASE_PORT', '5432'),
+            # Neon recommends these settings (https://neon.com/docs/guides/django)
             'DISABLE_SERVER_SIDE_CURSORS': True, # Disable server-side cursors due to db pooling issues
+            'CONN_HEALTH_CHECKS': True, # Test db connection before re-use between requests
         },
     },
     'test': {


### PR DESCRIPTION
Fixes #931 

According to django docs (https://docs.djangoproject.com/en/5.2/ref/databases/#transaction-pooling-server-side-cursors) it seems like django will hold onto the connection in order to speed things up. However this doesn't work if we're punted off to another db connection mid-call. (my understanding)

This is currently happening explicitly in the admin panel when you open a bunch of records in new tabs, but this could affect regular end-users. 

Best to fix this with the nuclear option and then look at how we can resolve this wrt pooling later. 