### PR TITLE
Switch how we default zoneinfo/locale to their default values. (Fixes #939)

### DIFF
--- a/src/thunderbird_accounts/authentication/admin/forms.py
+++ b/src/thunderbird_accounts/authentication/admin/forms.py
@@ -98,7 +98,7 @@ class CustomNewUserForm(CustomUserFormBase):
             keycloak_pkid = keycloak.import_user(
                 self.cleaned_data.get('username'),
                 self.cleaned_data.get('recovery_email'),
-                self.cleaned_data.get('timezone'),
+                timezone=self.cleaned_data.get('timezone'),
                 name=name,
             )
 

--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -48,8 +48,8 @@ def sign_up(request: Request):
     # This email is the recovery / verification email address at this point
     email = data.get('email')
 
-    timezone = data.get('zoneinfo', 'UTC')
-    locale = data.get('locale', 'en')
+    timezone = data.get('zoneinfo') or 'UTC'
+    locale = data.get('locale') or 'en'
 
     partial_username = data.get('partialUsername')
     username = f'{partial_username}@{settings.PRIMARY_EMAIL_DOMAIN}'
@@ -98,7 +98,7 @@ def sign_up(request: Request):
         keycloak_pkid = keycloak.import_user(
             username,
             email,
-            timezone,
+            timezone=timezone,
             password=data.get('password'),
             send_action_email=KeycloakRequiredAction.VERIFY_EMAIL,
             verified_email=False,

--- a/src/thunderbird_accounts/authentication/clients.py
+++ b/src/thunderbird_accounts/authentication/clients.py
@@ -261,6 +261,7 @@ class KeycloakClient:
         self,
         username,
         backup_email,
+        *,
         timezone,
         name: Optional[str] = None,
         password: Optional[str] = None,

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -33,7 +33,7 @@ class SignUpTestcase(APITestCase):
         """Factory for sign up data. Pass in kwargs to override any data you need."""
         return {
             'email': 'hello@example.com',
-            'timezone': 'UTC',
+            'zoneinfo': 'UTC',
             'locale': 'en',
             'partialUsername': 'hello',
             'password': '123',
@@ -51,6 +51,27 @@ class SignUpTestcase(APITestCase):
             self.make_sign_up_data(email=self.wait_list[0]),
         )
         assert_fail_msg = self.get_messages(response)
+
+        self.assertEqual(response.status_code, 200, msg=assert_fail_msg)
+        self.assertEqual(response.json(), {'success': True}, msg=assert_fail_msg)
+
+    def test_success_with_zoneinfo_null(self, mock_import_user: MagicMock):
+        """Test that an unauthenticated user can sign-up if they're in the allow list."""
+
+        # Set a return value for oidc_id
+        mock_import_user.return_value = 1
+
+        sign_up_data = self.make_sign_up_data(email=self.wait_list[0], zoneinfo='')
+
+        response = self.client.post(
+            '/api/v1/auth/sign-up/',
+            sign_up_data,
+        )
+        assert_fail_msg = self.get_messages(response)
+
+        # Make sure the default value overrides the one we used during signup
+        self.assertNotEqual(mock_import_user.call_args.kwargs['timezone'], sign_up_data.get('zoneinfo'))
+        self.assertEqual(mock_import_user.call_args.kwargs['timezone'], 'UTC')
 
         self.assertEqual(response.status_code, 200, msg=assert_fail_msg)
         self.assertEqual(response.json(), {'success': True}, msg=assert_fail_msg)


### PR DESCRIPTION
Fixes #939 

If someone's browser doesn't want to return a timezone then we'll get `zoneinfo: None`. Because the key is there the data.get('zoneinfo')'s default value will not be pulled and zoneinfo will continue to be None. However we need zoneinfo as a non null value. So we flip zoneinfo (and locale) to use `or $val`. 

In order to better test for this I added the positional argument thingy to import_user, so now if you want to specify timezone it has to be via kwargs. This allows us to test the value in the mock call.