### PR TITLE
Update DMARC validation to pass any record that starts with V=DMARC1 (Take 2) (#941)

### DIFF
--- a/src/thunderbird_accounts/mail/dns.py
+++ b/src/thunderbird_accounts/mail/dns.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Optional
 
 import dns.rdatatype as dns_rdatatype
@@ -6,6 +7,13 @@ import dns.resolver as dns_resolver
 from django.conf import settings
 
 from thunderbird_accounts.mail.clients import DNSRecordStatus, StaleDNSRecordCode
+
+TXT_TAG_SPEC_RE = re.compile(
+    r'[ \t]*(?P<tag>[A-Za-z][A-Za-z0-9_]*)[ \t]*=[ \t]*'
+    r'(?P<value>(?:[!-:<-~]+(?:[ \t]+[!-:<-~]+)*)?)[ \t]*'
+)
+DMARC_VERSION_TAG_RE = re.compile(r'^[ \t]*v[ \t]*=')
+VALID_DMARC_POLICIES = {'none', 'quarantine', 'reject'}
 
 
 def normalize_dns_query_name(name: str, domain_name: str) -> str:
@@ -15,11 +23,10 @@ def normalize_dns_query_name(name: str, domain_name: str) -> str:
 
 
 def txt_tag_value(content: str, tag: str) -> Optional[str]:
-    for part in content.split(';'):
-        part = part.strip()
-        if part.startswith(f'{tag}='):
-            return part[len(tag) + 1 :]
-    return None
+    tags = _parse_txt_tag_value_list(content)
+    if tags is None:
+        return None
+    return dict(tags).get(tag)
 
 
 def normalize_txt_content(content: str) -> str:
@@ -139,13 +146,56 @@ def _compare_dkim_txt(expected_content: str, live_values: list[str]) -> tuple[DN
     return DNSRecordStatus.CONFLICT, dkim_values
 
 
+def _parse_txt_tag_value_list(content: str) -> Optional[list[tuple[str, str]]]:
+    parts = content.strip().split(';')
+    # Remove empty segments.
+    if parts and not parts[-1].strip():
+        parts.pop()
+    if not parts:
+        return None
+
+    tags = []
+    seen_tags = set()
+    for part in parts:
+        match = TXT_TAG_SPEC_RE.fullmatch(part)
+        if not match:
+            return None
+
+        tag = match.group('tag')
+        if tag in seen_tags:
+            return None
+
+        seen_tags.add(tag)
+        tags.append((tag, match.group('value')))
+
+    return tags
+
+
+def _is_valid_dmarc_record(tags: list[tuple[str, str]]) -> bool:
+    tag_values = dict(tags)
+    return tags[0] == ('v', 'DMARC1') and tag_values.get('p') in VALID_DMARC_POLICIES
+
+
+def _is_dmarc_record_candidate(content: str, tags: Optional[list[tuple[str, str]]]) -> bool:
+    if tags is None:
+        return bool(DMARC_VERSION_TAG_RE.match(content))
+    tag_values = dict(tags)
+    return 'v' in tag_values or 'p' in tag_values
+
+
 def _verify_dmarc(live_values: list[str]) -> tuple[DNSRecordStatus, list[str]]:
-    dmarc_values = [value for value in live_values if value.startswith('v=DMARC1')]
+    invalid_dmarc_values = []
+    for value in live_values:
+        tags = _parse_txt_tag_value_list(value)
+        if tags and _is_valid_dmarc_record(tags):
+            return DNSRecordStatus.MATCH, []
+        if _is_dmarc_record_candidate(value, tags):
+            invalid_dmarc_values.append(value)
 
-    if not dmarc_values:
-        return DNSRecordStatus.MISSING, []
+    if invalid_dmarc_values:
+        return DNSRecordStatus.CONFLICT, invalid_dmarc_values
 
-    return DNSRecordStatus.MATCH, []
+    return DNSRecordStatus.MISSING, []
 
 
 def _compare_spf_txt(expected_content: str, live_values: list[str]) -> tuple[DNSRecordStatus, list[str]]:

--- a/src/thunderbird_accounts/mail/dns.py
+++ b/src/thunderbird_accounts/mail/dns.py
@@ -139,6 +139,15 @@ def _compare_dkim_txt(expected_content: str, live_values: list[str]) -> tuple[DN
     return DNSRecordStatus.CONFLICT, dkim_values
 
 
+def _verify_dmarc(live_values: list[str]) -> tuple[DNSRecordStatus, list[str]]:
+    dmarc_values = [value for value in live_values if value.startswith('v=DMARC1')]
+
+    if not dmarc_values:
+        return DNSRecordStatus.MISSING, []
+
+    return DNSRecordStatus.MATCH, []
+
+
 def _compare_spf_txt(expected_content: str, live_values: list[str]) -> tuple[DNSRecordStatus, list[str]]:
     spf_values = [value for value in live_values if value.startswith('v=spf1')]
 
@@ -196,7 +205,7 @@ def check_txt_record_status(domain_name: str, record: dict) -> tuple[DNSRecordSt
     if expected_content.startswith('v=spf1'):
         return _compare_spf_txt(expected_content, live_values)
     if query_name.startswith('_dmarc.'):
-        return _compare_semantic_txt(expected_content, live_values, prefix='v=DMARC1')
+        return _verify_dmarc(live_values)
     if query_name.startswith('_mta-sts.'):
         return _compare_semantic_txt(expected_content, live_values, prefix='v=STSv1')
     if query_name.startswith('_smtp._tls.'):

--- a/src/thunderbird_accounts/mail/tests/test_dns.py
+++ b/src/thunderbird_accounts/mail/tests/test_dns.py
@@ -13,6 +13,7 @@ from thunderbird_accounts.mail.dns import (
     check_txt_record_status,
     enrich_dns_records_with_status,
     normalize_dns_query_name,
+    txt_tag_value,
 )
 
 
@@ -25,6 +26,20 @@ class TestNormalizeDNSQueryName(SimpleTestCase):
 
     def test_adds_trailing_dot(self):
         self.assertEqual(normalize_dns_query_name('_dmarc.example.com', 'example.com'), '_dmarc.example.com.')
+
+
+class TestTXTTagValue(SimpleTestCase):
+    def test_returns_tag_value_with_optional_whitespace(self):
+        self.assertEqual(txt_tag_value('v=DKIM1; k = rsa; p = expectedkey', 'p'), 'expectedkey')
+
+    def test_returns_none_for_malformed_tag_list(self):
+        self.assertIsNone(txt_tag_value('v=DKIM1; p=expectedkey; broken', 'p'))
+
+    def test_returns_none_for_tag_list_with_newline(self):
+        self.assertIsNone(txt_tag_value('v=DKIM1;\n p=expectedkey', 'p'))
+
+    def test_returns_none_for_duplicate_tag(self):
+        self.assertIsNone(txt_tag_value('v=DKIM1; p=expectedkey; p=otherkey', 'p'))
 
 
 class TestCompareSemanticTXT(SimpleTestCase):
@@ -62,6 +77,19 @@ class TestCompareSemanticTXT(SimpleTestCase):
 class TestDNSRecordStatus(SimpleTestCase):
     def setUp(self):
         self.domain = 'example.com'
+
+    def _txt_record(self, value):
+        mock_txt = MagicMock()
+        mock_txt.strings = [value.encode()]
+        return mock_txt
+
+    def _dmarc_record(self):
+        return {
+            'type': 'TXT',
+            'name': f'_dmarc.{self.domain}.',
+            'content': 'v=DMARC1; p=none;',
+            'priority': '-',
+        }
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
     def test_mx_match_with_extra_records_at_different_priority(self, mock_resolve):
@@ -247,39 +275,43 @@ class TestDNSRecordStatus(SimpleTestCase):
         self.assertEqual(existing_values, [])
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
-    def test_dmarc_match_allows_any_record_starting_with_version(self, mock_resolve):
-        mock_txt = MagicMock()
-        mock_txt.strings = [b'v=DMARC1; p=reject; rua=mailto:dmarc@example.com']
-        mock_resolve.return_value = [mock_txt]
+    def test_dmarc_match_accepts_valid_tag_value_record(self, mock_resolve):
+        mock_resolve.return_value = [self._txt_record(' v = DMARC1 ; p = reject ; rua = mailto:dmarc@example.com ')]
 
-        status, existing_values = check_txt_record_status(
-            self.domain,
-            {
-                'type': 'TXT',
-                'name': f'_dmarc.{self.domain}.',
-                'content': 'v=DMARC1; p=none;',
-                'priority': '-',
-            },
-        )
+        status, existing_values = check_txt_record_status(self.domain, self._dmarc_record())
 
         self.assertEqual(status, DNSRecordStatus.MATCH)
         self.assertEqual(existing_values, [])
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
-    def test_dmarc_missing_without_version_prefix(self, mock_resolve):
-        mock_txt = MagicMock()
-        mock_txt.strings = [b'google-site-verification=example']
-        mock_resolve.return_value = [mock_txt]
+    def test_dmarc_conflict_for_invalid_required_tags(self, mock_resolve):
+        for value in [
+            'v=DMARC1; rua=mailto:dmarc@example.com',
+            'v=DMARC1; p=monitor',
+            'p=none; v=DMARC1',
+        ]:
+            with self.subTest(value=value):
+                mock_resolve.return_value = [self._txt_record(value)]
 
-        status, existing_values = check_txt_record_status(
-            self.domain,
-            {
-                'type': 'TXT',
-                'name': f'_dmarc.{self.domain}.',
-                'content': 'v=DMARC1; p=none;',
-                'priority': '-',
-            },
-        )
+                status, existing_values = check_txt_record_status(self.domain, self._dmarc_record())
+
+                self.assertEqual(status, DNSRecordStatus.CONFLICT)
+                self.assertEqual(existing_values, [value])
+
+    @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
+    def test_dmarc_conflict_when_tag_value_record_is_malformed(self, mock_resolve):
+        mock_resolve.return_value = [self._txt_record('v=DMARC1; p=none; rua')]
+
+        status, existing_values = check_txt_record_status(self.domain, self._dmarc_record())
+
+        self.assertEqual(status, DNSRecordStatus.CONFLICT)
+        self.assertEqual(existing_values, ['v=DMARC1; p=none; rua'])
+
+    @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
+    def test_dmarc_missing_without_dmarc_record(self, mock_resolve):
+        mock_resolve.return_value = [self._txt_record('google-site-verification=example')]
+
+        status, existing_values = check_txt_record_status(self.domain, self._dmarc_record())
 
         self.assertEqual(status, DNSRecordStatus.MISSING)
         self.assertEqual(existing_values, [])
@@ -304,6 +336,23 @@ class TestDNSRecordStatus(SimpleTestCase):
 
         self.assertEqual(status, DNSRecordStatus.MATCH)
         self.assertEqual(existing_values, [])
+
+    @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
+    def test_dkim_conflict_when_matching_record_has_duplicate_tag(self, mock_resolve):
+        mock_resolve.return_value = [self._txt_record('v=DKIM1; k=rsa; p=expectedkey; p=otherkey')]
+
+        status, existing_values = check_txt_record_status(
+            self.domain,
+            {
+                'type': 'TXT',
+                'name': f'selector._domainkey.{self.domain}.',
+                'content': 'v=DKIM1; k=rsa; p=expectedkey',
+                'priority': '-',
+            },
+        )
+
+        self.assertEqual(status, DNSRecordStatus.CONFLICT)
+        self.assertEqual(existing_values, ['v=DKIM1; k=rsa; p=expectedkey; p=otherkey'])
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
     def test_enrich_dns_records_with_status(self, mock_resolve):

--- a/src/thunderbird_accounts/mail/tests/test_dns.py
+++ b/src/thunderbird_accounts/mail/tests/test_dns.py
@@ -30,9 +30,9 @@ class TestNormalizeDNSQueryName(SimpleTestCase):
 class TestCompareSemanticTXT(SimpleTestCase):
     def test_missing_when_live_values_do_not_include_prefix(self):
         status, existing_values = _compare_semantic_txt(
-            'v=DMARC1; p=none;',
-            ['v=spf1 include:spf.test.com -all'],
-            prefix='v=DMARC1',
+            'v=STSv1; id=18139500144460329770',
+            ['BOOM'],
+            prefix='v=STSv1',
         )
 
         self.assertEqual(status, DNSRecordStatus.MISSING)
@@ -40,9 +40,9 @@ class TestCompareSemanticTXT(SimpleTestCase):
 
     def test_match_normalizes_whitespace(self):
         status, existing_values = _compare_semantic_txt(
-            'v=DMARC1; p=none;',
-            ['v=DMARC1;    p=none;'],
-            prefix='v=DMARC1',
+            'v=STSv1; id=18139500144460329770',
+            ['v=STSv1;    id=18139500144460329770'],
+            prefix='v=STSv1',
         )
 
         self.assertEqual(status, DNSRecordStatus.MATCH)
@@ -50,13 +50,13 @@ class TestCompareSemanticTXT(SimpleTestCase):
 
     def test_conflict_returns_only_relevant_values(self):
         status, existing_values = _compare_semantic_txt(
-            'v=DMARC1; p=none;',
-            ['v=spf1 include:spf.test.com -all', 'v=DMARC1; p=reject;'],
-            prefix='v=DMARC1',
+            'v=STSv1; id=18139500144460329770',
+            ['BOOM', 'v=STSv1; id=wrong'],
+            prefix='v=STSv1',
         )
 
         self.assertEqual(status, DNSRecordStatus.CONFLICT)
-        self.assertEqual(existing_values, ['v=DMARC1; p=reject;'])
+        self.assertEqual(existing_values, ['v=STSv1; id=wrong'])
 
 
 class TestDNSRecordStatus(SimpleTestCase):
@@ -244,6 +244,44 @@ class TestDNSRecordStatus(SimpleTestCase):
         )
 
         self.assertEqual(status, DNSRecordStatus.MATCH)
+        self.assertEqual(existing_values, [])
+
+    @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
+    def test_dmarc_match_allows_any_record_starting_with_version(self, mock_resolve):
+        mock_txt = MagicMock()
+        mock_txt.strings = [b'v=DMARC1; p=reject; rua=mailto:dmarc@example.com']
+        mock_resolve.return_value = [mock_txt]
+
+        status, existing_values = check_txt_record_status(
+            self.domain,
+            {
+                'type': 'TXT',
+                'name': f'_dmarc.{self.domain}.',
+                'content': 'v=DMARC1; p=none;',
+                'priority': '-',
+            },
+        )
+
+        self.assertEqual(status, DNSRecordStatus.MATCH)
+        self.assertEqual(existing_values, [])
+
+    @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')
+    def test_dmarc_missing_without_version_prefix(self, mock_resolve):
+        mock_txt = MagicMock()
+        mock_txt.strings = [b'google-site-verification=example']
+        mock_resolve.return_value = [mock_txt]
+
+        status, existing_values = check_txt_record_status(
+            self.domain,
+            {
+                'type': 'TXT',
+                'name': f'_dmarc.{self.domain}.',
+                'content': 'v=DMARC1; p=none;',
+                'priority': '-',
+            },
+        )
+
+        self.assertEqual(status, DNSRecordStatus.MISSING)
         self.assertEqual(existing_values, [])
 
     @patch('thunderbird_accounts.mail.dns.dns_resolver.resolve')


### PR DESCRIPTION
Supercedes #949 with a clean rebase.

No additional changes, only cherry-picking.

(I also tried rebasing #949 and somehow that didn't clean up the commit
history either).
