### PR TITLE
Custom domain UI revamp

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -236,6 +236,7 @@
           "recordConflictWarning": "Conflict detected. Replace {currentValue} with the value in the row above.",
           "mxRecordConflictWarning": "This record conflicts. Remove conflicting MX records or change the priority.",
           "spfRecordConflictWarning": "This record conflicts. The current SPF record does not contain {includeValue}.",
+          "spfRecordIncludeValue": "the expected include value",
           "recordMissingWarning": "Record is missing.",
           "staleDnsRecordsTitle": "Remove these stale records",
           "staleDnsRecords": "Please remove the {type} record for {name} as it points to {existing_values}.",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -253,6 +253,53 @@
           "domainAlreadyExists": "Domain already exists",
           "domainAlreadyConfigured": "This domain is already configured. Please {link} in case you believe this is a mistake.",
           "reachOutToSupport": "reach out to support",
+          "recordActionInfo": {
+            "MX": {
+              "remove": {
+                "remove": "Remove",
+                "content": "{bold} this record from your DNS register site to avoid having email sent to multiple servers. {link}",
+                "link": "Learn more on our support site."
+              },
+              "add": {
+                "add": "Add",
+                "content": "{bold} this record to your DNS register site to have your email sent to Thunderbird Pro servers. {link}",
+                "link": "Learn more on our support site."
+              },
+              "edit": {
+                "edit": "Edit",
+                "content": "{bold} this record from your DNS register site to avoid having email sent to multiple servers. {link}",
+                "link": "Learn more on our support site."
+              }
+            },
+            "SRV": {
+              "remove": {
+                "remove": "Remove",
+                "content": "{bold} this record from your DNS register site to avoid compatibility issues."
+              },
+              "add": {
+                "add": "Add",
+                "content": "{bold} this record to your DNS register site to avoid compatibility issues."
+              },
+              "edit": {
+                "edit": "Edit",
+                "content": "{bold} this record from your DNS register site to avoid compatibility issues."
+              }
+            },
+            "OTHER": {
+              "remove": {
+                "remove": "Remove",
+                "content": "{bold} this record from your DNS register site to avoid having your outgoing email be flagged as spam."
+              },
+              "add": {
+                "add": "Add",
+                "content": "{bold} this record to your DNS register site to avoid having your outgoing email be flagged as spam."
+              },
+              "edit": {
+                "edit": "Edit",
+                "content": "{bold} this record from your DNS register site to avoid having your outgoing email be flagged as spam."
+              }
+            }
+          },
           "verificationValidationErrors": {
             "mxLookupError": "Unable to find MX record pointing to Thundermail",
             "ipLookupError": "Unable to resolve IP addresses",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -227,6 +227,12 @@
           "recordsTableHeaderNameHost": "{'Name/Host'}",
           "recordsTableHeaderValueData": "{'Value/Data'}",
           "recordsTableHeaderPriority": "Priority",
+          "copyValue": "Copy value",
+          "recordAction": {
+            "add": "Add",
+            "edit": "Edit",
+            "remove": "Remove"
+          },
           "recordConflictWarning": "Conflict detected. Replace {currentValue} with the value in the row above.",
           "mxRecordConflictWarning": "This record conflicts. Remove conflicting MX records or change the priority.",
           "spfRecordConflictWarning": "This record conflicts. The current SPF record does not contain {includeValue}.",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -200,6 +200,10 @@
         },
         "customDomains": {
           "customDomains": "Custom Domains",
+          "domains": "Domains",
+          "ownerDNSRecords": "{domainName} DNS records",
+          "conflictingRecords": "Conflicting records",
+          "allRecords": "All records",
           "customDomainsDescriptionInitial": "Use your own domain to create personalized email addresses.",
           "customDomainsDescriptionAdd": "Adding a domain you own to your account allows you to create aliases using your custom domains.",
           "domainsAdded": "{domainCount} / {domainLimit} domains added",

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainAddStep.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainAddStep.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { PrimaryButton, TextInput, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
+
+defineProps<{
+  customDomain: string | null;
+  customDomainError: string | null;
+  domainAlreadyConfigured: boolean;
+  isAddingCustomDomain: boolean;
+}>();
+
+const emit = defineEmits<{
+  submit: [];
+  'update:customDomain': [value: string | null];
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <form @submit.prevent="emit('submit')">
+    <text-input
+      :placeholder="t('views.mail.sections.customDomains.domainPlaceholder')"
+      name="custom-domain"
+      :help="t('views.mail.sections.customDomains.domainHelp')"
+      :error="customDomainError"
+      class="custom-domain-text-input"
+      :model-value="customDomain"
+      @update:model-value="emit('update:customDomain', $event)"
+    >
+      {{ t('views.mail.sections.customDomains.enterCustomDomain') }}
+    </text-input>
+
+    <notice-bar
+      :type="NoticeBarTypes.Critical"
+      v-if="domainAlreadyConfigured"
+      class="domain-already-configured-notice-bar"
+    >
+      <i18n-t keypath="views.mail.sections.customDomains.domainAlreadyConfigured" tag="span">
+        <template #link>
+          <router-link to="/contact">{{ t('views.mail.sections.customDomains.reachOutToSupport') }}</router-link>
+        </template>
+      </i18n-t>
+    </notice-bar>
+
+    <primary-button variant="outline" @click="emit('submit')" :disabled="isAddingCustomDomain">
+      {{ t('views.mail.sections.customDomains.continue') }}
+    </primary-button>
+  </form>
+</template>
+
+<style scoped>
+.custom-domain-text-input {
+  margin-block-end: 1.5rem;
+}
+
+.domain-already-configured-notice-bar {
+  margin-block-end: 1.5rem;
+
+  a {
+    color: var(--colour-ti-secondary);
+  }
+}
+
+@media (min-width: 768px) {
+  .custom-domain-text-input {
+    max-width: 50%;
+  }
+
+  .domain-already-configured-notice-bar {
+    max-width: 50%;
+  }
+}
+</style>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -1,31 +1,16 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { PrimaryButton, TextInput, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
-import {
-  PhCheck,
-  PhCheckCircle,
-  PhCopySimple,
-  PhInfo,
-  PhWarning,
-  PhWarningCircle,
-  PhWarningOctagon,
-} from '@phosphor-icons/vue';
+import { PrimaryButton } from '@thunderbirdops/services-ui';
 
-// Types
-import { CustomDomain, DNSRecord, StaleDNSRecord, STEP, DOMAIN_STATUS, DNSRecordStatus } from '../types';
-import type {
-  DomainVerificationResult,
-  InlineIssueSeverity,
-  InlineIssue,
-  DnsTableRow,
-  DecoratedDnsTableRow,
-  RowAction,
-  RowStatus,
-} from '../types';
+import { CustomDomain, StaleDNSRecord, STEP, DOMAIN_STATUS, DNSRecord } from '../types';
+import type { DomainVerificationResult, InlineIssue, DecoratedDnsTableRow } from '../types';
 
-// API
 import { addCustomDomain, verifyDomain, getRemoteDNSRecords } from '../api';
+import { buildDecoratedDnsTableRows, buildUnanchoredValidationIssues, validationResultFromApi } from '../utils';
+
+import CustomDomainAddStep from './CustomDomainAddStep.vue';
+import CustomDomainVerifyStep from './CustomDomainVerifyStep.vue';
 
 const { t, te } = useI18n();
 
@@ -55,81 +40,15 @@ const criticalErrors = ref<string[]>([]);
 const validationWarnings = ref<string[]>([]);
 const showMissingIssues = ref(false);
 const verificationResultsByDomain = ref<Record<string, Omit<DomainVerificationResult, 'domainName'>>>({});
-const copiedCellKey = ref<string | null>(null);
-let copiedResetTimer: ReturnType<typeof setTimeout> | undefined;
 
-const copyCellValue = async (cellKey: string, value: string) => {
-  try {
-    await navigator.clipboard.writeText(value);
-    copiedCellKey.value = cellKey;
-    clearTimeout(copiedResetTimer);
-    copiedResetTimer = setTimeout(() => {
-      copiedCellKey.value = null;
-    }, 1500);
-  } catch (error) {
-    console.error(error);
-  }
-};
+const dnsTableState = computed(() => ({
+  customDomain: customDomain.value ?? '',
+  criticalErrors: criticalErrors.value,
+  validationWarnings: validationWarnings.value,
+  showMissingIssues: showMissingIssues.value,
+}));
 
-const hasCopyableValue = (value?: string | null): boolean => Boolean(value) && value !== '-';
-
-const formatValidationError = (error: string): string => {
-  const translationKey = `views.mail.sections.customDomains.verificationValidationErrors.${error}`;
-  return te(translationKey) ? t(translationKey) : error;
-};
-
-const currentValue = (record: DNSRecord): string => record.existing_values?.join(', ') || '-';
-
-const isMxRecord = (record: DNSRecord): boolean => record.type === 'MX';
-
-const isSpfRecord = (record: DNSRecord): boolean =>
-  record.type === 'TXT' && record.content.trim().toLowerCase().startsWith('v=spf1');
-
-const spfIncludeValue = (record: DNSRecord): string =>
-  record.content.split(/\s+/).find((part) => part.startsWith('include:')) ?? 'the expected include value';
-
-const normalizeDomainName = (domainName?: string | null): string =>
-  (domainName ?? '').trim().replace(/\.$/, '').toLowerCase();
-
-const dkimRecordDomain = (record: DNSRecord): string | null => {
-  if (record.type !== 'CNAME') {
-    return null;
-  }
-
-  const normalizedName = normalizeDomainName(record.name);
-  const domainKeySegment = '._domainkey.';
-  const domainKeyIndex = normalizedName.indexOf(domainKeySegment);
-  if (domainKeyIndex <= 0) {
-    return null;
-  }
-
-  return normalizedName.slice(domainKeyIndex + domainKeySegment.length);
-};
-
-const isDkimRecordForCurrentDomain = (record: DNSRecord): boolean =>
-  dkimRecordDomain(record) === normalizeDomainName(customDomain.value);
-
-const missingOrConflicted = (record: DNSRecord): boolean =>
-  record.status === DNSRecordStatus.MISSING || record.status === DNSRecordStatus.CONFLICT;
-
-const missingValidationKeys = new Set(['mxLookupError', 'spfRecordNotFound', 'dkimRecordNotFound']);
-
-const shouldAnchorDkimMissingIssue = (record: DNSRecord): boolean =>
-  showMissingIssues.value &&
-  validationWarnings.value.includes('dkimRecordNotFound') &&
-  isDkimRecordForCurrentDomain(record);
-
-const validationResult = (data?: {
-  critical_errors?: string[];
-  warnings?: string[];
-  dns_records?: DNSRecord[];
-  stale_dns_records?: StaleDNSRecord[];
-}): Pick<DomainVerificationResult, 'criticalErrors' | 'warnings' | 'dnsRecords' | 'staleDnsRecords'> => ({
-  criticalErrors: data?.critical_errors ?? [],
-  warnings: data?.warnings ?? [],
-  dnsRecords: data?.dns_records ?? [],
-  staleDnsRecords: data?.stale_dns_records ?? [],
-});
+const dnsTableI18n = { t, te };
 
 const applyVerificationResult = (
   domainName: string,
@@ -152,305 +71,30 @@ const applyVerificationResult = (
   }
 };
 
-const issueSeverity = (issues: InlineIssue[]): InlineIssueSeverity | null => {
-  if (issues.some((issue) => issue.severity === 'critical')) {
-    return 'critical';
-  }
-  if (issues.length > 0) {
-    return 'warning';
-  }
-  return null;
-};
-
-const recordValidationKeys = (record: DNSRecord): string[] => {
-  const keys = [];
-  if (isMxRecord(record)) {
-    keys.push('mxLookupError');
-  }
-  if (isSpfRecord(record)) {
-    keys.push('spfRecordNotFound');
-  }
-  if (isDkimRecordForCurrentDomain(record)) {
-    keys.push('dkimRecordNotFound');
-  }
-  return keys;
-};
-
-const recordStatusIssue = (record: DNSRecord): InlineIssue | null => {
-  const validationKeys = recordValidationKeys(record);
-  const validationKey = validationKeys.find(
-    (key) => criticalErrors.value.includes(key) || validationWarnings.value.includes(key)
-  );
-  const missingKey = validationKey ?? validationKeys.find((key) => missingValidationKeys.has(key));
-
-  if (isMxRecord(record) && record.status === DNSRecordStatus.CONFLICT) {
-    return {
-      key: 'mxLookupError',
-      severity: 'critical',
-      text: t('views.mail.sections.customDomains.mxRecordConflictWarning'),
-    };
-  }
-
-  if (isMxRecord(record) && record.status === DNSRecordStatus.MISSING) {
-    if (!showMissingIssues.value) {
-      return null;
-    }
-
-    return {
-      key: 'mxLookupError',
-      severity: 'critical',
-      text: formatValidationError('mxLookupError'),
-    };
-  }
-
-  if (record.status === DNSRecordStatus.UNKNOWN && shouldAnchorDkimMissingIssue(record)) {
-    return {
-      key: 'dkimRecordNotFound',
-      severity: 'warning',
-      text: t('views.mail.sections.customDomains.recordMissingWarning'),
-    };
-  }
-
-  if (isSpfRecord(record) && record.status === DNSRecordStatus.CONFLICT) {
-    return {
-      key: 'spfRecordNotFound',
-      severity: 'warning',
-      text: t('views.mail.sections.customDomains.spfRecordConflictWarning', { includeValue: spfIncludeValue(record) }),
-    };
-  }
-
-  if (record.status === DNSRecordStatus.CONFLICT) {
-    return {
-      key: validationKey ?? `${record.type}-${record.name}-conflict`,
-      severity: 'warning',
-      text: t('views.mail.sections.customDomains.recordConflictWarning', { currentValue: currentValue(record) }),
-    };
-  }
-
-  if (record.status === DNSRecordStatus.MISSING) {
-    if (!showMissingIssues.value) {
-      return null;
-    }
-
-    return {
-      key: missingKey ?? `${record.type}-${record.name}-missing`,
-      severity: 'warning',
-      text: t('views.mail.sections.customDomains.recordMissingWarning'),
-    };
-  }
-
-  return null;
-};
-
-const validationIssuesForRecord = (record: DNSRecord): InlineIssue[] =>
-  recordValidationKeys(record)
-    .filter((key) => criticalErrors.value.includes(key) || validationWarnings.value.includes(key))
-    .filter((key) => showMissingIssues.value || !missingValidationKeys.has(key))
-    .filter((key) => key === 'mxLookupError' || missingOrConflicted(record))
-    .map((key) => ({
-      key,
-      severity: criticalErrors.value.includes(key) ? 'critical' : 'warning',
-      text: formatValidationError(key),
-    }));
-
-const createDnsTableRow = (record: DNSRecord, index: number): DnsTableRow => {
-  const hasConflictRows = record.status === DNSRecordStatus.CONFLICT && (record.existing_values?.length ?? 0) > 0;
-  const statusIssue = hasConflictRows ? null : recordStatusIssue(record);
-  const validationIssues = statusIssue || hasConflictRows ? [] : validationIssuesForRecord(record);
-  const issues = statusIssue ? [statusIssue, ...validationIssues] : validationIssues;
-
-  return {
-    key: `${record.type}-${record.name}-${record.content}-${index}`,
-    record,
-    issues,
-    severity: issueSeverity(issues),
-    isStale: false,
-    isConflict: false,
-  };
-};
-
-const createConflictingRecord = (record: DNSRecord, existingValue: string): DNSRecord => {
-  const valueParts = existingValue.trim().split(/\s+/);
-
-  if (record.type === 'MX' && valueParts.length > 1) {
-    return {
-      ...record,
-      content: valueParts.slice(1).join(' '),
-      priority: valueParts[0],
-      existing_values: [existingValue],
-    };
-  }
-
-  if (record.type === 'SRV' && valueParts.length > 3) {
-    return {
-      ...record,
-      content: valueParts.slice(1).join(' '),
-      priority: valueParts[0],
-      existing_values: [existingValue],
-    };
-  }
-
-  return {
-    ...record,
-    content: existingValue,
-    priority: '-',
-    existing_values: [existingValue],
-  };
-};
-
-const createConflictDnsTableRows = (record: DNSRecord, index: number): DnsTableRow[] => {
-  if (record.status !== DNSRecordStatus.CONFLICT || !record.existing_values?.length) {
-    return [];
-  }
-
-  const statusIssue = recordStatusIssue(record);
-  const validationIssues = statusIssue ? [] : validationIssuesForRecord(record);
-  const issues = statusIssue ? [statusIssue, ...validationIssues] : validationIssues;
-
-  return record.existing_values.map((existingValue, conflictIndex) => ({
-    key: `conflict-${record.type}-${record.name}-${existingValue}-${index}-${conflictIndex}`,
-    record: createConflictingRecord(record, existingValue),
-    issues: conflictIndex === 0 ? issues : [],
-    severity: 'warning',
-    isStale: false,
-    isConflict: true,
-  }));
-};
-
-const createDnsTableRows = (record: DNSRecord, index: number): DnsTableRow[] => [
-  createDnsTableRow(record, index),
-  ...createConflictDnsTableRows(record, index),
-];
-
-const createStaleDnsTableRow = (record: StaleDNSRecord): DnsTableRow => {
-  const isSrv = record.code === 'autodiscoverSrvUnexpected';
-  const validationKey = isSrv ? 'autodiscoverSrvRecordFound' : 'autodiscoverRecordFound';
-  const issues = [
-    {
-      key: validationKey,
-      severity: 'critical' as const,
-      text: formatValidationError(validationKey),
-    },
-  ];
-
-  return {
-    key: `stale-${record.code}-${record.type}-${record.name}`,
-    record: {
-      type: record.type,
-      name: record.name,
-      content: record.existing_values.join(', '),
-      priority: '-',
-      status: DNSRecordStatus.CONFLICT,
-      existing_values: record.existing_values,
-    },
-    issues,
-    severity: 'critical',
-    isStale: true,
-    isConflict: false,
-  };
-};
-
-const staleAddressRows = computed(() =>
-  staleDnsRecords.value.filter((record) => record.code === 'autodiscoverCnameUnexpected').map(createStaleDnsTableRow)
+const dnsTableRows = computed<DecoratedDnsTableRow[]>(() =>
+  buildDecoratedDnsTableRows(recordsInfo.value, staleDnsRecords.value, dnsTableState.value, dnsTableI18n)
 );
-
-const staleSrvRows = computed(() =>
-  staleDnsRecords.value.filter((record) => record.code === 'autodiscoverSrvUnexpected').map(createStaleDnsTableRow)
-);
-
-const rowAction = (row: DnsTableRow): RowAction | null => {
-  if (row.isStale || row.isConflict) {
-    return 'remove';
-  }
-
-  switch (row.record.status) {
-    case DNSRecordStatus.MISSING:
-      return 'add';
-    case DNSRecordStatus.CONFLICT:
-      return 'edit';
-    case DNSRecordStatus.UNKNOWN:
-      return row.issues.length > 0 ? 'add' : null;
-    default:
-      return null;
-  }
-};
-
-const rowStatus = (row: DnsTableRow, action: RowAction | null): RowStatus => {
-  if (row.severity === 'warning' || action) {
-    return 'warning';
-  }
-  return 'success';
-};
-
-const decorateRow = (row: DnsTableRow): DecoratedDnsTableRow => {
-  const action = rowAction(row);
-  return { ...row, action, status: rowStatus(row, action) };
-};
-
-const dnsTableRows = computed<DecoratedDnsTableRow[]>(() => {
-  const expectedRows = recordsInfo.value.flatMap(createDnsTableRows);
-  const rows = [];
-  let insertedAddressRows = false;
-  let insertedSrvRows = false;
-
-  expectedRows.forEach((row, index) => {
-    rows.push(row);
-    const nextRow = expectedRows[index + 1];
-
-    if (!insertedSrvRows && row.record.type === 'SRV' && nextRow?.record.type !== 'SRV') {
-      rows.push(...staleSrvRows.value);
-      insertedSrvRows = true;
-    }
-
-    if (!insertedAddressRows && row.record.type === 'CNAME' && nextRow?.record.type !== 'CNAME') {
-      rows.push(...staleAddressRows.value);
-      insertedAddressRows = true;
-    }
-  });
-
-  if (!insertedSrvRows) {
-    rows.push(...staleSrvRows.value);
-  }
-  if (!insertedAddressRows) {
-    rows.push(...staleAddressRows.value);
-  }
-
-  return rows.map(decorateRow);
-});
-
-const actionLabel = (action: RowAction): string => t(`views.mail.sections.customDomains.recordAction.${action}`);
-
-const issuesTooltip = (issues: InlineIssue[]): string => issues.map((issue) => issue.text).join('\n');
 
 const anchoredValidationKeys = computed(
   () => new Set(dnsTableRows.value.flatMap((row) => row.issues.map((issue) => issue.key)))
 );
 
-const unanchoredValidationIssues = computed<InlineIssue[]>(() => [
-  ...criticalErrors.value
-    .filter((key) => !anchoredValidationKeys.value.has(key))
-    .filter((key) => showMissingIssues.value || !missingValidationKeys.has(key))
-    .map((key) => ({
-      key,
-      severity: 'critical' as const,
-      text: formatValidationError(key),
-    })),
-  ...validationWarnings.value
-    .filter((key) => !anchoredValidationKeys.value.has(key))
-    .filter((key) => showMissingIssues.value || !missingValidationKeys.has(key))
-    .map((key) => ({
-      key,
-      severity: 'warning' as const,
-      text: formatValidationError(key),
-    })),
-]);
+const unanchoredValidationIssues = computed<InlineIssue[]>(() =>
+  buildUnanchoredValidationIssues(
+    criticalErrors.value,
+    validationWarnings.value,
+    anchoredValidationKeys.value,
+    showMissingIssues.value,
+    dnsTableI18n
+  )
+);
 
 const handleDNSRecords = async (domainName: string) => {
   try {
     const remoteDNSRecords = await getRemoteDNSRecords(domainName);
 
     if (remoteDNSRecords.success) {
-      applyVerificationResult(domainName, validationResult(remoteDNSRecords), { showMissingIssues: false });
+      applyVerificationResult(domainName, validationResultFromApi(remoteDNSRecords), { showMissingIssues: false });
     } else {
       console.error(remoteDNSRecords.error);
       customDomainError.value = remoteDNSRecords.error;
@@ -496,7 +140,7 @@ const onVerifyDomain = async () => {
   try {
     const data = await verifyDomain(customDomain.value);
 
-    applyVerificationResult(customDomain.value, validationResult(data), {
+    applyVerificationResult(customDomain.value, validationResultFromApi(data), {
       showMissingIssues: true,
       cacheResult: true,
     });
@@ -518,9 +162,9 @@ const onVerifyDomain = async () => {
 
 const viewDnsRecords = async (domainName: string) => {
   customDomain.value = domainName;
-  const verificationResult = verificationResultsByDomain.value[domainName];
-  if (verificationResult) {
-    applyVerificationResult(domainName, verificationResult, { showMissingIssues: true });
+  const cachedResult = verificationResultsByDomain.value[domainName];
+  if (cachedResult) {
+    applyVerificationResult(domainName, cachedResult, { showMissingIssues: true });
     return;
   }
 
@@ -547,7 +191,6 @@ watch(
 watch(
   () => props.lastDomainRemoved,
   (newLastDomainRemoved) => {
-    // If we just removed the domain we were adding, reset the step to initial
     if (newLastDomainRemoved === customDomain.value) {
       step.value = STEP.INITIAL;
       customDomain.value = null;
@@ -571,441 +214,20 @@ watch(
     </primary-button>
   </template>
 
-  <template v-else-if="step === STEP.ADD">
-    <form @submit.prevent="onCreateCustomDomain">
-      <text-input
-        :placeholder="t('views.mail.sections.customDomains.domainPlaceholder')"
-        name="custom-domain"
-        :help="t('views.mail.sections.customDomains.domainHelp')"
-        :error="customDomainError"
-        class="custom-domain-text-input"
-        v-model="customDomain"
-      >
-        {{ t('views.mail.sections.customDomains.enterCustomDomain') }}
-      </text-input>
+  <custom-domain-add-step
+    v-else-if="step === STEP.ADD"
+    v-model:custom-domain="customDomain"
+    :custom-domain-error="customDomainError"
+    :domain-already-configured="domainAlreadyConfigured"
+    :is-adding-custom-domain="isAddingCustomDomain"
+    @submit="onCreateCustomDomain"
+  />
 
-      <notice-bar
-        :type="NoticeBarTypes.Critical"
-        v-if="domainAlreadyConfigured"
-        class="domain-already-configured-notice-bar"
-      >
-        <i18n-t keypath="views.mail.sections.customDomains.domainAlreadyConfigured" tag="span">
-          <template #link>
-            <router-link to="/contact">{{ t('views.mail.sections.customDomains.reachOutToSupport') }}</router-link>
-          </template>
-        </i18n-t>
-      </notice-bar>
-
-      <primary-button variant="outline" @click="onCreateCustomDomain" :disabled="isAddingCustomDomain">
-        {{ t('views.mail.sections.customDomains.continue') }}
-      </primary-button>
-    </form>
-  </template>
-
-  <template v-else-if="step === STEP.VERIFY_DOMAIN">
-    <h3>{{ t('views.mail.sections.customDomains.verifyStepTitle') }}</h3>
-    <div class="verify-step-list">
-      <h4>{{ t('views.mail.sections.customDomains.verifyStepOneTitle') }}</h4>
-      <p>{{ t('views.mail.sections.customDomains.verifyStepOne') }}</p>
-      <h4>{{ t('views.mail.sections.customDomains.verifyStepTwoTitle') }}</h4>
-      <p>{{ t('views.mail.sections.customDomains.verifyStepTwo') }}</p>
-      <h4>{{ t('views.mail.sections.customDomains.verifyStepThreeTitle') }}</h4>
-      <p>{{ t('views.mail.sections.customDomains.verifyStepThree') }}</p>
-      <p class="verify-step-note">
-        <strong>{{ t('views.mail.sections.customDomains.verifyStepNoteTip') }}</strong>
-        {{ t('views.mail.sections.customDomains.verifyStepNote') }}
-      </p>
-    </div>
-
-    <div class="records-table-wrapper">
-      <div class="records-table">
-        <div class="records-table-header">
-          <p class="records-cell-status" aria-hidden="true"></p>
-          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderType') }}</p>
-          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderNameHost') }}</p>
-          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderValueData') }}</p>
-          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderPriority') }}</p>
-          <p class="records-cell-action" aria-hidden="true"></p>
-        </div>
-        <div
-          class="records-table-row"
-          :class="{
-            'record-warning': row.severity === 'warning',
-            'record-stale': row.isStale,
-            'record-conflict': row.isConflict,
-          }"
-          v-for="row in dnsTableRows"
-          :key="row.key"
-        >
-          <div class="records-cell records-cell-status">
-            <ph-check-circle
-              v-if="row.status === 'success'"
-              size="16"
-              weight="duotone"
-              class="status-icon status-icon-success"
-              aria-hidden="true"
-            />
-            <ph-warning v-else size="16" weight="duotone" class="status-icon status-icon-warning" aria-hidden="true" />
-          </div>
-
-          <p class="records-cell">{{ row.record.type }}</p>
-
-          <div class="records-cell records-cell-copyable">
-            <span>{{ row.record.name }}</span>
-            <button
-              v-if="hasCopyableValue(row.record.name)"
-              type="button"
-              class="copy-button"
-              :aria-label="t('views.mail.sections.customDomains.copyValue')"
-              @click="copyCellValue(`${row.key}-name`, row.record.name)"
-            >
-              <ph-check v-if="copiedCellKey === `${row.key}-name`" size="14" />
-              <ph-copy-simple v-else size="14" />
-            </button>
-          </div>
-
-          <div class="records-cell records-cell-copyable">
-            <span>{{ row.record.content }}</span>
-            <button
-              v-if="hasCopyableValue(row.record.content)"
-              type="button"
-              class="copy-button"
-              :aria-label="t('views.mail.sections.customDomains.copyValue')"
-              @click="copyCellValue(`${row.key}-content`, row.record.content)"
-            >
-              <ph-check v-if="copiedCellKey === `${row.key}-content`" size="14" />
-              <ph-copy-simple v-else size="14" />
-            </button>
-          </div>
-
-          <div class="records-cell records-cell-copyable">
-            <span>{{ row.record.priority || '-' }}</span>
-            <button
-              v-if="hasCopyableValue(row.record.priority)"
-              type="button"
-              class="copy-button"
-              :aria-label="t('views.mail.sections.customDomains.copyValue')"
-              @click="copyCellValue(`${row.key}-priority`, row.record.priority || '')"
-            >
-              <ph-check v-if="copiedCellKey === `${row.key}-priority`" size="14" />
-              <ph-copy-simple v-else size="14" />
-            </button>
-          </div>
-
-          <div class="records-cell records-cell-action">
-            <span v-if="row.action" class="action-badge" :class="`action-badge-${row.action}`">
-              {{ actionLabel(row.action) }}
-            </span>
-            <ph-info
-              v-if="row.issues.length > 0"
-              size="18"
-              class="action-info-icon"
-              :class="`action-info-icon-${row.severity}`"
-              :title="issuesTooltip(row.issues)"
-            />
-          </div>
-        </div>
-
-        <div class="records-table-footer" v-if="unanchoredValidationIssues.length > 0">
-          <p
-            v-for="issue in unanchoredValidationIssues"
-            :key="issue.key"
-            class="inline-issue"
-            :class="`inline-issue-${issue.severity}`"
-          >
-            <ph-warning-octagon v-if="issue.severity === 'critical'" size="18" weight="fill" aria-hidden="true" />
-            <ph-warning-circle v-else size="18" weight="fill" aria-hidden="true" />
-            <span>{{ issue.text }}</span>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <!-- TODO: Uncomment this once we have the task / job to automatically verify domains -->
-    <!-- <notice-bar :type="NoticeBarTypes.Info" class="verify-step-notice-bar" v-if="showNoticeBar">
-      <strong>{{ t('views.mail.sections.customDomains.verifyStepInfoTitle') }}</strong>
-      <p>{{ t('views.mail.sections.customDomains.verifyStepInfoDescription') }}</p>
-
-      <template #cta>
-        <button class="close-button" @click="showNoticeBar = false">
-          <ph-x size="24" />
-        </button>
-      </template>
-    </notice-bar> -->
-
-    <primary-button class="verify-step-button" @click="onVerifyDomain" :disabled="isVerifyingDomain">
-      {{ t('views.mail.sections.customDomains.verifyStepButton') }}
-    </primary-button>
-  </template>
+  <custom-domain-verify-step
+    v-else-if="step === STEP.VERIFY_DOMAIN"
+    :dns-table-rows="dnsTableRows"
+    :unanchored-validation-issues="unanchoredValidationIssues"
+    :is-verifying-domain="isVerifyingDomain"
+    @verify="onVerifyDomain"
+  />
 </template>
-
-<style scoped>
-.custom-domain-text-input {
-  margin-block-end: 1.5rem;
-}
-
-.domain-already-configured-notice-bar {
-  margin-block-end: 1.5rem;
-
-  a {
-    color: var(--colour-ti-secondary);
-  }
-}
-
-h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: 0.48px;
-  margin-block-end: 1.5rem;
-}
-
-.verify-step-list {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.32;
-  color: var(--colour-ti-secondary);
-  margin-block-end: 1.5rem;
-
-  h4 {
-    font-size: 1rem;
-    font-weight: 600;
-    line-height: 1.32;
-    margin-block-end: 0.25rem;
-  }
-
-  p {
-    margin-inline-start: 1rem;
-    margin-block-end: 1.5rem;
-    font-size: 0.875rem;
-  }
-
-  .verify-step-note {
-    font-size: 0.875rem;
-    line-height: normal;
-    margin: 0;
-  }
-}
-
-.records-table-wrapper {
-  --records-grid-columns: 3rem max-content minmax(150px, 1fr) minmax(200px, 1fr) max-content max-content;
-
-  overflow-x: auto;
-  margin-block-end: 1.5rem;
-}
-
-.records-table {
-  display: grid;
-  grid-template-columns: var(--records-grid-columns);
-  min-width: max-content;
-}
-
-.records-table-header,
-.records-table-row {
-  display: grid;
-  grid-column: 1 / -1;
-  grid-template-columns: subgrid;
-  align-items: center;
-}
-
-.records-table-header {
-  border-block-end: 1px solid var(--colour-neutral-border);
-
-  p {
-    padding: 1rem;
-    text-transform: uppercase;
-    font-weight: 600;
-    font-size: 0.8125rem;
-    letter-spacing: 0.39px;
-  }
-}
-
-.records-table-row {
-  border-block-end: 0.0625rem solid var(--colour-neutral-border);
-
-  &.record-warning {
-    border-block-end-color: var(--colour-warning-default);
-    background-color: var(--colour-warning-soft);
-  }
-}
-
-.records-cell {
-  padding: 1rem;
-  margin: 0;
-  font-size: 0.75rem;
-  word-break: break-word;
-}
-
-.records-cell-status {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-inline: 0;
-}
-
-.status-icon {
-  flex: 0 0 auto;
-}
-
-.status-icon-success {
-  color: var(--colour-success-pressed);
-}
-
-.status-icon-warning {
-  color: var(--colour-ti-warning);
-}
-
-.records-cell-copyable {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-
-  span {
-    word-break: break-word;
-  }
-}
-
-.copy-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  padding: 0.25rem;
-  border: none;
-  background: none;
-  color: var(--colour-ti-secondary);
-  cursor: pointer;
-
-  &:hover {
-    color: var(--colour-primary-hover);
-  }
-
-  &:active {
-    color: var(--colour-primary-pressed);
-  }
-}
-
-.records-cell-action {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-}
-
-.action-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.75rem;
-  border: 1px solid currentColor;
-  border-radius: 300px;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.39px;
-  white-space: nowrap;
-}
-
-.action-badge-add {
-  color: var(--colour-ti-success);
-}
-
-.action-badge-edit {
-  color: var(--colour-ti-warning);
-}
-
-.action-badge-remove {
-  color: var(--colour-danger-default);
-}
-
-.action-info-icon {
-  flex: 0 0 auto;
-  color: var(--colour-ti-secondary);
-  cursor: help;
-}
-
-.action-info-icon-critical {
-  color: var(--colour-danger-default);
-}
-
-.action-info-icon-warning {
-  color: var(--colour-ti-warning);
-}
-
-.records-table-footer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0 1rem 1rem;
-}
-
-.records-table-footer {
-  grid-column: 1 / -1;
-  border-block-start: 1px solid var(--colour-neutral-border);
-  padding-block-start: 1rem;
-}
-
-.inline-issue {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.35;
-
-  svg {
-    flex: 0 0 auto;
-    margin-block-start: 0.0625rem;
-  }
-}
-
-.inline-issue-warning {
-  color: var(--colour-ti-warning);
-}
-
-.verify-step-notice-bar {
-  margin-block-end: 1.5rem;
-
-  .close-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.5rem;
-    border: none;
-    border-radius: 300px;
-    box-shadow: inset 2px 2px 4px 0 rgba(0, 0, 0, 0.05);
-    background-color: rgba(0, 0, 0, 0.05);
-    color: var(--colour-ti-secondary);
-    cursor: pointer;
-
-    &:hover {
-      background-color: rgba(0, 0, 0, 0.1);
-    }
-
-    &:active {
-      background-color: rgba(0, 0, 0, 0.2);
-    }
-  }
-}
-
-.verify-step-button {
-  margin-block-start: 1.5rem;
-}
-
-@media (min-width: 768px) {
-  .custom-domain-text-input {
-    max-width: 50%;
-  }
-
-  .domain-already-configured-notice-bar {
-    max-width: 50%;
-  }
-
-  .records-table-wrapper {
-    overflow-x: visible;
-  }
-
-  .records-table {
-    min-width: auto;
-  }
-}
-</style>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -680,10 +680,6 @@ h3 {
     margin-inline-start: 1rem;
     margin-block-end: 1.5rem;
     font-size: 0.875rem;
-
-    &:not(:first-of-type) {
-      margin-inline-start: 1.25rem;
-    }
   }
 
   .verify-step-note {
@@ -694,12 +690,15 @@ h3 {
 }
 
 .records-table-wrapper {
+  --records-grid-columns: minmax(80px, 0.7fr) minmax(160px, 1.4fr) minmax(220px, 2.4fr) minmax(100px, 0.7fr);
+
   overflow-x: auto;
   margin-block-end: 1.5rem;
 }
 
 .records-table-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--records-grid-columns);
   align-items: center;
   border-block-end: 1px solid var(--colour-neutral-border);
   min-width: max-content;
@@ -707,8 +706,6 @@ h3 {
   p {
     padding: 1rem;
     text-transform: uppercase;
-    width: 150px;
-    flex-shrink: 0;
     font-weight: 600;
     font-size: 0.8125rem;
     letter-spacing: 0.39px;
@@ -749,15 +746,14 @@ h3 {
 }
 
 .records-table-row-cells {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--records-grid-columns);
   align-items: center;
   min-width: max-content;
 
   p {
     padding: 1rem;
     font-size: 0.75rem;
-    width: 150px;
-    flex-shrink: 0;
     word-break: break-word;
   }
 }
@@ -842,11 +838,6 @@ h3 {
 
   .records-table-header {
     min-width: auto;
-
-    p {
-      width: 25%;
-      flex: 1;
-    }
   }
 
   .records-table-row {
@@ -855,11 +846,6 @@ h3 {
 
   .records-table-row-cells {
     min-width: auto;
-
-    p {
-      width: 25%;
-      flex: 1;
-    }
   }
 }
 </style>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -2,33 +2,32 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { PrimaryButton, TextInput, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
-import { PhWarningCircle, PhWarningOctagon } from '@phosphor-icons/vue';
+import {
+  PhCheck,
+  PhCheckCircle,
+  PhCopySimple,
+  PhInfo,
+  PhWarning,
+  PhWarningCircle,
+  PhWarningOctagon,
+} from '@phosphor-icons/vue';
 
 // Types
 import { CustomDomain, DNSRecord, StaleDNSRecord, STEP, DOMAIN_STATUS, DNSRecordStatus } from '../types';
-import type { DomainVerificationResult } from '../types';
+import type {
+  DomainVerificationResult,
+  InlineIssueSeverity,
+  InlineIssue,
+  DnsTableRow,
+  DecoratedDnsTableRow,
+  RowAction,
+  RowStatus,
+} from '../types';
 
 // API
 import { addCustomDomain, verifyDomain, getRemoteDNSRecords } from '../api';
 
 const { t, te } = useI18n();
-
-type InlineIssueSeverity = 'critical' | 'warning';
-
-type InlineIssue = {
-  key: string;
-  severity: InlineIssueSeverity;
-  text: string;
-};
-
-type DnsTableRow = {
-  key: string;
-  record: DNSRecord;
-  issues: InlineIssue[];
-  severity: InlineIssueSeverity | null;
-  isStale: boolean;
-  isConflict: boolean;
-};
 
 const props = defineProps<{
   customDomains: CustomDomain[];
@@ -36,9 +35,9 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  'step-change': [step: STEP]
-  'custom-domain-added': [customDomain: string]
-  'custom-domain-verified': [customDomain: { name: string, status: DOMAIN_STATUS }]
+  'step-change': [step: STEP];
+  'custom-domain-added': [customDomain: string];
+  'custom-domain-verified': [customDomain: { name: string; status: DOMAIN_STATUS }];
 }>();
 
 const step = ref<STEP>(STEP.INITIAL);
@@ -56,6 +55,23 @@ const criticalErrors = ref<string[]>([]);
 const validationWarnings = ref<string[]>([]);
 const showMissingIssues = ref(false);
 const verificationResultsByDomain = ref<Record<string, Omit<DomainVerificationResult, 'domainName'>>>({});
+const copiedCellKey = ref<string | null>(null);
+let copiedResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+const copyCellValue = async (cellKey: string, value: string) => {
+  try {
+    await navigator.clipboard.writeText(value);
+    copiedCellKey.value = cellKey;
+    clearTimeout(copiedResetTimer);
+    copiedResetTimer = setTimeout(() => {
+      copiedCellKey.value = null;
+    }, 1500);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const hasCopyableValue = (value?: string | null): boolean => Boolean(value) && value !== '-';
 
 const formatValidationError = (error: string): string => {
   const translationKey = `views.mail.sections.customDomains.verificationValidationErrors.${error}`;
@@ -99,9 +115,9 @@ const missingOrConflicted = (record: DNSRecord): boolean =>
 const missingValidationKeys = new Set(['mxLookupError', 'spfRecordNotFound', 'dkimRecordNotFound']);
 
 const shouldAnchorDkimMissingIssue = (record: DNSRecord): boolean =>
-  showMissingIssues.value
-  && validationWarnings.value.includes('dkimRecordNotFound')
-  && isDkimRecordForCurrentDomain(record);
+  showMissingIssues.value &&
+  validationWarnings.value.includes('dkimRecordNotFound') &&
+  isDkimRecordForCurrentDomain(record);
 
 const validationResult = (data?: {
   critical_errors?: string[];
@@ -253,8 +269,6 @@ const createDnsTableRow = (record: DNSRecord, index: number): DnsTableRow => {
   };
 };
 
-const conflictSeverity = (record: DNSRecord): InlineIssueSeverity => (isMxRecord(record) ? 'critical' : 'warning');
-
 const createConflictingRecord = (record: DNSRecord, existingValue: string): DNSRecord => {
   const valueParts = existingValue.trim().split(/\s+/);
 
@@ -297,7 +311,7 @@ const createConflictDnsTableRows = (record: DNSRecord, index: number): DnsTableR
     key: `conflict-${record.type}-${record.name}-${existingValue}-${index}-${conflictIndex}`,
     record: createConflictingRecord(record, existingValue),
     issues: conflictIndex === 0 ? issues : [],
-    severity: conflictSeverity(record),
+    severity: 'warning',
     isStale: false,
     isConflict: true,
   }));
@@ -337,18 +351,43 @@ const createStaleDnsTableRow = (record: StaleDNSRecord): DnsTableRow => {
 };
 
 const staleAddressRows = computed(() =>
-  staleDnsRecords.value
-    .filter((record) => record.code === 'autodiscoverCnameUnexpected')
-    .map(createStaleDnsTableRow)
+  staleDnsRecords.value.filter((record) => record.code === 'autodiscoverCnameUnexpected').map(createStaleDnsTableRow)
 );
 
 const staleSrvRows = computed(() =>
-  staleDnsRecords.value
-    .filter((record) => record.code === 'autodiscoverSrvUnexpected')
-    .map(createStaleDnsTableRow)
+  staleDnsRecords.value.filter((record) => record.code === 'autodiscoverSrvUnexpected').map(createStaleDnsTableRow)
 );
 
-const dnsTableRows = computed(() => {
+const rowAction = (row: DnsTableRow): RowAction | null => {
+  if (row.isStale || row.isConflict) {
+    return 'remove';
+  }
+
+  switch (row.record.status) {
+    case DNSRecordStatus.MISSING:
+      return 'add';
+    case DNSRecordStatus.CONFLICT:
+      return 'edit';
+    case DNSRecordStatus.UNKNOWN:
+      return row.issues.length > 0 ? 'add' : null;
+    default:
+      return null;
+  }
+};
+
+const rowStatus = (row: DnsTableRow, action: RowAction | null): RowStatus => {
+  if (row.severity === 'warning' || action) {
+    return 'warning';
+  }
+  return 'success';
+};
+
+const decorateRow = (row: DnsTableRow): DecoratedDnsTableRow => {
+  const action = rowAction(row);
+  return { ...row, action, status: rowStatus(row, action) };
+};
+
+const dnsTableRows = computed<DecoratedDnsTableRow[]>(() => {
   const expectedRows = recordsInfo.value.flatMap(createDnsTableRows);
   const rows = [];
   let insertedAddressRows = false;
@@ -376,10 +415,16 @@ const dnsTableRows = computed(() => {
     rows.push(...staleAddressRows.value);
   }
 
-  return rows;
+  return rows.map(decorateRow);
 });
 
-const anchoredValidationKeys = computed(() => new Set(dnsTableRows.value.flatMap((row) => row.issues.map((issue) => issue.key))));
+const actionLabel = (action: RowAction): string => t(`views.mail.sections.customDomains.recordAction.${action}`);
+
+const issuesTooltip = (issues: InlineIssue[]): string => issues.map((issue) => issue.text).join('\n');
+
+const anchoredValidationKeys = computed(
+  () => new Set(dnsTableRows.value.flatMap((row) => row.issues.map((issue) => issue.key)))
+);
 
 const unanchoredValidationIssues = computed<InlineIssue[]>(() => [
   ...criticalErrors.value
@@ -408,13 +453,13 @@ const handleDNSRecords = async (domainName: string) => {
       applyVerificationResult(domainName, validationResult(remoteDNSRecords), { showMissingIssues: false });
     } else {
       console.error(remoteDNSRecords.error);
-      customDomainError.value = remoteDNSRecords.error;    
+      customDomainError.value = remoteDNSRecords.error;
     }
   } catch (error) {
     console.error(error);
     customDomainError.value = error;
   }
-}
+};
 
 const onCreateCustomDomain = async () => {
   if (props.customDomains.some((domain) => domain.name === customDomain.value)) {
@@ -432,7 +477,7 @@ const onCreateCustomDomain = async () => {
       await handleDNSRecords(customDomain.value);
     } else if (data.code === 'domain_already_configured') {
       console.error(data.error);
-      domainAlreadyConfigured.value = true
+      domainAlreadyConfigured.value = true;
     } else {
       console.error(data.error);
       customDomainError.value = data.error;
@@ -491,33 +536,37 @@ defineExpose({
   showVerificationResult,
 });
 
-watch(step, (newStep) => {
-  emit('step-change', newStep);
-}, { immediate: true });
+watch(
+  step,
+  (newStep) => {
+    emit('step-change', newStep);
+  },
+  { immediate: true }
+);
 
-watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
-  // If we just removed the domain we were adding, reset the step to initial
-  if (newLastDomainRemoved === customDomain.value) {
-    step.value = STEP.INITIAL;
-    customDomain.value = null;
-    customDomainError.value = null;
-    domainAlreadyConfigured.value = false;
-    staleDnsRecords.value = [];
-    criticalErrors.value = [];
-    validationWarnings.value = [];
-    showMissingIssues.value = false;
-    delete verificationResultsByDomain.value[newLastDomainRemoved];
-  }
-}, { immediate: true });
+watch(
+  () => props.lastDomainRemoved,
+  (newLastDomainRemoved) => {
+    // If we just removed the domain we were adding, reset the step to initial
+    if (newLastDomainRemoved === customDomain.value) {
+      step.value = STEP.INITIAL;
+      customDomain.value = null;
+      customDomainError.value = null;
+      domainAlreadyConfigured.value = false;
+      staleDnsRecords.value = [];
+      criticalErrors.value = [];
+      validationWarnings.value = [];
+      showMissingIssues.value = false;
+      delete verificationResultsByDomain.value[newLastDomainRemoved];
+    }
+  },
+  { immediate: true }
+);
 </script>
 
 <template>
   <template v-if="step === STEP.INITIAL">
-    <primary-button
-      variant="outline"
-      @click="step = STEP.ADD"
-      v-if="customDomains.length < maxCustomDomains"
-    >
+    <primary-button variant="outline" @click="step = STEP.ADD" v-if="customDomains.length < maxCustomDomains">
       {{ t('views.mail.sections.customDomains.addDomain') }}
     </primary-button>
   </template>
@@ -534,11 +583,15 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
       >
         {{ t('views.mail.sections.customDomains.enterCustomDomain') }}
       </text-input>
-  
-      <notice-bar :type="NoticeBarTypes.Critical" v-if="domainAlreadyConfigured" class="domain-already-configured-notice-bar">
+
+      <notice-bar
+        :type="NoticeBarTypes.Critical"
+        v-if="domainAlreadyConfigured"
+        class="domain-already-configured-notice-bar"
+      >
         <i18n-t keypath="views.mail.sections.customDomains.domainAlreadyConfigured" tag="span">
           <template #link>
-             <router-link to="/contact">{{ t('views.mail.sections.customDomains.reachOutToSupport') }}</router-link>
+            <router-link to="/contact">{{ t('views.mail.sections.customDomains.reachOutToSupport') }}</router-link>
           </template>
         </i18n-t>
       </notice-bar>
@@ -565,36 +618,97 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
     </div>
 
     <div class="records-table-wrapper">
-      <div class="records-table-header">
-        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderType') }}</p>
-        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderNameHost') }}</p>
-        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderValueData') }}</p>
-        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderPriority') }}</p>
-      </div>
-      <div
-        class="records-table-row"
-        :class="{
-          'record-critical': row.severity === 'critical',
-          'record-warning': row.severity === 'warning',
-          'record-stale': row.isStale,
-          'record-conflict': row.isConflict,
-        }"
-        v-for="row in dnsTableRows"
-        :key="row.key"
-      >
-        <div class="records-table-row-cells">
-          <p>{{ row.record.type }}</p>
-          <p>{{ row.record.name }}</p>
-          <p>{{ row.record.content }}</p>
-          <p>{{ row.record.priority || '-' }}</p>
+      <div class="records-table">
+        <div class="records-table-header">
+          <p class="records-cell-status" aria-hidden="true"></p>
+          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderType') }}</p>
+          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderNameHost') }}</p>
+          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderValueData') }}</p>
+          <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderPriority') }}</p>
+          <p class="records-cell-action" aria-hidden="true"></p>
+        </div>
+        <div
+          class="records-table-row"
+          :class="{
+            'record-warning': row.severity === 'warning',
+            'record-stale': row.isStale,
+            'record-conflict': row.isConflict,
+          }"
+          v-for="row in dnsTableRows"
+          :key="row.key"
+        >
+          <div class="records-cell records-cell-status">
+            <ph-check-circle
+              v-if="row.status === 'success'"
+              size="16"
+              weight="duotone"
+              class="status-icon status-icon-success"
+              aria-hidden="true"
+            />
+            <ph-warning v-else size="16" weight="duotone" class="status-icon status-icon-warning" aria-hidden="true" />
+          </div>
+
+          <p class="records-cell">{{ row.record.type }}</p>
+
+          <div class="records-cell records-cell-copyable">
+            <span>{{ row.record.name }}</span>
+            <button
+              v-if="hasCopyableValue(row.record.name)"
+              type="button"
+              class="copy-button"
+              :aria-label="t('views.mail.sections.customDomains.copyValue')"
+              @click="copyCellValue(`${row.key}-name`, row.record.name)"
+            >
+              <ph-check v-if="copiedCellKey === `${row.key}-name`" size="14" />
+              <ph-copy-simple v-else size="14" />
+            </button>
+          </div>
+
+          <div class="records-cell records-cell-copyable">
+            <span>{{ row.record.content }}</span>
+            <button
+              v-if="hasCopyableValue(row.record.content)"
+              type="button"
+              class="copy-button"
+              :aria-label="t('views.mail.sections.customDomains.copyValue')"
+              @click="copyCellValue(`${row.key}-content`, row.record.content)"
+            >
+              <ph-check v-if="copiedCellKey === `${row.key}-content`" size="14" />
+              <ph-copy-simple v-else size="14" />
+            </button>
+          </div>
+
+          <div class="records-cell records-cell-copyable">
+            <span>{{ row.record.priority || '-' }}</span>
+            <button
+              v-if="hasCopyableValue(row.record.priority)"
+              type="button"
+              class="copy-button"
+              :aria-label="t('views.mail.sections.customDomains.copyValue')"
+              @click="copyCellValue(`${row.key}-priority`, row.record.priority || '')"
+            >
+              <ph-check v-if="copiedCellKey === `${row.key}-priority`" size="14" />
+              <ph-copy-simple v-else size="14" />
+            </button>
+          </div>
+
+          <div class="records-cell records-cell-action">
+            <span v-if="row.action" class="action-badge" :class="`action-badge-${row.action}`">
+              {{ actionLabel(row.action) }}
+            </span>
+            <ph-info
+              v-if="row.issues.length > 0"
+              size="18"
+              class="action-info-icon"
+              :class="`action-info-icon-${row.severity}`"
+              :title="issuesTooltip(row.issues)"
+            />
+          </div>
         </div>
 
-        <div
-          v-if="row.issues.length > 0"
-          class="record-inline-issues"
-        >
+        <div class="records-table-footer" v-if="unanchoredValidationIssues.length > 0">
           <p
-            v-for="issue in row.issues"
+            v-for="issue in unanchoredValidationIssues"
             :key="issue.key"
             class="inline-issue"
             :class="`inline-issue-${issue.severity}`"
@@ -604,19 +718,6 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
             <span>{{ issue.text }}</span>
           </p>
         </div>
-      </div>
-
-      <div class="records-table-footer" v-if="unanchoredValidationIssues.length > 0">
-        <p
-          v-for="issue in unanchoredValidationIssues"
-          :key="issue.key"
-          class="inline-issue"
-          :class="`inline-issue-${issue.severity}`"
-        >
-          <ph-warning-octagon v-if="issue.severity === 'critical'" size="18" weight="fill" aria-hidden="true" />
-          <ph-warning-circle v-else size="18" weight="fill" aria-hidden="true" />
-          <span>{{ issue.text }}</span>
-        </p>
       </div>
     </div>
 
@@ -632,11 +733,7 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
       </template>
     </notice-bar> -->
 
-    <primary-button
-      class="verify-step-button"
-      @click="onVerifyDomain"
-      :disabled="isVerifyingDomain"
-    >
+    <primary-button class="verify-step-button" @click="onVerifyDomain" :disabled="isVerifyingDomain">
       {{ t('views.mail.sections.customDomains.verifyStepButton') }}
     </primary-button>
   </template>
@@ -690,18 +787,28 @@ h3 {
 }
 
 .records-table-wrapper {
-  --records-grid-columns: minmax(80px, 0.7fr) minmax(160px, 1.4fr) minmax(220px, 2.4fr) minmax(100px, 0.7fr);
+  --records-grid-columns: 3rem max-content minmax(150px, 1fr) minmax(200px, 1fr) max-content max-content;
 
   overflow-x: auto;
   margin-block-end: 1.5rem;
 }
 
-.records-table-header {
+.records-table {
   display: grid;
   grid-template-columns: var(--records-grid-columns);
-  align-items: center;
-  border-block-end: 1px solid var(--colour-neutral-border);
   min-width: max-content;
+}
+
+.records-table-header,
+.records-table-row {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  align-items: center;
+}
+
+.records-table-header {
+  border-block-end: 1px solid var(--colour-neutral-border);
 
   p {
     padding: 1rem;
@@ -713,52 +820,117 @@ h3 {
 }
 
 .records-table-row {
-  display: flex;
-  flex-direction: column;
-  min-width: max-content;
-  border-inline-start: 0.25rem solid transparent;
-
-  &:nth-child(odd) {
-    background-color: var(--colour-neutral-lower);
-  }
+  border-block-end: 0.0625rem solid var(--colour-neutral-border);
 
   &.record-warning {
-    border-inline-start-color: var(--colour-warning-default);
+    border-block-end-color: var(--colour-warning-default);
     background-color: var(--colour-warning-soft);
-  }
-
-  &.record-critical {
-    border-inline-start-color: var(--colour-danger-default);
-    background-color: var(--colour-danger-soft);
-  }
-
-  &.record-stale {
-    .records-table-row-cells p:first-child {
-      font-weight: 600;
-    }
-  }
-
-  &.record-conflict {
-    .records-table-row-cells p {
-      font-weight: 600;
-    }
   }
 }
 
-.records-table-row-cells {
-  display: grid;
-  grid-template-columns: var(--records-grid-columns);
-  align-items: center;
-  min-width: max-content;
+.records-cell {
+  padding: 1rem;
+  margin: 0;
+  font-size: 0.75rem;
+  word-break: break-word;
+}
 
-  p {
-    padding: 1rem;
-    font-size: 0.75rem;
+.records-cell-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 0;
+}
+
+.status-icon {
+  flex: 0 0 auto;
+}
+
+.status-icon-success {
+  color: var(--colour-success-pressed);
+}
+
+.status-icon-warning {
+  color: var(--colour-ti-warning);
+}
+
+.records-cell-copyable {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  span {
     word-break: break-word;
   }
 }
 
-.record-inline-issues,
+.copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  padding: 0.25rem;
+  border: none;
+  background: none;
+  color: var(--colour-ti-secondary);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--colour-primary-hover);
+  }
+
+  &:active {
+    color: var(--colour-primary-pressed);
+  }
+}
+
+.records-cell-action {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.action-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid currentColor;
+  border-radius: 300px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.39px;
+  white-space: nowrap;
+}
+
+.action-badge-add {
+  color: var(--colour-ti-success);
+}
+
+.action-badge-edit {
+  color: var(--colour-ti-warning);
+}
+
+.action-badge-remove {
+  color: var(--colour-danger-default);
+}
+
+.action-info-icon {
+  flex: 0 0 auto;
+  color: var(--colour-ti-secondary);
+  cursor: help;
+}
+
+.action-info-icon-critical {
+  color: var(--colour-danger-default);
+}
+
+.action-info-icon-warning {
+  color: var(--colour-ti-warning);
+}
+
 .records-table-footer {
   display: flex;
   flex-direction: column;
@@ -767,7 +939,7 @@ h3 {
 }
 
 .records-table-footer {
-  min-width: max-content;
+  grid-column: 1 / -1;
   border-block-start: 1px solid var(--colour-neutral-border);
   padding-block-start: 1rem;
 }
@@ -784,10 +956,6 @@ h3 {
     flex: 0 0 auto;
     margin-block-start: 0.0625rem;
   }
-}
-
-.inline-issue-critical {
-  color: var(--colour-danger-default);
 }
 
 .inline-issue-warning {
@@ -836,15 +1004,7 @@ h3 {
     overflow-x: visible;
   }
 
-  .records-table-header {
-    min-width: auto;
-  }
-
-  .records-table-row {
-    min-width: auto;
-  }
-
-  .records-table-row-cells {
+  .records-table {
     min-width: auto;
   }
 }

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -225,6 +225,7 @@ watch(
 
   <custom-domain-verify-step
     v-else-if="step === STEP.VERIFY_DOMAIN"
+    :domain-name="customDomain"
     :dns-table-rows="dnsTableRows"
     :unanchored-validation-issues="unanchoredValidationIssues"
     :is-verifying-domain="isVerifyingDomain"

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -228,6 +228,7 @@ watch(
     :dns-table-rows="dnsTableRows"
     :unanchored-validation-issues="unanchoredValidationIssues"
     :is-verifying-domain="isVerifyingDomain"
+    :show-record-status="showMissingIssues"
     @verify="onVerifyDomain"
   />
 </template>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
@@ -9,6 +9,7 @@ defineProps<{
   dnsTableRows: DecoratedDnsTableRow[];
   unanchoredValidationIssues: InlineIssue[];
   isVerifyingDomain: boolean;
+  showRecordStatus: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -33,7 +34,11 @@ const { t } = useI18n();
     </p>
   </div>
 
-  <dns-records-table :rows="dnsTableRows" :unanchored-validation-issues="unanchoredValidationIssues" />
+  <dns-records-table
+    :rows="dnsTableRows"
+    :unanchored-validation-issues="unanchoredValidationIssues"
+    :show-record-status="showRecordStatus"
+  />
 
   <!-- TODO: Uncomment this once we have the task / job to automatically verify domains -->
   <!-- <notice-bar :type="NoticeBarTypes.Info" class="verify-step-notice-bar" v-if="showNoticeBar">

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
+import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 
-import type { DecoratedDnsTableRow, InlineIssue } from '../types';
+import { DecoratedDnsTableRow, InlineIssue, RecordTab } from '../types';
 import DnsRecordsTable from './DnsRecordsTable.vue';
 
-defineProps<{
+const props = defineProps<{
+  domainName: string;
   dnsTableRows: DecoratedDnsTableRow[];
   unanchoredValidationIssues: InlineIssue[];
   isVerifyingDomain: boolean;
@@ -17,6 +19,16 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
+
+const activeTab = ref<RecordTab>(RecordTab.CONFLICTING);
+
+const hasConflictingRecords = computed(() => {
+  return props.dnsTableRows.some((row) => row.status === 'warning' || row.status === 'critical');
+})
+
+const onTabSelected = (tab: RecordTab) => {
+  activeTab.value = tab;
+};
 </script>
 
 <template>
@@ -34,10 +46,30 @@ const { t } = useI18n();
     </p>
   </div>
 
+  <h2 class="domain-title-header">{{ t('views.mail.sections.customDomains.domains') }} > {{ t('views.mail.sections.customDomains.ownerDNSRecords', { domainName }) }}</h2>
+
+  <div class="record-tabs" v-if="showRecordStatus && hasConflictingRecords">
+    <button
+      type="button"
+      :class="{ active: activeTab === RecordTab.CONFLICTING }"
+      @click="onTabSelected(RecordTab.CONFLICTING)"
+    >
+      {{ t('views.mail.sections.customDomains.conflictingRecords') }}
+    </button>
+    <button
+      type="button"
+      :class="{ active: activeTab === RecordTab.ALL }"
+      @click="onTabSelected(RecordTab.ALL)"
+    >
+      {{ t('views.mail.sections.customDomains.allRecords') }}
+    </button>
+  </div>
+
   <dns-records-table
     :rows="dnsTableRows"
     :unanchored-validation-issues="unanchoredValidationIssues"
     :show-record-status="showRecordStatus"
+    :active-tab="activeTab"
   />
 
   <!-- TODO: Uncomment this once we have the task / job to automatically verify domains -->
@@ -58,6 +90,15 @@ const { t } = useI18n();
 </template>
 
 <style scoped>
+h2 {
+  font-size: 1rem;
+  font-weight: 500;
+  font-family: metropolis;
+  color: var(--colour-ti-highlight);
+  margin-block-end: 1rem;
+  text-transform: uppercase;
+}
+
 h3 {
   font-size: 1rem;
   font-weight: 600;
@@ -65,12 +106,37 @@ h3 {
   margin-block-end: 1.5rem;
 }
 
+.record-tabs {
+  border-block-end: 1px solid var(--colour-neutral-border-intense);
+
+  button {
+    padding: 1rem;
+    background-color: var(--colour-neutral-base);
+    text-transform: uppercase;
+    font-weight: 600;
+    font-size: 0.83rem;
+    border: none;
+    cursor: pointer;
+    color: var(--colour-ti-secondary);
+    border-block-end: 1.5px solid transparent;
+
+    &:hover {
+      background-color: var(--colour-neutral-lower);
+    }
+
+    &.active {
+      color: var(--colour-ti-base);
+      border-block-end-color: var(--colour-primary-default);
+    }
+  }
+}
+
 .verify-step-list {
   display: flex;
   flex-direction: column;
   line-height: 1.32;
   color: var(--colour-ti-secondary);
-  margin-block-end: 1.5rem;
+  margin-block-end: 2.5rem;
 
   h4 {
     font-size: 1rem;

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
@@ -70,6 +70,7 @@ const onTabSelected = (tab: RecordTab) => {
     :unanchored-validation-issues="unanchoredValidationIssues"
     :show-record-status="showRecordStatus"
     :active-tab="activeTab"
+    :has-conflicting-records="hasConflictingRecords"
   />
 
   <!-- TODO: Uncomment this once we have the task / job to automatically verify domains -->

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainVerifyStep.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { PrimaryButton } from '@thunderbirdops/services-ui';
+
+import type { DecoratedDnsTableRow, InlineIssue } from '../types';
+import DnsRecordsTable from './DnsRecordsTable.vue';
+
+defineProps<{
+  dnsTableRows: DecoratedDnsTableRow[];
+  unanchoredValidationIssues: InlineIssue[];
+  isVerifyingDomain: boolean;
+}>();
+
+const emit = defineEmits<{
+  verify: [];
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <h3>{{ t('views.mail.sections.customDomains.verifyStepTitle') }}</h3>
+  <div class="verify-step-list">
+    <h4>{{ t('views.mail.sections.customDomains.verifyStepOneTitle') }}</h4>
+    <p>{{ t('views.mail.sections.customDomains.verifyStepOne') }}</p>
+    <h4>{{ t('views.mail.sections.customDomains.verifyStepTwoTitle') }}</h4>
+    <p>{{ t('views.mail.sections.customDomains.verifyStepTwo') }}</p>
+    <h4>{{ t('views.mail.sections.customDomains.verifyStepThreeTitle') }}</h4>
+    <p>{{ t('views.mail.sections.customDomains.verifyStepThree') }}</p>
+    <p class="verify-step-note">
+      <strong>{{ t('views.mail.sections.customDomains.verifyStepNoteTip') }}</strong>
+      {{ t('views.mail.sections.customDomains.verifyStepNote') }}
+    </p>
+  </div>
+
+  <dns-records-table :rows="dnsTableRows" :unanchored-validation-issues="unanchoredValidationIssues" />
+
+  <!-- TODO: Uncomment this once we have the task / job to automatically verify domains -->
+  <!-- <notice-bar :type="NoticeBarTypes.Info" class="verify-step-notice-bar" v-if="showNoticeBar">
+    <strong>{{ t('views.mail.sections.customDomains.verifyStepInfoTitle') }}</strong>
+    <p>{{ t('views.mail.sections.customDomains.verifyStepInfoDescription') }}</p>
+
+    <template #cta>
+      <button class="close-button" @click="showNoticeBar = false">
+        <ph-x size="24" />
+      </button>
+    </template>
+  </notice-bar> -->
+
+  <primary-button class="verify-step-button" @click="emit('verify')" :disabled="isVerifyingDomain">
+    {{ t('views.mail.sections.customDomains.verifyStepButton') }}
+  </primary-button>
+</template>
+
+<style scoped>
+h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.48px;
+  margin-block-end: 1.5rem;
+}
+
+.verify-step-list {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.32;
+  color: var(--colour-ti-secondary);
+  margin-block-end: 1.5rem;
+
+  h4 {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.32;
+    margin-block-end: 0.25rem;
+  }
+
+  p {
+    margin-inline-start: 1rem;
+    margin-block-end: 1.5rem;
+    font-size: 0.875rem;
+  }
+
+  .verify-step-note {
+    font-size: 0.875rem;
+    line-height: normal;
+    margin: 0;
+  }
+}
+
+.verify-step-notice-bar {
+  margin-block-end: 1.5rem;
+
+  .close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 300px;
+    box-shadow: inset 2px 2px 4px 0 rgba(0, 0, 0, 0.05);
+    background-color: rgba(0, 0, 0, 0.05);
+    color: var(--colour-ti-secondary);
+    cursor: pointer;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.1);
+    }
+
+    &:active {
+      background-color: rgba(0, 0, 0, 0.2);
+    }
+  }
+}
+
+.verify-step-button {
+  margin-block-start: 1.5rem;
+}
+</style>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
@@ -19,6 +19,7 @@ const props = defineProps<{
   unanchoredValidationIssues: InlineIssue[];
   showRecordStatus?: boolean;
   activeTab?: RecordTab;
+  hasConflictingRecords?: boolean;
 }>();
 
 const { t } = useI18n();
@@ -27,7 +28,7 @@ const copiedCellKey = ref<string | null>(null);
 let copiedResetTimer: ReturnType<typeof setTimeout> | undefined;
 
 const filteredRows = computed(() => {
-  if (props.showRecordStatus) {
+  if (props.showRecordStatus && props.hasConflictingRecords) {
     return props.rows.filter((row) => {
       if (props.activeTab === RecordTab.CONFLICTING) {
         return row.status === 'warning' || row.status === 'critical';
@@ -49,6 +50,7 @@ const copyCellValue = async (cellKey: string, value: string) => {
       copiedCellKey.value = null;
     }, 1500);
   } catch (error) {
+    // TODO: Change this when we decide where to show the error
     console.error(error);
   }
 };

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   PhCheck,
@@ -11,19 +11,34 @@ import {
   PhWarningOctagon,
 } from '@phosphor-icons/vue';
 
-import type { DecoratedDnsTableRow, InlineIssue } from '../types';
+import { DecoratedDnsTableRow, InlineIssue, RecordTab } from '../types';
 import { hasCopyableValue } from '../utils';
 
-defineProps<{
+const props = defineProps<{
   rows: DecoratedDnsTableRow[];
   unanchoredValidationIssues: InlineIssue[];
   showRecordStatus?: boolean;
+  activeTab?: RecordTab;
 }>();
 
 const { t } = useI18n();
 
 const copiedCellKey = ref<string | null>(null);
 let copiedResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+const filteredRows = computed(() => {
+  if (props.showRecordStatus) {
+    return props.rows.filter((row) => {
+      if (props.activeTab === RecordTab.CONFLICTING) {
+        return row.status === 'warning' || row.status === 'critical';
+      }
+
+      return true;
+    });
+  }
+
+  return props.rows;
+});
 
 const copyCellValue = async (cellKey: string, value: string) => {
   try {
@@ -52,12 +67,8 @@ const copyCellValue = async (cellKey: string, value: string) => {
       </div>
       <div
         class="records-table-row"
-        :class="{
-          'record-warning': row.severity === 'warning',
-          'record-stale': row.isStale,
-          'record-conflict': row.isConflict,
-        }"
-        v-for="row in rows"
+        :class="{ 'record-warning': row.status === 'warning' || row.status === 'critical' }"
+        v-for="row in filteredRows"
         :key="row.key"
       >
         <div v-if="showRecordStatus" class="records-cell records-cell-status">

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
@@ -7,7 +7,6 @@ import {
   PhCopySimple,
   PhWarning,
   PhWarningCircle,
-  PhWarningOctagon,
 } from '@phosphor-icons/vue';
 
 import { DecoratedDnsTableRow, InlineIssue, RecordTab } from '../types';
@@ -145,11 +144,9 @@ const copyCellValue = async (cellKey: string, value: string) => {
         <p
           v-for="issue in unanchoredValidationIssues"
           :key="issue.key"
-          class="inline-issue"
-          :class="`inline-issue-${issue.severity}`"
+          class="inline-issue inline-issue-warning"
         >
-          <ph-warning-octagon v-if="issue.severity === 'critical'" size="18" weight="fill" aria-hidden="true" />
-          <ph-warning-circle v-else size="18" weight="fill" aria-hidden="true" />
+          <ph-warning-circle size="18" weight="fill" aria-hidden="true" />
           <span>{{ issue.text }}</span>
         </p>
       </div>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
@@ -17,6 +17,7 @@ import { hasCopyableValue } from '../utils';
 defineProps<{
   rows: DecoratedDnsTableRow[];
   unanchoredValidationIssues: InlineIssue[];
+  showRecordStatus?: boolean;
 }>();
 
 const { t } = useI18n();
@@ -39,10 +40,10 @@ const copyCellValue = async (cellKey: string, value: string) => {
 </script>
 
 <template>
-  <div class="records-table-wrapper">
+  <div class="records-table-wrapper" :class="{ 'records-table-wrapper-with-status': showRecordStatus }">
     <div class="records-table">
       <div class="records-table-header">
-        <p class="records-cell-status" aria-hidden="true"></p>
+        <p v-if="showRecordStatus" class="records-cell-status" aria-hidden="true"></p>
         <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderType') }}</p>
         <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderNameHost') }}</p>
         <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderValueData') }}</p>
@@ -59,7 +60,7 @@ const copyCellValue = async (cellKey: string, value: string) => {
         v-for="row in rows"
         :key="row.key"
       >
-        <div class="records-cell records-cell-status">
+        <div v-if="showRecordStatus" class="records-cell records-cell-status">
           <ph-check-circle
             v-if="row.status === 'success'"
             size="16"
@@ -109,22 +110,22 @@ const copyCellValue = async (cellKey: string, value: string) => {
             :aria-label="t('views.mail.sections.customDomains.copyValue')"
             @click="copyCellValue(`${row.key}-priority`, row.record.priority || '')"
           >
-            <ph-check v-if="copiedCellKey === `${row.key}-priority`" size="14" />
-            <ph-copy-simple v-else size="14" />
+            <ph-check v-if="copiedCellKey === `${row.key}-priority`" size="16" />
+            <ph-copy-simple v-else size="16" />
           </button>
         </div>
 
         <div class="records-cell records-cell-action">
-          <span v-if="row.action" class="action-badge" :class="`action-badge-${row.action}`">
-            {{ t(`views.mail.sections.customDomains.recordAction.${row.action}`) }}
-          </span>
-          <ph-info
-            v-if="row.issues.length > 0"
-            size="18"
-            class="action-info-icon"
-            :class="`action-info-icon-${row.severity}`"
-            :title="row.issues.map((issue) => issue.text).join('\n')"
-          />
+          <template v-if="row.action">
+            <span class="action-badge">
+              {{ t(`views.mail.sections.customDomains.recordAction.${row.action}`) }}
+            </span>
+            <ph-info
+              size="16"
+              class="action-info-icon"
+              :title="row.issues.map((issue) => issue.text).join('\n')"
+            />
+          </template>
         </div>
       </div>
 
@@ -146,10 +147,14 @@ const copyCellValue = async (cellKey: string, value: string) => {
 
 <style scoped>
 .records-table-wrapper {
-  --records-grid-columns: 3rem max-content minmax(150px, 1fr) minmax(200px, 1fr) max-content max-content;
+  --records-grid-columns: max-content minmax(150px, 1fr) minmax(200px, 1fr) max-content max-content;
 
   overflow-x: auto;
   margin-block-end: 1.5rem;
+
+  &.records-table-wrapper-with-status {
+    --records-grid-columns: 3rem max-content minmax(150px, 1fr) minmax(200px, 1fr) max-content max-content;
+  }
 }
 
 .records-table {
@@ -247,7 +252,7 @@ const copyCellValue = async (cellKey: string, value: string) => {
 .records-cell-action {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 0.5rem;
 }
 
@@ -258,35 +263,16 @@ const copyCellValue = async (cellKey: string, value: string) => {
   border: 1px solid currentColor;
   border-radius: 300px;
   font-size: 0.6875rem;
+  margin: 0 auto;
+  color: var(--colour-ti-warning);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.39px;
   white-space: nowrap;
 }
 
-.action-badge-add {
-  color: var(--colour-ti-success);
-}
-
-.action-badge-edit {
-  color: var(--colour-ti-warning);
-}
-
-.action-badge-remove {
-  color: var(--colour-danger-default);
-}
-
 .action-info-icon {
   flex: 0 0 auto;
-  color: var(--colour-ti-secondary);
-  cursor: help;
-}
-
-.action-info-icon-critical {
-  color: var(--colour-danger-default);
-}
-
-.action-info-icon-warning {
   color: var(--colour-ti-warning);
 }
 

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
@@ -1,0 +1,330 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import {
+  PhCheck,
+  PhCheckCircle,
+  PhCopySimple,
+  PhInfo,
+  PhWarning,
+  PhWarningCircle,
+  PhWarningOctagon,
+} from '@phosphor-icons/vue';
+
+import type { DecoratedDnsTableRow, InlineIssue } from '../types';
+import { hasCopyableValue } from '../utils';
+
+defineProps<{
+  rows: DecoratedDnsTableRow[];
+  unanchoredValidationIssues: InlineIssue[];
+}>();
+
+const { t } = useI18n();
+
+const copiedCellKey = ref<string | null>(null);
+let copiedResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+const copyCellValue = async (cellKey: string, value: string) => {
+  try {
+    await navigator.clipboard.writeText(value);
+    copiedCellKey.value = cellKey;
+    clearTimeout(copiedResetTimer);
+    copiedResetTimer = setTimeout(() => {
+      copiedCellKey.value = null;
+    }, 1500);
+  } catch (error) {
+    console.error(error);
+  }
+};
+</script>
+
+<template>
+  <div class="records-table-wrapper">
+    <div class="records-table">
+      <div class="records-table-header">
+        <p class="records-cell-status" aria-hidden="true"></p>
+        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderType') }}</p>
+        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderNameHost') }}</p>
+        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderValueData') }}</p>
+        <p>{{ t('views.mail.sections.customDomains.recordsTableHeaderPriority') }}</p>
+        <p class="records-cell-action" aria-hidden="true"></p>
+      </div>
+      <div
+        class="records-table-row"
+        :class="{
+          'record-warning': row.severity === 'warning',
+          'record-stale': row.isStale,
+          'record-conflict': row.isConflict,
+        }"
+        v-for="row in rows"
+        :key="row.key"
+      >
+        <div class="records-cell records-cell-status">
+          <ph-check-circle
+            v-if="row.status === 'success'"
+            size="16"
+            weight="duotone"
+            class="status-icon status-icon-success"
+            aria-hidden="true"
+          />
+          <ph-warning v-else size="16" weight="duotone" class="status-icon status-icon-warning" aria-hidden="true" />
+        </div>
+
+        <p class="records-cell">{{ row.record.type }}</p>
+
+        <div class="records-cell records-cell-copyable">
+          <span>{{ row.record.name }}</span>
+          <button
+            v-if="hasCopyableValue(row.record.name)"
+            type="button"
+            class="copy-button"
+            :aria-label="t('views.mail.sections.customDomains.copyValue')"
+            @click="copyCellValue(`${row.key}-name`, row.record.name)"
+          >
+            <ph-check v-if="copiedCellKey === `${row.key}-name`" size="14" />
+            <ph-copy-simple v-else size="14" />
+          </button>
+        </div>
+
+        <div class="records-cell records-cell-copyable">
+          <span>{{ row.record.content }}</span>
+          <button
+            v-if="hasCopyableValue(row.record.content)"
+            type="button"
+            class="copy-button"
+            :aria-label="t('views.mail.sections.customDomains.copyValue')"
+            @click="copyCellValue(`${row.key}-content`, row.record.content)"
+          >
+            <ph-check v-if="copiedCellKey === `${row.key}-content`" size="14" />
+            <ph-copy-simple v-else size="14" />
+          </button>
+        </div>
+
+        <div class="records-cell records-cell-copyable">
+          <span>{{ row.record.priority || '-' }}</span>
+          <button
+            v-if="hasCopyableValue(row.record.priority)"
+            type="button"
+            class="copy-button"
+            :aria-label="t('views.mail.sections.customDomains.copyValue')"
+            @click="copyCellValue(`${row.key}-priority`, row.record.priority || '')"
+          >
+            <ph-check v-if="copiedCellKey === `${row.key}-priority`" size="14" />
+            <ph-copy-simple v-else size="14" />
+          </button>
+        </div>
+
+        <div class="records-cell records-cell-action">
+          <span v-if="row.action" class="action-badge" :class="`action-badge-${row.action}`">
+            {{ t(`views.mail.sections.customDomains.recordAction.${row.action}`) }}
+          </span>
+          <ph-info
+            v-if="row.issues.length > 0"
+            size="18"
+            class="action-info-icon"
+            :class="`action-info-icon-${row.severity}`"
+            :title="row.issues.map((issue) => issue.text).join('\n')"
+          />
+        </div>
+      </div>
+
+      <div class="records-table-footer" v-if="unanchoredValidationIssues.length > 0">
+        <p
+          v-for="issue in unanchoredValidationIssues"
+          :key="issue.key"
+          class="inline-issue"
+          :class="`inline-issue-${issue.severity}`"
+        >
+          <ph-warning-octagon v-if="issue.severity === 'critical'" size="18" weight="fill" aria-hidden="true" />
+          <ph-warning-circle v-else size="18" weight="fill" aria-hidden="true" />
+          <span>{{ issue.text }}</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.records-table-wrapper {
+  --records-grid-columns: 3rem max-content minmax(150px, 1fr) minmax(200px, 1fr) max-content max-content;
+
+  overflow-x: auto;
+  margin-block-end: 1.5rem;
+}
+
+.records-table {
+  display: grid;
+  grid-template-columns: var(--records-grid-columns);
+  min-width: max-content;
+}
+
+.records-table-header,
+.records-table-row {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  align-items: center;
+}
+
+.records-table-header {
+  border-block-end: 1px solid var(--colour-neutral-border);
+
+  p {
+    padding: 1rem;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    letter-spacing: 0.39px;
+  }
+}
+
+.records-table-row {
+  border-block-end: 0.0625rem solid var(--colour-neutral-border);
+
+  &.record-warning {
+    border-block-end-color: var(--colour-warning-default);
+    background-color: var(--colour-warning-soft);
+  }
+}
+
+.records-cell {
+  padding: 1rem;
+  margin: 0;
+  font-size: 0.75rem;
+  word-break: break-word;
+}
+
+.records-cell-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 0;
+}
+
+.status-icon {
+  flex: 0 0 auto;
+}
+
+.status-icon-success {
+  color: var(--colour-success-pressed);
+}
+
+.status-icon-warning {
+  color: var(--colour-ti-warning);
+}
+
+.records-cell-copyable {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  span {
+    word-break: break-word;
+  }
+}
+
+.copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  padding: 0.25rem;
+  border: none;
+  background: none;
+  color: var(--colour-ti-secondary);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--colour-primary-hover);
+  }
+
+  &:active {
+    color: var(--colour-primary-pressed);
+  }
+}
+
+.records-cell-action {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.action-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid currentColor;
+  border-radius: 300px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.39px;
+  white-space: nowrap;
+}
+
+.action-badge-add {
+  color: var(--colour-ti-success);
+}
+
+.action-badge-edit {
+  color: var(--colour-ti-warning);
+}
+
+.action-badge-remove {
+  color: var(--colour-danger-default);
+}
+
+.action-info-icon {
+  flex: 0 0 auto;
+  color: var(--colour-ti-secondary);
+  cursor: help;
+}
+
+.action-info-icon-critical {
+  color: var(--colour-danger-default);
+}
+
+.action-info-icon-warning {
+  color: var(--colour-ti-warning);
+}
+
+.records-table-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0 1rem 1rem;
+  grid-column: 1 / -1;
+  border-block-start: 1px solid var(--colour-neutral-border);
+  padding-block-start: 1rem;
+}
+
+.inline-issue {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.35;
+
+  svg {
+    flex: 0 0 auto;
+    margin-block-start: 0.0625rem;
+  }
+}
+
+.inline-issue-warning {
+  color: var(--colour-ti-warning);
+}
+
+@media (min-width: 768px) {
+  .records-table-wrapper {
+    overflow-x: visible;
+  }
+
+  .records-table {
+    min-width: auto;
+  }
+}
+</style>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/DnsRecordsTable.vue
@@ -5,7 +5,6 @@ import {
   PhCheck,
   PhCheckCircle,
   PhCopySimple,
-  PhInfo,
   PhWarning,
   PhWarningCircle,
   PhWarningOctagon,
@@ -13,6 +12,7 @@ import {
 
 import { DecoratedDnsTableRow, InlineIssue, RecordTab } from '../types';
 import { hasCopyableValue } from '../utils';
+import RecordActionInfoTooltip from './RecordActionInfoTooltip.vue';
 
 const props = defineProps<{
   rows: DecoratedDnsTableRow[];
@@ -131,10 +131,9 @@ const copyCellValue = async (cellKey: string, value: string) => {
             <span class="action-badge">
               {{ t(`views.mail.sections.customDomains.recordAction.${row.action}`) }}
             </span>
-            <ph-info
-              size="16"
-              class="action-info-icon"
-              :title="row.issues.map((issue) => issue.text).join('\n')"
+            <record-action-info-tooltip
+              :record-type="row.record.type"
+              :action="row.action"
             />
           </template>
         </div>
@@ -280,11 +279,6 @@ const copyCellValue = async (cellKey: string, value: string) => {
   text-transform: uppercase;
   letter-spacing: 0.39px;
   white-space: nowrap;
-}
-
-.action-info-icon {
-  flex: 0 0 auto;
-  color: var(--colour-ti-warning);
 }
 
 .records-table-footer {

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/RecordActionInfoTooltip.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/RecordActionInfoTooltip.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { PhInfo } from '@phosphor-icons/vue';
+import { ToolTip } from '@thunderbirdops/services-ui';
+
+import type { RowAction } from '../types';
+
+const props = defineProps<{
+  recordType: string;
+  action: RowAction;
+}>();
+
+const { t, te } = useI18n();
+const triggerRef = ref<HTMLElement | null>(null);
+const isVisible = ref(false);
+
+const containsTarget = (target: EventTarget | null) =>
+  target instanceof Node && triggerRef.value?.contains(target);
+
+const showTooltip = () => {
+  isVisible.value = true;
+};
+
+const hideTooltip = (event: MouseEvent) => {
+  if (!containsTarget(event.relatedTarget)) {
+    isVisible.value = false;
+  }
+};
+
+const info = computed(() => {
+  const category = props.recordType === 'MX' ? 'MX' : props.recordType === 'SRV' ? 'SRV' : 'OTHER';
+  const baseKey = `views.mail.sections.customDomains.recordActionInfo.${category}.${props.action}`;
+  const hasLink = te(`${baseKey}.link`);
+  const boldLabel = t(`${baseKey}.${props.action}`);
+  const linkLabel = hasLink ? t(`${baseKey}.link`) : '';
+
+  return {
+    contentKey: `${baseKey}.content`,
+    boldLabel,
+    linkLabel,
+    hasLink,
+    alt: t(`${baseKey}.content`, { bold: boldLabel, link: linkLabel }),
+  };
+});
+</script>
+
+<template>
+  <span
+    ref="triggerRef"
+    class="action-info-tooltip-trigger"
+    :class="{ 'is-visible': isVisible }"
+    @mouseleave="hideTooltip"
+  >
+    <span class="action-info-icon-trigger" @mouseenter="showTooltip">
+      <ph-info size="16" class="action-info-icon" aria-hidden="true" />
+    </span>
+    <tool-tip :alt="info.alt">
+      <i18n-t :keypath="info.contentKey" tag="span">
+        <template #bold>
+          <strong>{{ info.boldLabel }}</strong>
+        </template>
+        <template v-if="info.hasLink" #link>
+          <!-- TODO: Replace with the actual support URL once we have one. -->
+          <a href="https://support.tb.pro/" target="_blank">{{ info.linkLabel }}</a>
+        </template>
+      </i18n-t>
+    </tool-tip>
+  </span>
+</template>
+
+<style scoped>
+.action-info-tooltip-trigger {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.action-info-icon-trigger {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+
+  &::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    width: 100%;
+    height: 0.5rem;
+  }
+}
+
+.action-info-icon {
+  color: var(--colour-ti-warning);
+}
+
+.action-info-tooltip-trigger :deep(.tooltip) {
+  visibility: hidden;
+  opacity: 0;
+  width: max-content;
+  max-width: 18rem;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  top: auto;
+  transform: translateX(-50%);
+  font-size: 0.8125rem;
+  white-space: normal;
+}
+
+.action-info-tooltip-trigger.is-visible :deep(.tooltip) {
+  visibility: visible;
+  opacity: 1;
+  cursor: default;
+}
+
+.action-info-tooltip-trigger :deep(.tooltip a) {
+  color: var(--colour-ti-secondary);
+}
+</style>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/types.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/types.ts
@@ -72,3 +72,8 @@ export type DecoratedDnsTableRow = DnsTableRow & {
   action: RowAction | null;
   status: RowStatus;
 };
+
+export enum RecordTab {
+  CONFLICTING = 'conflicting',
+  ALL = 'all',
+}

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/types.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/types.ts
@@ -46,3 +46,29 @@ export type DomainVerificationResult = {
   criticalErrors: string[];
   warnings: string[];
 };
+
+export type InlineIssueSeverity = 'critical' | 'warning';
+
+export type RowAction = 'add' | 'edit' | 'remove';
+
+export type RowStatus = 'success' | 'warning' | 'critical';
+
+export type InlineIssue = {
+  key: string;
+  severity: InlineIssueSeverity;
+  text: string;
+};
+
+export type DnsTableRow = {
+  key: string;
+  record: DNSRecord;
+  issues: InlineIssue[];
+  severity: InlineIssueSeverity | null;
+  isStale: boolean;
+  isConflict: boolean;
+};
+
+export type DecoratedDnsTableRow = DnsTableRow & {
+  action: RowAction | null;
+  status: RowStatus;
+};

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/utils.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/utils.ts
@@ -64,11 +64,6 @@ export const hasValidationIssue = (
   validationWarnings: string[]
 ): boolean => criticalErrors.includes(key) || validationWarnings.includes(key);
 
-export const validationSeverity = (
-  key: string | null | undefined,
-  criticalErrors: string[]
-): InlineIssueSeverity => (key && criticalErrors.includes(key) ? 'critical' : 'warning');
-
 export const shouldAnchorDkimMissingIssue = (
   record: DNSRecord,
   customDomain: string,
@@ -80,15 +75,7 @@ export const shouldAnchorDkimMissingIssue = (
   hasValidationIssue('dkimRecordNotFound', criticalErrors, validationWarnings) &&
   isDkimRecordForCurrentDomain(record, customDomain);
 
-export const conflictSeverity = (
-  record: DNSRecord,
-  customDomain: string,
-  criticalErrors: string[]
-): InlineIssueSeverity =>
-  isMxRecord(record) ||
-  recordValidationKeys(record, customDomain).some((key) => criticalErrors.includes(key))
-    ? 'critical'
-    : 'warning';
+const UI_ISSUE_SEVERITY: InlineIssueSeverity = 'warning';
 
 export type DnsTableI18n = {
   t: (key: string, params?: Record<string, unknown>) => string;
@@ -119,15 +106,8 @@ export const validationResultFromApi = (data?: {
   staleDnsRecords: data?.stale_dns_records ?? [],
 });
 
-export const issueSeverity = (issues: InlineIssue[]): InlineIssueSeverity | null => {
-  if (issues.some((issue) => issue.severity === 'critical')) {
-    return 'critical';
-  }
-  if (issues.length > 0) {
-    return 'warning';
-  }
-  return null;
-};
+export const issueSeverity = (issues: InlineIssue[]): InlineIssueSeverity | null =>
+  issues.length > 0 ? UI_ISSUE_SEVERITY : null;
 
 export const recordStatusIssue = (
   record: DNSRecord,
@@ -145,7 +125,7 @@ export const recordStatusIssue = (
   if (isMxRecord(record) && record.status === DNSRecordStatus.CONFLICT) {
     return {
       key: 'mxLookupError',
-      severity: 'critical',
+      severity: UI_ISSUE_SEVERITY,
       text: t('views.mail.sections.customDomains.mxRecordConflictWarning'),
     };
   }
@@ -157,7 +137,7 @@ export const recordStatusIssue = (
 
     return {
       key: 'mxLookupError',
-      severity: 'critical',
+      severity: UI_ISSUE_SEVERITY,
       text: formatValidationError('mxLookupError', i18n),
     };
   }
@@ -168,7 +148,7 @@ export const recordStatusIssue = (
   ) {
     return {
       key: 'dkimRecordNotFound',
-      severity: validationSeverity('dkimRecordNotFound', criticalErrors),
+      severity: UI_ISSUE_SEVERITY,
       text: t('views.mail.sections.customDomains.recordMissingWarning'),
     };
   }
@@ -180,7 +160,7 @@ export const recordStatusIssue = (
 
     return {
       key: 'spfRecordNotFound',
-      severity: 'warning',
+      severity: UI_ISSUE_SEVERITY,
       text: t('views.mail.sections.customDomains.spfRecordConflictWarning', { includeValue }),
     };
   }
@@ -188,7 +168,7 @@ export const recordStatusIssue = (
   if (record.status === DNSRecordStatus.CONFLICT) {
     return {
       key: validationKey ?? `${record.type}-${record.name}-conflict`,
-      severity: validationSeverity(validationKey, criticalErrors),
+      severity: UI_ISSUE_SEVERITY,
       text: t('views.mail.sections.customDomains.recordConflictWarning', {
         currentValue: record.existing_values?.join(', ') || '-',
       }),
@@ -202,7 +182,7 @@ export const recordStatusIssue = (
 
     return {
       key: missingKey ?? `${record.type}-${record.name}-missing`,
-      severity: validationSeverity(missingKey, criticalErrors),
+      severity: UI_ISSUE_SEVERITY,
       text: t('views.mail.sections.customDomains.recordMissingWarning'),
     };
   }
@@ -223,7 +203,7 @@ export const validationIssuesForRecord = (
     .filter((key) => key === 'mxLookupError' || missingOrConflicted(record))
     .map((key) => ({
       key,
-      severity: criticalErrors.includes(key) ? ('critical' as const) : ('warning' as const),
+      severity: UI_ISSUE_SEVERITY,
       text: formatValidationError(key, i18n),
     }));
 };
@@ -296,7 +276,7 @@ export const createConflictDnsTableRows = (
     key: `conflict-${record.type}-${record.name}-${existingValue}-${index}-${conflictIndex}`,
     record: createConflictingRecord(record, existingValue),
     issues: conflictIndex === 0 ? issues : [],
-    severity: conflictSeverity(record, state.customDomain, state.criticalErrors),
+    severity: UI_ISSUE_SEVERITY,
     isStale: false,
     isConflict: true,
   }));
@@ -321,7 +301,7 @@ export const createStaleDnsTableRow = (
   const issues = [
     {
       key: validationKey,
-      severity: 'critical' as const,
+      severity: UI_ISSUE_SEVERITY,
       text: formatValidationError(validationKey, i18n),
     },
   ];
@@ -337,7 +317,7 @@ export const createStaleDnsTableRow = (
       existing_values: record.existing_values,
     },
     issues,
-    severity: 'critical',
+    severity: UI_ISSUE_SEVERITY,
     isStale: true,
     isConflict: false,
   };
@@ -361,7 +341,7 @@ export const rowAction = (row: DnsTableRow): RowAction | null => {
 };
 
 export const rowStatus = (row: DnsTableRow, action: RowAction | null): RowStatus => {
-  if (row.severity === 'warning' || action) {
+  if (row.severity || action) {
     return 'warning';
   }
   return 'success';
@@ -427,7 +407,7 @@ export const buildUnanchoredValidationIssues = (
     .filter((key) => showMissingIssues || !MISSING_VALIDATION_KEYS.has(key))
     .map((key) => ({
       key,
-      severity: 'critical' as const,
+      severity: UI_ISSUE_SEVERITY,
       text: formatValidationError(key, i18n),
     })),
   ...validationWarnings
@@ -435,7 +415,7 @@ export const buildUnanchoredValidationIssues = (
     .filter((key) => showMissingIssues || !MISSING_VALIDATION_KEYS.has(key))
     .map((key) => ({
       key,
-      severity: 'warning' as const,
+      severity: UI_ISSUE_SEVERITY,
       text: formatValidationError(key, i18n),
     })),
 ];

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/utils.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/utils.ts
@@ -1,20 +1,419 @@
-/**
- * Deduplicates critical errors by consolidating ehloError and readGreetingError
- * since they represent the same issue (inability to verify domain records connect to Thundermail)
- */
-export const deduplicateCriticalErrors = (errors: string[]): string[] => {
-  const errorSet = new Set(errors);
+import {
+  DNSRecordStatus,
+  type DNSRecord,
+  type DecoratedDnsTableRow,
+  type DnsTableRow,
+  type DomainVerificationResult,
+  type InlineIssue,
+  type InlineIssueSeverity,
+  type RowAction,
+  type RowStatus,
+  type StaleDNSRecord,
+} from './types';
 
-  // If both ehloError and readGreetingError exist, keep only readGreetingError
-  if (errorSet.has('ehloError') && errorSet.has('readGreetingError')) {
-    errorSet.delete('ehloError');
+export const hasCopyableValue = (value?: string | null): boolean => Boolean(value) && value !== '-';
+
+export const isMxRecord = (record: DNSRecord): boolean => record.type === 'MX';
+
+export const isSpfRecord = (record: DNSRecord): boolean =>
+  record.type === 'TXT' && record.content.trim().toLowerCase().startsWith('v=spf1');
+
+const normalizeDomainName = (domainName?: string | null): string =>
+  (domainName ?? '').trim().replace(/\.$/, '').toLowerCase();
+
+const dkimRecordDomain = (record: DNSRecord): string | null => {
+  if (record.type !== 'CNAME') {
+    return null;
   }
 
-  // If only ehloError exists, replace it with readGreetingError
-  else if (errorSet.has('ehloError')) {
-    errorSet.delete('ehloError');
-    errorSet.add('readGreetingError');
+  const normalizedName = normalizeDomainName(record.name);
+  const domainKeySegment = '._domainkey.';
+  const domainKeyIndex = normalizedName.indexOf(domainKeySegment);
+  if (domainKeyIndex <= 0) {
+    return null;
   }
 
-  return Array.from(errorSet);
+  return normalizedName.slice(domainKeyIndex + domainKeySegment.length);
 };
+
+export const isDkimRecordForCurrentDomain = (record: DNSRecord, customDomain: string): boolean =>
+  dkimRecordDomain(record) === normalizeDomainName(customDomain);
+
+export const recordValidationKeys = (record: DNSRecord, customDomain: string): string[] => {
+  const keys = [];
+  if (isMxRecord(record)) {
+    keys.push('mxLookupError');
+  }
+  if (isSpfRecord(record)) {
+    keys.push('spfRecordNotFound');
+  }
+  if (isDkimRecordForCurrentDomain(record, customDomain)) {
+    keys.push('dkimRecordNotFound');
+  }
+  return keys;
+};
+
+export const MISSING_VALIDATION_KEYS = new Set(['mxLookupError', 'spfRecordNotFound', 'dkimRecordNotFound']);
+
+export const missingOrConflicted = (record: DNSRecord): boolean =>
+  record.status === DNSRecordStatus.MISSING || record.status === DNSRecordStatus.CONFLICT;
+
+export const shouldAnchorDkimMissingIssue = (
+  record: DNSRecord,
+  customDomain: string,
+  showMissingIssues: boolean,
+  validationWarnings: string[]
+): boolean =>
+  showMissingIssues &&
+  validationWarnings.includes('dkimRecordNotFound') &&
+  isDkimRecordForCurrentDomain(record, customDomain);
+
+export type DnsTableI18n = {
+  t: (key: string, params?: Record<string, unknown>) => string;
+  te: (key: string) => boolean;
+};
+
+export type DnsTableState = {
+  customDomain: string;
+  criticalErrors: string[];
+  validationWarnings: string[];
+  showMissingIssues: boolean;
+};
+
+export const formatValidationError = (error: string, { t, te }: DnsTableI18n): string => {
+  const translationKey = `views.mail.sections.customDomains.verificationValidationErrors.${error}`;
+  return te(translationKey) ? t(translationKey) : error;
+};
+
+export const validationResultFromApi = (data?: {
+  critical_errors?: string[];
+  warnings?: string[];
+  dns_records?: DNSRecord[];
+  stale_dns_records?: StaleDNSRecord[];
+}): Pick<DomainVerificationResult, 'criticalErrors' | 'warnings' | 'dnsRecords' | 'staleDnsRecords'> => ({
+  criticalErrors: data?.critical_errors ?? [],
+  warnings: data?.warnings ?? [],
+  dnsRecords: data?.dns_records ?? [],
+  staleDnsRecords: data?.stale_dns_records ?? [],
+});
+
+export const issueSeverity = (issues: InlineIssue[]): InlineIssueSeverity | null => {
+  if (issues.some((issue) => issue.severity === 'critical')) {
+    return 'critical';
+  }
+  if (issues.length > 0) {
+    return 'warning';
+  }
+  return null;
+};
+
+export const recordStatusIssue = (
+  record: DNSRecord,
+  state: DnsTableState,
+  i18n: DnsTableI18n
+): InlineIssue | null => {
+  const { customDomain, criticalErrors, validationWarnings, showMissingIssues } = state;
+  const { t } = i18n;
+  const validationKeys = recordValidationKeys(record, customDomain);
+  const validationKey = validationKeys.find(
+    (key) => criticalErrors.includes(key) || validationWarnings.includes(key)
+  );
+  const missingKey = validationKey ?? validationKeys.find((key) => MISSING_VALIDATION_KEYS.has(key));
+
+  if (isMxRecord(record) && record.status === DNSRecordStatus.CONFLICT) {
+    return {
+      key: 'mxLookupError',
+      severity: 'critical',
+      text: t('views.mail.sections.customDomains.mxRecordConflictWarning'),
+    };
+  }
+
+  if (isMxRecord(record) && record.status === DNSRecordStatus.MISSING) {
+    if (!showMissingIssues) {
+      return null;
+    }
+
+    return {
+      key: 'mxLookupError',
+      severity: 'critical',
+      text: formatValidationError('mxLookupError', i18n),
+    };
+  }
+
+  if (
+    record.status === DNSRecordStatus.UNKNOWN &&
+    shouldAnchorDkimMissingIssue(record, customDomain, showMissingIssues, validationWarnings)
+  ) {
+    return {
+      key: 'dkimRecordNotFound',
+      severity: 'warning',
+      text: t('views.mail.sections.customDomains.recordMissingWarning'),
+    };
+  }
+
+  if (isSpfRecord(record) && record.status === DNSRecordStatus.CONFLICT) {
+    const includeValue =
+      record.content.split(/\s+/).find((part) => part.startsWith('include:')) ??
+      t('views.mail.sections.customDomains.spfRecordIncludeValue');
+
+    return {
+      key: 'spfRecordNotFound',
+      severity: 'warning',
+      text: t('views.mail.sections.customDomains.spfRecordConflictWarning', { includeValue }),
+    };
+  }
+
+  if (record.status === DNSRecordStatus.CONFLICT) {
+    return {
+      key: validationKey ?? `${record.type}-${record.name}-conflict`,
+      severity: 'warning',
+      text: t('views.mail.sections.customDomains.recordConflictWarning', {
+        currentValue: record.existing_values?.join(', ') || '-',
+      }),
+    };
+  }
+
+  if (record.status === DNSRecordStatus.MISSING) {
+    if (!showMissingIssues) {
+      return null;
+    }
+
+    return {
+      key: missingKey ?? `${record.type}-${record.name}-missing`,
+      severity: 'warning',
+      text: t('views.mail.sections.customDomains.recordMissingWarning'),
+    };
+  }
+
+  return null;
+};
+
+export const validationIssuesForRecord = (
+  record: DNSRecord,
+  state: DnsTableState,
+  i18n: DnsTableI18n
+): InlineIssue[] => {
+  const { customDomain, criticalErrors, validationWarnings, showMissingIssues } = state;
+
+  return recordValidationKeys(record, customDomain)
+    .filter((key) => criticalErrors.includes(key) || validationWarnings.includes(key))
+    .filter((key) => showMissingIssues || !MISSING_VALIDATION_KEYS.has(key))
+    .filter((key) => key === 'mxLookupError' || missingOrConflicted(record))
+    .map((key) => ({
+      key,
+      severity: criticalErrors.includes(key) ? ('critical' as const) : ('warning' as const),
+      text: formatValidationError(key, i18n),
+    }));
+};
+
+export const createConflictingRecord = (record: DNSRecord, existingValue: string): DNSRecord => {
+  const valueParts = existingValue.trim().split(/\s+/);
+
+  if (record.type === 'MX' && valueParts.length > 1) {
+    return {
+      ...record,
+      content: valueParts.slice(1).join(' '),
+      priority: valueParts[0],
+      existing_values: [existingValue],
+    };
+  }
+
+  if (record.type === 'SRV' && valueParts.length > 3) {
+    return {
+      ...record,
+      content: valueParts.slice(1).join(' '),
+      priority: valueParts[0],
+      existing_values: [existingValue],
+    };
+  }
+
+  return {
+    ...record,
+    content: existingValue,
+    priority: '-',
+    existing_values: [existingValue],
+  };
+};
+
+export const createDnsTableRow = (
+  record: DNSRecord,
+  index: number,
+  state: DnsTableState,
+  i18n: DnsTableI18n
+): DnsTableRow => {
+  const hasConflictRows = record.status === DNSRecordStatus.CONFLICT && (record.existing_values?.length ?? 0) > 0;
+  const statusIssue = hasConflictRows ? null : recordStatusIssue(record, state, i18n);
+  const validationIssues = statusIssue || hasConflictRows ? [] : validationIssuesForRecord(record, state, i18n);
+  const issues = statusIssue ? [statusIssue, ...validationIssues] : validationIssues;
+
+  return {
+    key: `${record.type}-${record.name}-${record.content}-${index}`,
+    record,
+    issues,
+    severity: issueSeverity(issues),
+    isStale: false,
+    isConflict: false,
+  };
+};
+
+export const createConflictDnsTableRows = (
+  record: DNSRecord,
+  index: number,
+  state: DnsTableState,
+  i18n: DnsTableI18n
+): DnsTableRow[] => {
+  if (record.status !== DNSRecordStatus.CONFLICT || !record.existing_values?.length) {
+    return [];
+  }
+
+  const statusIssue = recordStatusIssue(record, state, i18n);
+  const validationIssues = statusIssue ? [] : validationIssuesForRecord(record, state, i18n);
+  const issues = statusIssue ? [statusIssue, ...validationIssues] : validationIssues;
+
+  return record.existing_values.map((existingValue, conflictIndex) => ({
+    key: `conflict-${record.type}-${record.name}-${existingValue}-${index}-${conflictIndex}`,
+    record: createConflictingRecord(record, existingValue),
+    issues: conflictIndex === 0 ? issues : [],
+    severity: 'warning',
+    isStale: false,
+    isConflict: true,
+  }));
+};
+
+export const createDnsTableRows = (
+  record: DNSRecord,
+  index: number,
+  state: DnsTableState,
+  i18n: DnsTableI18n
+): DnsTableRow[] => [
+  createDnsTableRow(record, index, state, i18n),
+  ...createConflictDnsTableRows(record, index, state, i18n),
+];
+
+export const createStaleDnsTableRow = (
+  record: StaleDNSRecord,
+  i18n: DnsTableI18n
+): DnsTableRow => {
+  const isSrv = record.code === 'autodiscoverSrvUnexpected';
+  const validationKey = isSrv ? 'autodiscoverSrvRecordFound' : 'autodiscoverRecordFound';
+  const issues = [
+    {
+      key: validationKey,
+      severity: 'critical' as const,
+      text: formatValidationError(validationKey, i18n),
+    },
+  ];
+
+  return {
+    key: `stale-${record.code}-${record.type}-${record.name}`,
+    record: {
+      type: record.type,
+      name: record.name,
+      content: record.existing_values.join(', '),
+      priority: '-',
+      status: DNSRecordStatus.CONFLICT,
+      existing_values: record.existing_values,
+    },
+    issues,
+    severity: 'critical',
+    isStale: true,
+    isConflict: false,
+  };
+};
+
+export const rowAction = (row: DnsTableRow): RowAction | null => {
+  if (row.isStale || row.isConflict) {
+    return 'remove';
+  }
+
+  switch (row.record.status) {
+    case DNSRecordStatus.MISSING:
+      return 'add';
+    case DNSRecordStatus.CONFLICT:
+      return 'edit';
+    case DNSRecordStatus.UNKNOWN:
+      return row.issues.length > 0 ? 'add' : null;
+    default:
+      return null;
+  }
+};
+
+export const rowStatus = (row: DnsTableRow, action: RowAction | null): RowStatus => {
+  if (row.severity === 'warning' || action) {
+    return 'warning';
+  }
+  return 'success';
+};
+
+export const decorateDnsTableRow = (row: DnsTableRow): DecoratedDnsTableRow => {
+  const action = rowAction(row);
+  return { ...row, action, status: rowStatus(row, action) };
+};
+
+export const buildDecoratedDnsTableRows = (
+  recordsInfo: DNSRecord[],
+  staleDnsRecords: StaleDNSRecord[],
+  state: DnsTableState,
+  i18n: DnsTableI18n
+): DecoratedDnsTableRow[] => {
+  const staleAddressRows = staleDnsRecords
+    .filter((record) => record.code === 'autodiscoverCnameUnexpected')
+    .map((record) => createStaleDnsTableRow(record, i18n));
+  const staleSrvRows = staleDnsRecords
+    .filter((record) => record.code === 'autodiscoverSrvUnexpected')
+    .map((record) => createStaleDnsTableRow(record, i18n));
+
+  const expectedRows = recordsInfo.flatMap((record, index) => createDnsTableRows(record, index, state, i18n));
+  const rows: DnsTableRow[] = [];
+  let insertedAddressRows = false;
+  let insertedSrvRows = false;
+
+  expectedRows.forEach((row, index) => {
+    rows.push(row);
+    const nextRow = expectedRows[index + 1];
+
+    if (!insertedSrvRows && row.record.type === 'SRV' && nextRow?.record.type !== 'SRV') {
+      rows.push(...staleSrvRows);
+      insertedSrvRows = true;
+    }
+
+    if (!insertedAddressRows && row.record.type === 'CNAME' && nextRow?.record.type !== 'CNAME') {
+      rows.push(...staleAddressRows);
+      insertedAddressRows = true;
+    }
+  });
+
+  if (!insertedSrvRows) {
+    rows.push(...staleSrvRows);
+  }
+  if (!insertedAddressRows) {
+    rows.push(...staleAddressRows);
+  }
+
+  return rows.map(decorateDnsTableRow);
+};
+
+export const buildUnanchoredValidationIssues = (
+  criticalErrors: string[],
+  validationWarnings: string[],
+  anchoredValidationKeys: Set<string>,
+  showMissingIssues: boolean,
+  i18n: DnsTableI18n
+): InlineIssue[] => [
+  ...criticalErrors
+    .filter((key) => !anchoredValidationKeys.has(key))
+    .filter((key) => showMissingIssues || !MISSING_VALIDATION_KEYS.has(key))
+    .map((key) => ({
+      key,
+      severity: 'critical' as const,
+      text: formatValidationError(key, i18n),
+    })),
+  ...validationWarnings
+    .filter((key) => !anchoredValidationKeys.has(key))
+    .filter((key) => showMissingIssues || !MISSING_VALIDATION_KEYS.has(key))
+    .map((key) => ({
+      key,
+      severity: 'warning' as const,
+      text: formatValidationError(key, i18n),
+    })),
+];


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Refactored the `CustomDomainForm` component into more focused / granular components for better future maintainability:
  - `CustomDomainAddStep` and `CustomDomainVerifyStep` only take care of their respective steps
  -  `DnsRecordsTable` only cares about the table itself
  -  `utils.ts` has all the non-component-specific functions used throughout the components
- The `DnsRecordsTable` now uses grid and subgrid for better / easier layouts
- Removed the `critical` status handling in favor of keeping them all as `warning`, per Design request
- Added a header showcasing which domain is the one you are seeing the records of
- Added copy buttons when there are values to be copied 
- Added `Conflicting Records` / `All Records` tabs to filter through the table
- Added info tooltips for conflicting records with personalized tooltips per record type / action

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

Even though we recently updated the Custom Domain UI, it was a temporary measure to unblock the Flight 2. There were still more design updates that the Design team wanted to do that we didn't have time to address so now that we've got a more polished version of it, we should implement it!

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

- We are missing the support article to be added in the MX record tooltips. There's already a [Notion ticket requesting it](https://app.notion.com/p/mzthunderbird/New-Article-TB-Pro-Domains-having-more-than-one-MX-record-3742df5d45ae806584afdfff3fe88cf4?source=copy_link&assetsVersion=23.13.20260612.1035) and it has to be updated soon. Currently this is hard-coded to point to the support website homepage.

- There's no place yet to showcase error in case the clipboard is not available for copying the button. We are only doing a console.error for now but this will probably change in the near future. There's a TODO in the code for that!

- This design is a step towards the north star of custom domains but not the definitive version yet. The Design team is currently evaluating if/when they will get time to do further work around this.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Related with https://github.com/thunderbird/thunderbird-accounts/issues/944

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

<details>
<summary>View DNS records only (no verification yet)</summary>
<img width="2031" height="3043" alt="image" src="https://github.com/user-attachments/assets/120a4275-1ffb-45cd-ab05-9198cdc28bfa" />
</details>

<details>
<summary>Failed (various conflicting records, all records tab)</summary>
<img width="2022" height="3320" alt="image" src="https://github.com/user-attachments/assets/993fc5a1-317d-400c-b50a-7b57f853d6e4" />
</details>

<details>
<summary>Failed (various conflicting records, conflicting records tab)</summary>
<img width="2015" height="2082" alt="image" src="https://github.com/user-attachments/assets/273f39ad-9390-4157-b122-382edf29cb6f" />
</details>

<details>
<summary>Verified (check marks on the left, no tabs are displayed and no action column)</summary>
<img width="2050" height="3011" alt="image" src="https://github.com/user-attachments/assets/28f16bab-121f-48a6-9875-7dc9bc0dae86" />
</details>
