### PR TITLE
Simplify and wrap user plan activation in a db lock (Maybe fixes #838)

### DIFF
--- a/src/thunderbird_accounts/subscription/tasks.py
+++ b/src/thunderbird_accounts/subscription/tasks.py
@@ -313,6 +313,12 @@ def paddle_subscription_event(self, event_data: dict, occurred_at: datetime.date
             },
         )
 
+    # Log some problem cases that would be our fault. 
+    if len(subscription_items) == 0:
+        logging.error(f'Subscription contains no items. This user ({user.uuid}) will not have any features enabled!')
+    elif len(subscription_items) > 1:
+        logging.error('Subscription contains more than one item. This is not supported!')
+
     for item in subscription_items:
         # Note: These are reoccurring items only
         # Slurp up the subscription items, these are only created if all three items are new
@@ -353,8 +359,8 @@ def paddle_subscription_event(self, event_data: dict, occurred_at: datetime.date
             # Update quota
             plan = product_obj.plan
             if not plan:
-                logging.warning(f'Product {product.get("id")} has no plan attached!')
-            else:
+                logging.error(f'Product {product.get("id")} has no plan attached!')
+            elif status == Subscription.StatusValues.ACTIVE.value:
                 activate_subscription_features(user, plan)
 
         SubscriptionItem.objects.update_or_create(
@@ -366,11 +372,6 @@ def paddle_subscription_event(self, event_data: dict, occurred_at: datetime.date
             product_id=product_obj.uuid if product_obj else None,
             defaults={'quantity': quantity},
         )
-
-    # If the subscription updated or was created with active then clear any payment pending flags
-    if status == Subscription.StatusValues.ACTIVE.value:
-        user.is_awaiting_payment_verification = False
-        user.save()
 
     # Queue up the price update for now.
     retrieve_and_update_localized_subscription_price.delay(subscription_uuid=str(subscription.uuid))
@@ -617,6 +618,7 @@ def add_subscriber_to_mailchimp_list(self, user_uuid):
         'user_uuid': user_uuid,
         'task_status': TaskReturnStatus.SUCCESS,
     }
+
 
 @shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
 @inject_paddle

--- a/src/thunderbird_accounts/subscription/utils.py
+++ b/src/thunderbird_accounts/subscription/utils.py
@@ -1,3 +1,4 @@
+from django.db import transaction as dj_transaction
 from thunderbird_accounts.authentication.clients import KeycloakClient
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.utils import create_stalwart_account, update_quota_on_stalwart_account
@@ -33,12 +34,16 @@ def activate_subscription_features(user: User, plan: Plan):
     if not user.has_active_subscription:
         return
 
-    # Associate the plan id
+    # Associate the plan id and remove any payment verification flag
     # We technically have a link through user -> subscriptions -> subscription items -> product -> plan
     # but that's too long...
-    if user.plan_id != plan.uuid:
-        user.plan_id = plan.uuid
-        user.save()
+    # We also lock the user row for this update as it's pretty important
+    with dj_transaction.atomic():
+        locked_user = User.objects.select_for_update().get(pk=user.uuid)
+        if locked_user.plan_id != plan.uuid:
+            locked_user.plan_id = plan.uuid
+        locked_user.is_awaiting_payment_verification = False
+        locked_user.save()
 
     # TODO: Temporarily removed until https://github.com/thunderbird/thunderbird-accounts/issues/346 is ready
     # sync_plan_to_keycloak(user)

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -112,7 +112,7 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     completed (noted as doneish.)
 
     There's some special logic for certain payment processors that open a pop-up window instead of
-    redirecting to another page or completeing on page. Those processors are defined in code, and
+    redirecting to another page or completing on page. Those processors are defined in code, and
     will redirect the pop-up window to a django template that _should_ immediately close the window.
     For those processors the doneish/redirect logic is handled in
     :any:`thunderbird_accounts.subscription.views.is_paddle_transaction_done`
@@ -121,12 +121,12 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     The front-end will handle if the check to see if the user's transaction and subscription has been pulled
     in our db via webhooks.
     """
-    user = request.user
+    user: User = request.user
     transaction_id = request.session.pop(SESSION_PADDLE_TRANSACTION_ID, None)
     payment_type = request.session.pop(SESSION_PADDLE_PAYMENT_TYPE, None)
     redirect_response = HttpResponseRedirect('/subscribe')
 
-    # This can happen if their browser isn't storing our functional session cookie. 
+    # This can happen if their browser isn't storing our functional session cookie.
     # This will be a small UX pain, but it won't brick their payment progress.
     if not transaction_id or not payment_type:
         return redirect_response
@@ -135,11 +135,14 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     status = transaction.status.value
 
     if transaction and status in [Transaction.StatusValues.COMPLETED.value, Transaction.StatusValues.PAID.value]:
-        # Only set enable payment verification mode if they don't have an active subscription
+        # Only set enable payment verification mode if they don't have an 
+        # active subscription (no plan, no active subscription)
         # As the webhook could technically come in before or during this successUrl redirect...
-        if not user.has_active_subscription:
-            user.is_awaiting_payment_verification = True
-            user.save()
+        with dj_transaction.atomic():
+            user.refresh_from_db()
+            if not user.plan and not user.has_active_subscription:
+                user.is_awaiting_payment_verification = True
+                user.save()
 
         if settings.IS_DEV:
             tasks.dev_only_paddle_fake_webhook.delay(transaction_id=transaction_id, user_uuid=user.uuid.hex)

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -3,6 +3,7 @@ import json
 import logging
 import sentry_sdk
 
+from django.db import transaction as dj_transaction
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse, HttpRequest, HttpResponseRedirect
@@ -18,7 +19,7 @@ from paddle_billing.Notifications.Entities.Shared.PaymentMethodType import Payme
 from rest_framework.decorators import api_view, authentication_classes
 from rest_framework.request import Request
 
-from thunderbird_accounts.authentication.models import AllowListEntry
+from thunderbird_accounts.authentication.models import AllowListEntry, User
 from thunderbird_accounts.mail.clients import MailClient
 from thunderbird_accounts.authentication.permissions import IsValidPaddleWebhook
 from thunderbird_accounts.subscription import tasks
@@ -139,10 +140,11 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
         # active subscription (no plan, no active subscription)
         # As the webhook could technically come in before or during this successUrl redirect...
         with dj_transaction.atomic():
-            user.refresh_from_db()
-            if not user.plan and not user.has_active_subscription:
-                user.is_awaiting_payment_verification = True
-                user.save()
+            # If it's already locked we skip this update
+            locked_user = User.objects.select_for_update(skip_locked=True).get(pk=user.uuid)
+            if locked_user and not locked_user.plan and not locked_user.has_active_subscription:
+                locked_user.is_awaiting_payment_verification = True
+                locked_user.save()
 
         if settings.IS_DEV:
             tasks.dev_only_paddle_fake_webhook.delay(transaction_id=transaction_id, user_uuid=user.uuid.hex)


### PR DESCRIPTION
Fixes #838 

So we were experiencing a race condition where a slower internet connection would resolve the paddle transaction callback url which sets is_awaiting_payment_verification = True within a second (one case was 80ms) as the Paddle webhook which activates their plan (sets plan_id for relationship) and sets is_awaiting_payment_verification = False.

In cases where the callback route completed last the user would have their plan activate and then it would wipe out any user model changes. So they would have a thundermail address created but no way to get the information to use it, and would be locked out of the dashboard.

The solution here is to wrap the user model update from the task in a db lock. This is just a postgres row lock, and  **SHOULD** pause any other queries that have to do with this model. I don't see any evidence we have to start wrapping everything in a db lock. 

We additionally now wrap the critical user update on paddle complete view with a db lock as well, but specify that if there **IS** a lock to skip the rest of the atomic transaction. This along with checking for the existence of a plan relationship will hopefully remove the race condition we were experiencing.

I think the other issue here besides the lack of a db lock for this critical update is that we were updating with a stale object. So a user object would be updated in celery, but after we fetched it on a web route. So when we updated the web route user, the changes would overwrite the more important updates done in celery. We can also work-around this a little by using update_fields=['is_awaiting_payment_verification'] but I'm hopeful that these changes are enough.

Tests use sqlite which doesn't support db row locking, I'm also not sure it's the right tool to test race conditions. 

Am I missing anything obvious? If so, please nit!

Useful readings:
https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-for-update
