### PR TITLE
Fix alias count showing the incorrect count when filtering results (Fixes #937)

### DIFF
--- a/src/thunderbird_accounts/mail/admin/models.py
+++ b/src/thunderbird_accounts/mail/admin/models.py
@@ -35,7 +35,7 @@ class AccountAdmin(admin.ModelAdmin):
     )
 
     def get_queryset(self, request):
-        return super().get_queryset(request).annotate(email_count=Count('email'))
+        return super().get_queryset(request).annotate(email_count=Count('email', distinct=True))
 
     @admin.display(description=_('Email Count'), ordering='email_count')
     def email_count(self, obj):


### PR DESCRIPTION
The alias count now works correctly when filtering results. 

I found https://books.agiliq.com/projects/django-admin-cookbook/en/latest/optimize_queries.html which was quite helpful.

Fixes #937