### PR TITLE
Adjust fix_archives_folder to pass if it already exists. (Fixes #935)

### DIFF
--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -480,7 +480,7 @@ def fix_archives_folder(access_token, account: Account) -> bool:
                     [
                         'Mailbox/query',
                         {
-                            'accountId': account_id,
+                            'accountId': str(account_id),
                             'filter': {'role': 'archive'},
                         },
                         '0',
@@ -494,16 +494,16 @@ def fix_archives_folder(access_token, account: Account) -> bool:
             # If they don't create a new inbox with the role 'archive', named 'Archives'
             # (set in settings.STALWART_ARCHIVES_FOLDER_NAME) which is subscribed by default
             temp_id = str(uuid.uuid4())
-            inbox_res = client.make_jmap_call(
+            set_res = client.make_jmap_call(
                 {
                     'using': ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
                     'methodCalls': [
                         [
                             'Mailbox/set',
                             {
-                                'accountId': account_id,
+                                'accountId': str(account_id),
                                 'create': {
-                                    temp_id: {
+                                    str(temp_id): {
                                         'name': settings.STALWART_ARCHIVES_FOLDER_NAME,
                                         'role': 'archive',
                                         'isSubscribed': True,
@@ -544,25 +544,29 @@ def fix_archives_folder(access_token, account: Account) -> bool:
                 "A mailbox with role 'archive' already exists.",
             ]
 
-            method_response = inbox_res['methodResponses'][0][1]
+            method_response = set_res['methodResponses'][0][1]
             return_response = method_response.get('created')
             if not return_response:
                 return_response = method_response.get('notCreated', {})
                 # The only way we're getting out of here without an error, is if the folder already exists
                 desc = return_response.get(temp_id, {}).get('description')
+                
                 if desc and desc in already_exists_descriptions:
-                    raise Exception(f'Failed to create archive folder: {desc}')
+                    pass # If it already exists then we can actually mark it as done and move on
+                else:
+                    sentry_sdk.set_extra('desc', desc)
+                    raise RuntimeError('Failed to create archive folder')
             elif temp_id not in return_response:
                 # Note: If the request didn't work, it won't have temp_id in it,
                 # or if it's malformed it'll raise a keyerror.
-                raise Exception('Failed to create archive folder')
+                raise RuntimeError('Failed to create archive folder')
 
         # If we got here without an error, then we can mark this as verified
         account.verified_archive_folder = True
         account.save()
 
         return True
-    except (HTTPError, Exception, KeyError) as ex:
+    except (HTTPError, RuntimeError, KeyError) as ex:
         logging.error('fix_archive_folder failed!')
         sentry_sdk.set_extra('inbox_response', inboxes)
         sentry_sdk.capture_exception(ex)

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -554,7 +554,7 @@ def fix_archives_folder(access_token, account: Account) -> bool:
                 if desc and desc in already_exists_descriptions:
                     pass # If it already exists then we can actually mark it as done and move on
                 else:
-                    sentry_sdk.set_extra('desc', desc)
+                    sentry_sdk.set_context('desc', {'desc': desc})
                     raise RuntimeError('Failed to create archive folder')
             elif temp_id not in return_response:
                 # Note: If the request didn't work, it won't have temp_id in it,
@@ -568,7 +568,7 @@ def fix_archives_folder(access_token, account: Account) -> bool:
         return True
     except (HTTPError, RuntimeError, KeyError) as ex:
         logging.error('fix_archive_folder failed!')
-        sentry_sdk.set_extra('inbox_response', inboxes)
+        sentry_sdk.set_context('inbox_response', {'inbox':inboxes})
         sentry_sdk.capture_exception(ex)
 
     return False


### PR DESCRIPTION
Fixes #935 

I'm not sure why, but the mailbox query on some mailboxes seem to return an empty list. However the set returns an error that we can identify as "this folder already exists with this role." So if we get that we can mark the user as having an archives folder.

(For context: Stalwart was having issues making archives folders for a while, so this was a quick fix.)