### PR TITLE
Consider missing DKIM DNS records an error (#942)

### DIFF
--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -98,9 +98,15 @@ const missingOrConflicted = (record: DNSRecord): boolean =>
 
 const missingValidationKeys = new Set(['mxLookupError', 'spfRecordNotFound', 'dkimRecordNotFound']);
 
+const hasValidationIssue = (key: string): boolean =>
+  criticalErrors.value.includes(key) || validationWarnings.value.includes(key);
+
+const validationSeverity = (key?: string | null): InlineIssueSeverity =>
+  key && criticalErrors.value.includes(key) ? 'critical' : 'warning';
+
 const shouldAnchorDkimMissingIssue = (record: DNSRecord): boolean =>
   showMissingIssues.value
-  && validationWarnings.value.includes('dkimRecordNotFound')
+  && hasValidationIssue('dkimRecordNotFound')
   && isDkimRecordForCurrentDomain(record);
 
 const validationResult = (data?: {
@@ -190,7 +196,7 @@ const recordStatusIssue = (record: DNSRecord): InlineIssue | null => {
   if (record.status === DNSRecordStatus.UNKNOWN && shouldAnchorDkimMissingIssue(record)) {
     return {
       key: 'dkimRecordNotFound',
-      severity: 'warning',
+      severity: validationSeverity('dkimRecordNotFound'),
       text: t('views.mail.sections.customDomains.recordMissingWarning'),
     };
   }
@@ -206,7 +212,7 @@ const recordStatusIssue = (record: DNSRecord): InlineIssue | null => {
   if (record.status === DNSRecordStatus.CONFLICT) {
     return {
       key: validationKey ?? `${record.type}-${record.name}-conflict`,
-      severity: 'warning',
+      severity: validationSeverity(validationKey),
       text: t('views.mail.sections.customDomains.recordConflictWarning', { currentValue: currentValue(record) }),
     };
   }
@@ -218,7 +224,7 @@ const recordStatusIssue = (record: DNSRecord): InlineIssue | null => {
 
     return {
       key: missingKey ?? `${record.type}-${record.name}-missing`,
-      severity: 'warning',
+      severity: validationSeverity(missingKey),
       text: t('views.mail.sections.customDomains.recordMissingWarning'),
     };
   }
@@ -253,7 +259,10 @@ const createDnsTableRow = (record: DNSRecord, index: number): DnsTableRow => {
   };
 };
 
-const conflictSeverity = (record: DNSRecord): InlineIssueSeverity => (isMxRecord(record) ? 'critical' : 'warning');
+const conflictSeverity = (record: DNSRecord): InlineIssueSeverity =>
+  isMxRecord(record) || recordValidationKeys(record).some((key) => criticalErrors.value.includes(key))
+    ? 'critical'
+    : 'warning';
 
 const createConflictingRecord = (record: DNSRecord, existingValue: string): DNSRecord => {
   const valueParts = existingValue.trim().split(/\s+/);

--- a/src/thunderbird_accounts/mail/clients.py
+++ b/src/thunderbird_accounts/mail/clients.py
@@ -33,12 +33,12 @@ class DomainVerificationErrors(StrEnum):
 
     # Critical errors (fail verification)
     MX_LOOKUP_ERROR = 'mxLookupError'
+    DKIM_RECORD_NOT_FOUND = 'dkimRecordNotFound'
     AUTODISCOVER_RECORD_FOUND = 'autodiscoverRecordFound'
     AUTODISCOVER_SRV_RECORD_FOUND = 'autodiscoverSrvRecordFound'
 
     # Warnings (do not fail verification)
     SPF_RECORD_NOT_FOUND = 'spfRecordNotFound'
-    DKIM_RECORD_NOT_FOUND = 'dkimRecordNotFound'
 
 
 class DkimSignatureStage(StrEnum):
@@ -776,7 +776,7 @@ class MailClient:
 
         dkim_records = [record for record in dns_records if '_domainkey' in record.get('name', '')]
         if not dkim_records or any(record.get('status') != DNSRecordStatus.MATCH.value for record in dkim_records):
-            warnings.append(DomainVerificationErrors.DKIM_RECORD_NOT_FOUND)
+            critical_errors.append(DomainVerificationErrors.DKIM_RECORD_NOT_FOUND)
 
         is_verified = len(critical_errors) == 0
         return {

--- a/src/thunderbird_accounts/mail/tests/test_clients.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients.py
@@ -148,9 +148,9 @@ class TestMailClientCheckDomainDNS(SimpleTestCase):
 
         result = self.mail_client.check_domain_dns(self.domain)
 
-        self.assertTrue(result['is_verified'])
-        self.assertEqual(result['critical_errors'], [])
-        self.assertIn(DomainVerificationErrors.DKIM_RECORD_NOT_FOUND, result['warnings'])
+        self.assertFalse(result['is_verified'])
+        self.assertIn(DomainVerificationErrors.DKIM_RECORD_NOT_FOUND, result['critical_errors'])
+        self.assertEqual(result['warnings'], [])
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
     def test_check_domain_dns_dkim_missing(self, mock_resolve):
@@ -158,9 +158,9 @@ class TestMailClientCheckDomainDNS(SimpleTestCase):
 
         result = self.mail_client.check_domain_dns(self.domain)
 
-        self.assertTrue(result['is_verified'])
-        self.assertEqual(result['critical_errors'], [])
-        self.assertIn(DomainVerificationErrors.DKIM_RECORD_NOT_FOUND, result['warnings'])
+        self.assertFalse(result['is_verified'])
+        self.assertIn(DomainVerificationErrors.DKIM_RECORD_NOT_FOUND, result['critical_errors'])
+        self.assertEqual(result['warnings'], [])
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
     def test_check_domain_dns_queries_subdomain_mx(self, mock_resolve):


### PR DESCRIPTION
## What changed?

Missing DKIM DNS records are now considered an error.

## Why?

If they don't set it up deliverability will suffer, which isn't good for the user and will also likely result in higher support volumes. As long as they are updating their DNS records, there's no good reason to not add the DKIM records while they are at it.

## Applicable Issues

Closes #942

## QA Log

- Auto tests
- Tested locally with missing DKIM errors, observed critical error treatment.

## Screenshots

<img width="1157" height="490" alt="image" src="https://github.com/user-attachments/assets/b4f8429e-c12c-4b30-8095-d0d115715dc4" />


