### PR TITLE
Refactor Sentry set_extra to use set_context (#946)

### DIFF
--- a/src/thunderbird_accounts/legal/views.py
+++ b/src/thunderbird_accounts/legal/views.py
@@ -36,8 +36,13 @@ def _read_legal_content(content_path: str, locale: str) -> str:
     if not doc_path.is_relative_to(legal_templates_path) or not default_path.is_relative_to(
         legal_templates_path
     ):
-        sentry_sdk.set_extra('doc_path', doc_path)
-        sentry_sdk.set_extra('default_path', default_path)
+        sentry_sdk.set_context(
+            'legal_content_paths',
+            {
+                'doc_path': str(doc_path),
+                'default_path': str(default_path),
+            },
+        )
         logging.error('directory traversal attack!')
         return ''
 

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -212,9 +212,8 @@ def fix_archives_folder(access_token, account: Account) -> bool:
         return True
     except (HTTPError, RuntimeError, KeyError) as ex:
         logging.error('fix_archive_folder failed!')
-        sentry_sdk.set_context('inbox_response', {'inbox':inboxes})
+        sentry_sdk.set_context('inbox_response', {'inboxes': inboxes})
         sentry_sdk.capture_exception(ex)
-
     return False
 
 

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -571,11 +571,16 @@ if POSTHOG_API_KEY:
     }
 
 # Some debug info for sentry
-sentry_sdk.set_extra('REDIS_URL', REDIS_URL)
-sentry_sdk.set_extra('CELERY_BROKER_URL', CELERY_BROKER_URL)
-sentry_sdk.set_extra('CELERY_RESULT_BACKEND', CELERY_RESULT_BACKEND)
-sentry_sdk.set_extra('CELERY_RESULT_EXPIRES', CELERY_RESULT_EXPIRES)
-sentry_sdk.set_extra('CELERY_TASK_ALWAYS_EAGER', CELERY_TASK_ALWAYS_EAGER)
+sentry_sdk.set_context(
+    'celery_settings',
+    {
+        'REDIS_URL': REDIS_URL,
+        'CELERY_BROKER_URL': CELERY_BROKER_URL,
+        'CELERY_RESULT_BACKEND': CELERY_RESULT_BACKEND,
+        'CELERY_RESULT_EXPIRES': CELERY_RESULT_EXPIRES,
+        'CELERY_TASK_ALWAYS_EAGER': CELERY_TASK_ALWAYS_EAGER,
+    },
+)
 
 # Cors
 CORS_PREFLIGHT_MAX_AGE = 0  # For debugging purposes

--- a/src/thunderbird_accounts/subscription/tasks.py
+++ b/src/thunderbird_accounts/subscription/tasks.py
@@ -578,8 +578,7 @@ def add_subscriber_to_mailchimp_list(self, user_uuid):
             except (JSONDecodeError, AttributeError):
                 error_details = {}
 
-            # Send some extra information to sentry
-            sentry_sdk.set_extra('tag_error_details', error_details)
+            sentry_sdk.set_context('mailchimp_tag_error', {'details': error_details})
 
         # Try to create the user with the tag we want
         try:
@@ -602,8 +601,7 @@ def add_subscriber_to_mailchimp_list(self, user_uuid):
             except (JSONDecodeError, AttributeError):
                 error_details = {}
 
-            # Send some extra information to sentry
-            sentry_sdk.set_extra('error_details', error_details)
+            sentry_sdk.set_context('mailchimp_error', {'details': error_details})
             sentry_sdk.capture_exception(ex)
 
             raise TaskFailed(


### PR DESCRIPTION
Sentry's set_extra has been deprecated, set_context is the replacement.

## QA Log

- Checked the Sentry docs to confirm set_context() takes an object now.
- Automated refactoring
- grep'ed to confirm all set_extra() calls were found/updated.

Ref: https://develop.sentry.dev/sdk/foundations/envelopes/event-payloads/contexts/
