### PR TITLE
Pre-fill contact form with recovery email for users without active subscription

### DIFF
--- a/.github/workflows/e2e-desktop-nightly-chrome.yml
+++ b/.github/workflows/e2e-desktop-nightly-chrome.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      ACCTS_OIDC_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-desktop-nightly-firefox.yml
+++ b/.github/workflows/e2e-desktop-nightly-firefox.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      ACCTS_OIDC_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-desktop-nightly-safari.yml
+++ b/.github/workflows/e2e-desktop-nightly-safari.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      ACCTS_OIDC_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-mobile-nightly-android.yml
+++ b/.github/workflows/e2e-mobile-nightly-android.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      ACCTS_OIDC_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -298,6 +298,7 @@ jobs:
     env:
       ACCTS_OIDC_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_EMAIL }}
       ACCTS_OIDC_PWORD: ${{ secrets.E2E_ACCTS_OIDC_PWORD }}
+      ACCTS_OIDC_RECOVERY_EMAIL: ${{ secrets.E2E_ACCTS_OIDC_RECOVERY_EMAIL }}
       PRIMARY_THUNDERMAIL_EMAIL: ${{ secrets.E2E_PRIMARY_THUNDERMAIL_EMAIL }}
     steps:
       - uses: actions/checkout@v4

--- a/assets/app/vue/views/ContactView/components/ContactSupportForm.vue
+++ b/assets/app/vue/views/ContactView/components/ContactSupportForm.vue
@@ -39,7 +39,9 @@ const successText = ref('');
 const isSubmitting = ref(false);
 const tbProWaitListUrl = window._page?.tbProWaitListUrl;
 const form = ref({
-  email: window._page?.userEmail || '',
+  email: window._page?.hasActiveSubscription
+    ? window._page?.userEmail
+    : window._page?.recoveryEmail || '',
   name: window._page?.userFullName || '',
   attachments: [],
 });

--- a/assets/app/vue/views/ContactView/index.vue
+++ b/assets/app/vue/views/ContactView/index.vue
@@ -84,6 +84,7 @@ export default {
 @media (min-width: 768px) {
   .contact-view {
     gap: 4rem;
+    flex-wrap: nowrap;
   }
 }
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -41,6 +41,7 @@ declare global {
       currentView?: Record<string, any>;
       serverMessages: ServerMessage[];
       needsTosAcceptance?: boolean;
+      recoveryEmail?: string;
       // Special, only used for tbpro_500.html
       errorTitle?: string;
       isErrorPage?: boolean,

--- a/src/thunderbird_accounts/core/templates/index.html
+++ b/src/thunderbird_accounts/core/templates/index.html
@@ -47,6 +47,7 @@
     serverMessages: {{ server_messages|default:None|to_json|safe }},
     features: {{ features|safe|default:'{}' }},
     needsTosAcceptance: {{ needs_tos_acceptance|to_json|safe }},
+    recoveryEmail: {{ recovery_email|to_json|safe }},
     {% block extra_page_params %}{% endblock %}
   };
   csrfToken.remove();

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -58,6 +58,7 @@ def home(request: HttpRequest):
     max_custom_domains = None
     max_email_aliases = None
     needs_tos_acceptance = False
+    recovery_email = request.user.recovery_email if request.user.is_authenticated else None
 
     # This state can only really happen when a user hits PermissionDenied immediately upon logging in.
     # They will be logged in via Keycloak and then a redirect loop will happen as we deny them permission,
@@ -151,6 +152,7 @@ def home(request: HttpRequest):
             'form_data': form_data or None,
             'features': json.dumps(get_feature_flags()),
             'needs_tos_acceptance': needs_tos_acceptance,
+            'recovery_email': recovery_email,
         },
     )
 

--- a/test/e2e/.env.dev.example
+++ b/test/e2e/.env.dev.example
@@ -19,6 +19,7 @@ SMTP_TLS="None"
 # Sign-in credentials
 ACCTS_OIDC_EMAIL=admin@example.org
 ACCTS_OIDC_PWORD=admin
+ACCTS_OIDC_RECOVERY_EMAIL=recovery@example.org
 
 # Thundermail associated with the above account
 PRIMARY_THUNDERMAIL_EMAIL=admin@example.com

--- a/test/e2e/.env.prod.example
+++ b/test/e2e/.env.prod.example
@@ -16,6 +16,7 @@ SMTP_PORT=465
 # Sign-in credentials
 ACCTS_OIDC_EMAIL=
 ACCTS_OIDC_PWORD=
+ACCTS_OIDC_RECOVERY_EMAIL=
 
 # Thundermail associated with the above account
 PRIMARY_THUNDERMAIL_EMAIL=

--- a/test/e2e/.env.stage.example
+++ b/test/e2e/.env.stage.example
@@ -16,6 +16,7 @@ SMTP_PORT=465
 # Sign-in credentials
 ACCTS_OIDC_EMAIL=
 ACCTS_OIDC_PWORD=
+ACCTS_OIDC_RECOVERY_EMAIL=
 
 # Thundermail associated with the above account
 PRIMARY_THUNDERMAIL_EMAIL=

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -126,7 +126,7 @@ Then edit your local `.env` file and provide the following values:
 ACCTS_HUB_URL=<URL-for-TB-Accts-Hub>
 ACCTS_OIDC_EMAIL=<existing-tbpro-user-email>
 ACCTS_OIDC_PWORD=<exisiting-tbro-password>
-ACCTS_
+ACCTS_OIDC_RECOVERY_EMAIL=<existing-tbpro-user-recovery-email>
 PRIMARY_THUNDERMAIL_EMAIL=<primary-thundermail-email-address>
 ```
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -51,7 +51,8 @@ Then edit your local `.env` file and provide the following values:
 ```dotenv
 ACCTS_HUB_URL=<URL-for-TB-Accts-Hub>
 ACCTS_OIDC_EMAIL=<existing-tbpro-user-email>
-ACCTS_OIDC_PWORD=<exisiting-tbro-password>
+ACCTS_OIDC_PWORD=<existing-tbpro-password>
+ACCTS_OIDC_RECOVERY_EMAIL=<existing-tbpro-user-recovery-email>
 PRIMARY_THUNDERMAIL_EMAIL=<primary-thundermail-email-address>
 ```
 
@@ -125,6 +126,7 @@ Then edit your local `.env` file and provide the following values:
 ACCTS_HUB_URL=<URL-for-TB-Accts-Hub>
 ACCTS_OIDC_EMAIL=<existing-tbpro-user-email>
 ACCTS_OIDC_PWORD=<exisiting-tbro-password>
+ACCTS_
 PRIMARY_THUNDERMAIL_EMAIL=<primary-thundermail-email-address>
 ```
 

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -11,6 +11,7 @@ export const TB_PRO_WAIT_LIST_URL = String(process.env.TB_PRO_WAIT_LIST_URL);
 // sign-in credentials and corresponding info
 export const ACCTS_OIDC_EMAIL = String(process.env.ACCTS_OIDC_EMAIL);
 export const ACCTS_OIDC_PWORD = String(process.env.ACCTS_OIDC_PWORD);
+export const ACCTS_OIDC_RECOVERY_EMAIL = String(process.env.ACCTS_OIDC_RECOVERY_EMAIL);
 export const PRIMARY_THUNDERMAIL_EMAIL = String(process.env.PRIMARY_THUNDERMAIL_EMAIL);
 
 // expected dashboard subscription details

--- a/test/e2e/tests/desktop/contact.spec.ts
+++ b/test/e2e/tests/desktop/contact.spec.ts
@@ -1,14 +1,14 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { ContactPage } from '../../pages/contact-page';
-import { ensureWeAreSignedIn } from '../../utils/utils';
+import { ensureWeAreSignedIn, overridePageData } from '../../utils/utils';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE,
   PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY,
   ACCTS_OIDC_EMAIL,
+  ACCTS_OIDC_RECOVERY_EMAIL,
   PRIMARY_THUNDERMAIL_EMAIL,
-  TB_PRO_WAIT_LIST_URL,
   TIMEOUT_2_SECONDS,
   TIMEOUT_5_SECONDS,
   TIMEOUT_30_SECONDS,
@@ -139,17 +139,21 @@ test.beforeEach(async ({ page }) => {
 test.describe('contact support form on desktop browser', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY],
 }, () => {
-  test('contact form displayed correctly when signed in', async ({ page }) => {
-    // go to the contact / submit an issue form and wait for it to load
+  test('contact form pre-fills primary thundermail email when signed in with active subscription', async () => {
     await contactPage.navigateToContactPage();
-
-    // we are already signed into TB Accounts; ensure the form shows as expected when signed in
     await contactPage.verifyFormDisplayed();
 
-    // since we're signed in, email field should be pre-filled with the user's primary email
     await expect(contactPage.emailInput).toHaveValue(PRIMARY_THUNDERMAIL_EMAIL);
   });
-  
+
+  test('contact form pre-fills recovery email when signed in without active subscription', async ({ page }) => {
+    await overridePageData(page, { hasActiveSubscription: false });
+    await contactPage.navigateToContactPage();
+    await contactPage.verifyFormDisplayed();
+
+    await expect(contactPage.emailInput).toHaveValue(ACCTS_OIDC_RECOVERY_EMAIL);
+  });
+
   test('contact form displayed correctly when not signed in', async ({ page }) => {
     // clear authentication state for this test
     await page.context().clearCookies();
@@ -204,7 +208,7 @@ test.describe('contact support form on desktop browser', {
     await expect(contactPage.successMessage).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
   });
 
-  test('form validation prevents submission', async ({ page }) => {
+  test('form validation prevents submission', async () => {
     // go to the contact / submit an issue form and wait for it to load
     await contactPage.navigateToContactPage();
     await contactPage.submitForm();

--- a/test/e2e/tests/desktop/contact.spec.ts
+++ b/test/e2e/tests/desktop/contact.spec.ts
@@ -139,7 +139,14 @@ test.beforeEach(async ({ page }) => {
 test.describe('contact support form on desktop browser', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE, PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY],
 }, () => {
-  test('contact form pre-fills primary thundermail email when signed in with active subscription', async () => {
+  test('contact form pre-fills primary thundermail email when signed in with active subscription', async ({ page }) => {
+    const activeSubscriptionPageData = {
+      hasActiveSubscription: true,
+      userEmail: PRIMARY_THUNDERMAIL_EMAIL,
+      recoveryEmail: ACCTS_OIDC_RECOVERY_EMAIL,
+    };
+
+    await overridePageData(page, activeSubscriptionPageData);
     await contactPage.navigateToContactPage();
     await contactPage.verifyFormDisplayed();
 
@@ -147,7 +154,13 @@ test.describe('contact support form on desktop browser', {
   });
 
   test('contact form pre-fills recovery email when signed in without active subscription', async ({ page }) => {
-    await overridePageData(page, { hasActiveSubscription: false });
+    const inactiveSubscriptionPageData = {
+      hasActiveSubscription: false,
+      userEmail: PRIMARY_THUNDERMAIL_EMAIL,
+      recoveryEmail: ACCTS_OIDC_RECOVERY_EMAIL,
+    };
+
+    await overridePageData(page, inactiveSubscriptionPageData);
     await contactPage.navigateToContactPage();
     await contactPage.verifyFormDisplayed();
 

--- a/test/e2e/tests/mobile/contact.spec.ts
+++ b/test/e2e/tests/mobile/contact.spec.ts
@@ -1,17 +1,17 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { ContactPage } from '../../pages/contact-page';
-import { navigateToAccountsHubAndSignIn } from '../../utils/utils';
+import { navigateToAccountsHubAndSignIn, overridePageData } from '../../utils/utils';
 
 import {
   PLAYWRIGHT_TAG_E2E_SUITE_MOBILE,
   PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY,
   ACCTS_OIDC_EMAIL,
+  ACCTS_OIDC_RECOVERY_EMAIL,
   PRIMARY_THUNDERMAIL_EMAIL,
   TIMEOUT_2_SECONDS,
   TIMEOUT_5_SECONDS,
   TIMEOUT_30_SECONDS,
-  TB_PRO_WAIT_LIST_URL,
 } from '../../const/constants';
 
 let contactPage: ContactPage;
@@ -139,31 +139,32 @@ test.beforeEach(async ({ page }) => {
 test.describe('contact support form on mobile browser', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE_MOBILE, PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY],
 }, () => {
-  test('contact form displayed correctly when signed in', async ({ page }) => {
-    // go to the contact / submit an issue form and wait for it to load
+  test('contact form pre-fills primary thundermail email when signed in with active subscription', async () => {
     await contactPage.navigateToContactPage();
-
-    // we are already signed into TB Accounts; ensure the form shows as expected when signed in
     await contactPage.verifyFormDisplayed();
 
-    // since we're signed in, email field should be pre-filled with the user's primary email
     // locator.toHaveValue is not supported in iOS BrowserStack so must get value then verify it
-    //await expect(contactPage.emailInput).toHaveValue(PRIMARY_THUNDERMAIL_EMAIL);
     const emailValue = await contactPage.emailInput.inputValue();
     expect(emailValue).toBe(PRIMARY_THUNDERMAIL_EMAIL);
   });
 
+  test('contact form pre-fills recovery email when signed in without active subscription', async ({ page }) => {
+    await overridePageData(page, { hasActiveSubscription: false });
+    await contactPage.navigateToContactPage();
+    await contactPage.verifyFormDisplayed();
+
+    const emailValue = await contactPage.emailInput.inputValue();
+    expect(emailValue).toBe(ACCTS_OIDC_RECOVERY_EMAIL);
+  });
+
   test('contact form displayed correctly when not signed in', async ({ page }) => {
-    // clear authentication state for this test
     await page.context().clearCookies();
     await page.reload();
     await page.waitForTimeout(TIMEOUT_5_SECONDS);
     await contactPage.navigateToContactPage();
 
-    // check that the contact form is visible
     await contactPage.verifyFormDisplayed();
 
-    // not signed in, so check that email is not pre-filled
     await expect(contactPage.emailInput).toBeEmpty();
     await expect(contactPage.nameInput).toBeEmpty();
   });
@@ -208,7 +209,7 @@ test.describe('contact support form on mobile browser', {
     await expect(contactPage.successMessage).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
   });
 
-  test('form validation prevents submission', async ({ page }) => {
+  test('form validation prevents submission', async () => {
     // go to the contact / submit an issue form and wait for it to load
     await contactPage.navigateToContactPage();
     await contactPage.submitForm();

--- a/test/e2e/tests/mobile/contact.spec.ts
+++ b/test/e2e/tests/mobile/contact.spec.ts
@@ -139,7 +139,14 @@ test.beforeEach(async ({ page }) => {
 test.describe('contact support form on mobile browser', {
   tag: [PLAYWRIGHT_TAG_E2E_SUITE_MOBILE, PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY],
 }, () => {
-  test('contact form pre-fills primary thundermail email when signed in with active subscription', async () => {
+  test('contact form pre-fills primary thundermail email when signed in with active subscription', async ({ page }) => {
+    const activeSubscriptionPageData = {
+      hasActiveSubscription: true,
+      userEmail: PRIMARY_THUNDERMAIL_EMAIL,
+      recoveryEmail: ACCTS_OIDC_RECOVERY_EMAIL,
+    };
+
+    await overridePageData(page, activeSubscriptionPageData);
     await contactPage.navigateToContactPage();
     await contactPage.verifyFormDisplayed();
 
@@ -149,7 +156,13 @@ test.describe('contact support form on mobile browser', {
   });
 
   test('contact form pre-fills recovery email when signed in without active subscription', async ({ page }) => {
-    await overridePageData(page, { hasActiveSubscription: false });
+    const inactiveSubscriptionPageData = {
+      hasActiveSubscription: false,
+      userEmail: PRIMARY_THUNDERMAIL_EMAIL,
+      recoveryEmail: ACCTS_OIDC_RECOVERY_EMAIL,
+    };
+
+    await overridePageData(page, inactiveSubscriptionPageData);
     await contactPage.navigateToContactPage();
     await contactPage.verifyFormDisplayed();
 

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -24,6 +24,25 @@ export const showPageConsoleLog = async (page: Page) => {
     page.on('console', msg => console.log(`> ${msg.text()}`));
 
 }
+
+/**
+ * Override values on the server-rendered window._page object before the Vue app reads it.
+ */
+export const overridePageData = async (page: Page, overrides: Record<string, unknown>) => {
+    await page.addInitScript((pageOverrides) => {
+        let pageData: Record<string, unknown>;
+
+        Object.defineProperty(window, '_page', {
+            configurable: true,
+            get() {
+                return pageData;
+            },
+            set(value: Record<string, unknown>) {
+                pageData = { ...value, ...pageOverrides };
+            },
+        });
+    }, overrides);
+};
   
 /**
  * Similar to waitForLoadState but works with our vue applications.


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- `recovery_email` is now being passed in the `_page` context for the Vue app so that we can pre-fill it in the contact form in case the logged in user does not have an active subscription yet
- Added E2E tests (+ new .env var `ACCTS_OIDC_RECOVERY_EMAIL` and secret `E2E_ACCTS_OIDC_RECOVERY_EMAIL`)
- Sneaking in a tiny fix for the contact form UI in wider viewports


## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

For users that don't have an active subscription yet, we can't contact them back through their @thundermail.com address so we should prefill the contact form with the recovery email instead in those cases.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/923

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

https://github.com/user-attachments/assets/8c06245a-0eaf-4d31-ae60-26476be1d385


