### PR TITLE
Perform in-depth validation on autodiscover subdomains (#943)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "servestatic>=4.3.0",
     "sentry-sdk[django]>=2.60.0",
     "requests>=2.34.2",
+    "requests-toolbelt>=0.7.0",
     "celery[redis]>=5.6.3",
     "django-cors-headers>=4.9.0",
     "mozilla-django-oidc>=5.0.2",

--- a/src/thunderbird_accounts/mail/autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/autodiscover_probe.py
@@ -135,7 +135,18 @@ def _looks_like_exchange(response: requests.Response, body: bytes) -> bool:
 
 
 def exchange_autodiscover_endpoint_exists(hostname: str, domain_name: str) -> bool:
-    """Probe a host for a functional Exchange Autodiscover endpoint."""
+    """
+    Probe a host to see if it looks like an Exchange Autodiscover endpoint.
+
+    Resolve the DNS name to confirm it's public IP, not private.
+    To avoid a race condition with resolving the domain a second time,
+    we re-use the IP in the connection string and send the DNS name in the host header.
+
+    After allowing AUTODISCOVER_PROBE_MAX_REDIRECTS, we check the headers for an
+    Exchange-like header.
+
+    Finally, we'll check to see if the response body looks like Exchange.
+    """
     body = _autodiscover_probe_body(domain_name).encode()
     session = requests.Session()
     session.trust_env = False

--- a/src/thunderbird_accounts/mail/autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/autodiscover_probe.py
@@ -23,6 +23,7 @@ AUTODISCOVER_PROBE_HEADERS = {
     'Content-Type': 'text/xml; charset=utf-8',
 }
 AUTODISCOVER_EXCHANGE_HEADER_NAMES = {
+    'x-aspnet-version',
     'x-beserver',
     'x-calculatedbetarget',
     'x-diaginfo',

--- a/src/thunderbird_accounts/mail/autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/autodiscover_probe.py
@@ -3,12 +3,16 @@ Code for probing if a custom domain's autodiscover subdomain belongs to an Excha
 
 If so, that's a conflict to flag to the user.
 """
+
+from dataclasses import dataclass
 import ipaddress
 import logging
 import socket
 from urllib.parse import urljoin, urlparse
 
 import requests
+from requests_toolbelt.adapters import host_header_ssl
+
 AUTODISCOVER_PROBE_PATH = '/autodiscover/autodiscover.xml'
 AUTODISCOVER_PROBE_MAX_REDIRECTS = 3
 AUTODISCOVER_PROBE_MAX_BYTES = 65536
@@ -29,46 +33,74 @@ AUTODISCOVER_EXCHANGE_HEADER_NAMES = {
 AUTODISCOVER_EXCHANGE_TERMS = ('autodiscover', 'exchange', 'office365', 'outlook')
 
 
+@dataclass(frozen=True)
+class _AutodiscoverRequestTarget:
+    request_url: str
+    hostname: str
+
+
 def _autodiscover_probe_body(domain_name: str) -> str:
     """Build the minimal Exchange Autodiscover XML request body."""
     email_address = f'autodiscover-probe@{domain_name}'
-    return f'''<?xml version="1.0" encoding="utf-8"?>
+    return f"""<?xml version="1.0" encoding="utf-8"?>
 <Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/requestschema/2006">
   <Request>
     <EMailAddress>{email_address}</EMailAddress>
     <AcceptableResponseSchema>http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a</AcceptableResponseSchema>
   </Request>
-</Autodiscover>'''
+</Autodiscover>"""
 
 
-def _is_safe_autodiscover_url(url: str) -> bool:
+def _format_ip_for_url(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    if address.version == 6:
+        return f'[{address}]'
+    return str(address)
+
+
+def _safe_autodiscover_request_targets(url: str) -> list[_AutodiscoverRequestTarget]:
     """
     Because we are making HTTP + DNS requests to user-controlled domain,
-    Make various security checks for the actual HTTP request.
+    resolve and validate hostnames before connecting to the vetted IP address.
+    We connect via HTTP to an IP and send the the Host header to avoid a race condition
+    between the initial DNS resolution to check the validate the IP address and
+    the second DNS resolution to send the HTTP probe, as the DNS resolution could
+    potentially change during that window.
     """
     try:
         parsed = urlparse(url)
         if parsed.scheme not in {'http', 'https'} or parsed.port not in {None, 80, 443}:
-            return False
+            return []
         if not parsed.hostname or parsed.username or parsed.password:
-            return False
+            return []
         try:
             ipaddress.ip_address(parsed.hostname)
-            return False
+            return []
         except ValueError:
             pass
 
         port = parsed.port or (443 if parsed.scheme == 'https' else 80)
-        # SSRF check: resolve customer-controlled hostnames before requesting them so they cannot
-        # send backend HTTP traffic to private, loopback, link-local, or metadata addresses.
+        addresses = []
         for address_info in socket.getaddrinfo(parsed.hostname, port, type=socket.SOCK_STREAM):
             address = ipaddress.ip_address(address_info[4][0])
             if not address.is_global:
-                return False
+                return []
+            addresses.append(address)
     except (OSError, ValueError):
-        return False
+        return []
 
-    return True
+    path = parsed.path or '/'
+    if parsed.query:
+        path = f'{path}?{parsed.query}'
+
+    targets = []
+    seen_addresses = set()
+    for address in addresses:
+        if address in seen_addresses:
+            continue
+        seen_addresses.add(address)
+        request_url = f'{parsed.scheme}://{_format_ip_for_url(address)}:{port}{path}'
+        targets.append(_AutodiscoverRequestTarget(request_url=request_url, hostname=parsed.hostname))
+    return targets
 
 
 def _body_mentions_autodiscover(body: bytes) -> bool:
@@ -103,24 +135,34 @@ def _looks_like_exchange(response: requests.Response, body: bytes) -> bool:
 def exchange_autodiscover_endpoint_exists(hostname: str, domain_name: str) -> bool:
     """Probe a host for a functional Exchange Autodiscover endpoint."""
     body = _autodiscover_probe_body(domain_name).encode()
+    session = requests.Session()
+    session.trust_env = False
+    session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
 
     for scheme in ('https', 'http'):
         url = f'{scheme}://{hostname}{AUTODISCOVER_PROBE_PATH}'
         for _ in range(AUTODISCOVER_PROBE_MAX_REDIRECTS + 1):
-            if not _is_safe_autodiscover_url(url):
+            targets = _safe_autodiscover_request_targets(url)
+            if not targets:
                 break
 
-            try:
-                response = requests.post(
-                    url,
-                    data=body,
-                    headers=AUTODISCOVER_PROBE_HEADERS,
-                    timeout=AUTODISCOVER_PROBE_TIMEOUT,
-                    allow_redirects=False,
-                    stream=True,
-                )
-            except requests.RequestException as e:
-                logging.debug(f'Autodiscover probe failed for {url}: {e}')
+            response = None
+            for target in targets:
+                headers = {**AUTODISCOVER_PROBE_HEADERS, 'Host': target.hostname}
+                try:
+                    response = session.post(
+                        target.request_url,
+                        data=body,
+                        headers=headers,
+                        timeout=AUTODISCOVER_PROBE_TIMEOUT,
+                        allow_redirects=False,
+                        stream=True,
+                    )
+                    break
+                except requests.RequestException as e:
+                    logging.debug(f'Autodiscover probe failed for {target.request_url}: {e}')
+
+            if response is None:
                 break
 
             try:

--- a/src/thunderbird_accounts/mail/autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/autodiscover_probe.py
@@ -15,7 +15,8 @@ from requests_toolbelt.adapters import host_header_ssl
 
 AUTODISCOVER_PROBE_PATH = '/autodiscover/autodiscover.xml'
 AUTODISCOVER_PROBE_MAX_REDIRECTS = 3
-AUTODISCOVER_PROBE_MAX_BYTES = 65536
+# To avoid downloading huge bodies, only search the first 64 bytes.
+AUTODISCOVER_PROBE_MAX_BYTES = 64 * 1024
 # Short time-outs should be sufficient for legit servers and is better UX.
 AUTODISCOVER_PROBE_TIMEOUT = (0.75, 1.0)
 AUTODISCOVER_PROBE_HEADERS = {
@@ -157,7 +158,7 @@ def exchange_autodiscover_endpoint_exists(hostname: str, domain_name: str) -> bo
                         headers=headers,
                         timeout=AUTODISCOVER_PROBE_TIMEOUT,
                         allow_redirects=False,
-                        stream=True,
+                        stream=True, # enable us to only download the first few bytes
                     )
                     break
                 except requests.RequestException as e:

--- a/src/thunderbird_accounts/mail/autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/autodiscover_probe.py
@@ -1,0 +1,141 @@
+"""
+Code for probing if a custom domain's autodiscover subdomain belongs to an Exchange server.
+
+If so, that's a conflict to flag to the user.
+"""
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlparse
+
+import requests
+AUTODISCOVER_PROBE_PATH = '/autodiscover/autodiscover.xml'
+AUTODISCOVER_PROBE_MAX_REDIRECTS = 3
+AUTODISCOVER_PROBE_MAX_BYTES = 65536
+# Short time-outs should be sufficient for legit servers and is better UX.
+AUTODISCOVER_PROBE_TIMEOUT = (0.75, 1.0)
+AUTODISCOVER_PROBE_HEADERS = {
+    # outlook.com needs this exact string, with space and lower case "utf".
+    'Content-Type': 'text/xml; charset=utf-8',
+}
+AUTODISCOVER_EXCHANGE_HEADER_NAMES = {
+    'x-beserver',
+    'x-calculatedbetarget',
+    'x-diaginfo',
+    'x-feserver',
+    'x-msdiagnostics',
+    'x-owa-version',
+}
+AUTODISCOVER_EXCHANGE_TERMS = ('autodiscover', 'exchange', 'office365', 'outlook')
+
+
+def _autodiscover_probe_body(domain_name: str) -> str:
+    """Build the minimal Exchange Autodiscover XML request body."""
+    email_address = f'autodiscover-probe@{domain_name}'
+    return f'''<?xml version="1.0" encoding="utf-8"?>
+<Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/requestschema/2006">
+  <Request>
+    <EMailAddress>{email_address}</EMailAddress>
+    <AcceptableResponseSchema>http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a</AcceptableResponseSchema>
+  </Request>
+</Autodiscover>'''
+
+
+def _is_safe_autodiscover_url(url: str) -> bool:
+    """
+    Because we are making HTTP + DNS requests to user-controlled domain,
+    Make various security checks for the actual HTTP request.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in {'http', 'https'} or parsed.port not in {None, 80, 443}:
+            return False
+        if not parsed.hostname or parsed.username or parsed.password:
+            return False
+        try:
+            ipaddress.ip_address(parsed.hostname)
+            return False
+        except ValueError:
+            pass
+
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+        # SSRF check: resolve customer-controlled hostnames before requesting them so they cannot
+        # send backend HTTP traffic to private, loopback, link-local, or metadata addresses.
+        for address_info in socket.getaddrinfo(parsed.hostname, port, type=socket.SOCK_STREAM):
+            address = ipaddress.ip_address(address_info[4][0])
+            if not address.is_global:
+                return False
+    except (OSError, ValueError):
+        return False
+
+    return True
+
+
+def _body_mentions_autodiscover(body: bytes) -> bool:
+    return b'autodiscover' in body.lower()
+
+
+def _has_exchange_autodiscover_evidence(response: requests.Response, body: bytes) -> bool:
+    if _body_mentions_autodiscover(body):
+        return True
+
+    for name, value in response.headers.items():
+        name = name.lower()
+        value = value.lower()
+        if name in AUTODISCOVER_EXCHANGE_HEADER_NAMES:
+            return True
+        if any(term in value for term in AUTODISCOVER_EXCHANGE_TERMS):
+            return True
+    return False
+
+
+def _looks_like_exchange(response: requests.Response, body: bytes) -> bool:
+    """Besides 200, Exchange might response to probe with some 4XX responses (but not 404!)"""
+    if response.status_code == 401:
+        return True
+    if 200 <= response.status_code < 300:
+        return _body_mentions_autodiscover(body)
+    if response.status_code in {400, 403, 405}:
+        return _has_exchange_autodiscover_evidence(response, body)
+    return False
+
+
+def exchange_autodiscover_endpoint_exists(hostname: str, domain_name: str) -> bool:
+    """Probe a host for a functional Exchange Autodiscover endpoint."""
+    body = _autodiscover_probe_body(domain_name).encode()
+
+    for scheme in ('https', 'http'):
+        url = f'{scheme}://{hostname}{AUTODISCOVER_PROBE_PATH}'
+        for _ in range(AUTODISCOVER_PROBE_MAX_REDIRECTS + 1):
+            if not _is_safe_autodiscover_url(url):
+                break
+
+            try:
+                response = requests.post(
+                    url,
+                    data=body,
+                    headers=AUTODISCOVER_PROBE_HEADERS,
+                    timeout=AUTODISCOVER_PROBE_TIMEOUT,
+                    allow_redirects=False,
+                    stream=True,
+                )
+            except requests.RequestException as e:
+                logging.debug(f'Autodiscover probe failed for {url}: {e}')
+                break
+
+            try:
+                if response.is_redirect:
+                    redirect_url = response.headers.get('Location')
+                    if not redirect_url:
+                        break
+                    url = urljoin(url, redirect_url)
+                    continue
+
+                response_body = response.raw.read(AUTODISCOVER_PROBE_MAX_BYTES, decode_content=True)
+                if _looks_like_exchange(response, response_body):
+                    return True
+                break
+            finally:
+                response.close()
+
+    return False

--- a/src/thunderbird_accounts/mail/dns.py
+++ b/src/thunderbird_accounts/mail/dns.py
@@ -6,6 +6,7 @@ import dns.rdatatype as dns_rdatatype
 import dns.resolver as dns_resolver
 from django.conf import settings
 
+from thunderbird_accounts.mail.autodiscover_probe import exchange_autodiscover_endpoint_exists
 from thunderbird_accounts.mail.clients import DNSRecordStatus, StaleDNSRecordCode
 
 TXT_TAG_SPEC_RE = re.compile(
@@ -370,12 +371,11 @@ def check_stale_dns_records(cust_domain: str) -> list[dict]:
     resolver = dns_resolver.Resolver()
     resolver.lifetime = settings.STALE_DNS_LOOKUP_LIFETIME
 
-    # We currently don't show autodiscover records during custom domain setup
-    # so if they have it we should mark as stale / ask for removing it
-    # as it can trigger Office 365 / Exchange in Thunderbird Desktop
+    # We currently don't show autodiscover records during custom domain setup, so if they point at
+    # a real Exchange Autodiscover endpoint we should mark them stale and ask for removal.
     autodiscover_name = f'autodiscover.{cust_domain}'
     cname_targets = _resolve_autodiscover_cname_targets(resolver, autodiscover_name)
-    if cname_targets:
+    if cname_targets and exchange_autodiscover_endpoint_exists(autodiscover_name, cust_domain):
         stale_records.append(
             {
                 'code': StaleDNSRecordCode.AUTODISCOVER_CNAME_UNEXPECTED.value,
@@ -385,29 +385,37 @@ def check_stale_dns_records(cust_domain: str) -> list[dict]:
             }
         )
     else:
-        for record_type, address_records in _resolve_autodiscover_address_records(resolver, autodiscover_name).items():
-            stale_records.append(
-                {
-                    'code': StaleDNSRecordCode.AUTODISCOVER_CNAME_UNEXPECTED.value,
-                    'type': record_type,
-                    'name': autodiscover_name,
-                    'existing_values': address_records,
-                }
-            )
+        address_record_sets = _resolve_autodiscover_address_records(resolver, autodiscover_name)
+        if address_record_sets and exchange_autodiscover_endpoint_exists(autodiscover_name, cust_domain):
+            for record_type, address_records in address_record_sets.items():
+                stale_records.append(
+                    {
+                        'code': StaleDNSRecordCode.AUTODISCOVER_CNAME_UNEXPECTED.value,
+                        'type': record_type,
+                        'name': autodiscover_name,
+                        'existing_values': address_records,
+                    }
+                )
 
     autodiscover_srv_name = f'_autodiscover._tcp.{cust_domain}'
     try:
         answers = _stale_dns_resolve(resolver, autodiscover_srv_name, 'SRV')
-        live_values = [
-            f'{rdata.priority} {rdata.weight} {rdata.port} {rdata.target.to_text().rstrip(".")}' for rdata in answers
+        srv_records = [
+            {
+                'value': f'{rdata.priority} {rdata.weight} {rdata.port} {rdata.target.to_text().rstrip(".")}',
+                'target': rdata.target.to_text().rstrip('.'),
+            }
+            for rdata in answers
         ]
-        if live_values:
+        if srv_records and any(
+            exchange_autodiscover_endpoint_exists(record['target'], cust_domain) for record in srv_records
+        ):
             stale_records.append(
                 {
                     'code': StaleDNSRecordCode.AUTODISCOVER_SRV_UNEXPECTED.value,
                     'type': 'SRV',
                     'name': autodiscover_srv_name,
-                    'existing_values': live_values,
+                    'existing_values': [record['value'] for record in srv_records],
                 }
             )
     except (dns_resolver.NoAnswer, dns_resolver.NXDOMAIN, dns_resolver.NoNameservers):

--- a/src/thunderbird_accounts/mail/tests/test_autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/tests/test_autodiscover_probe.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from thunderbird_accounts.mail.autodiscover_probe import (
+    AUTODISCOVER_PROBE_PATH,
+    AUTODISCOVER_PROBE_TIMEOUT,
+    _is_safe_autodiscover_url,
+    exchange_autodiscover_endpoint_exists,
+)
+
+
+def _response(status_code: int, *, body: bytes = b'', headers: dict | None = None, is_redirect: bool = False):
+    """Build a minimal requests-like response for probe tests."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.is_redirect = is_redirect
+    response.raw.read.return_value = body
+    return response
+
+
+class TestExchangeAutodiscoverEndpointExists(SimpleTestCase):
+    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
+    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
+    def test_posts_autodiscover_xml_and_accepts_unauthorized(self, mock_post, mock_is_safe):
+        mock_post.return_value = _response(401)
+
+        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+
+        self.assertTrue(exists)
+        mock_is_safe.assert_called_once_with(f'https://autodiscover.example.com{AUTODISCOVER_PROBE_PATH}')
+        mock_post.assert_called_once()
+        post_kwargs = mock_post.call_args.kwargs
+        self.assertEqual(post_kwargs['headers']['Content-Type'], 'text/xml; charset=utf-8')
+        self.assertEqual(post_kwargs['timeout'], AUTODISCOVER_PROBE_TIMEOUT)
+        self.assertFalse(post_kwargs['allow_redirects'])
+        self.assertIn(b'<EMailAddress>autodiscover-probe@example.com</EMailAddress>', post_kwargs['data'])
+        self.assertIn(b'<AcceptableResponseSchema>', post_kwargs['data'])
+        self.assertEqual(mock_post.call_args.args[0], f'https://autodiscover.example.com{AUTODISCOVER_PROBE_PATH}')
+
+    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
+    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
+    def test_does_not_accept_generic_success_response(self, mock_post, mock_is_safe):
+        mock_post.return_value = _response(200, body=b'<html>Wildcard site</html>')
+
+        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+
+        self.assertFalse(exists)
+        self.assertEqual(mock_is_safe.call_count, 2)
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
+    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
+    def test_accepts_success_response_that_mentions_autodiscover(self, mock_post, mock_is_safe):
+        mock_post.return_value = _response(200, body=b'<Autodiscover><Response /></Autodiscover>')
+
+        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+
+        self.assertTrue(exists)
+        mock_is_safe.assert_called_once()
+        mock_post.assert_called_once()
+
+    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
+    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
+    def test_follows_redirects_with_post_body(self, mock_post, mock_is_safe):
+        mock_post.side_effect = [
+            _response(
+                302,
+                headers={'Location': 'https://outlook.example.net/autodiscover/autodiscover.xml'},
+                is_redirect=True,
+            ),
+            _response(401),
+        ]
+
+        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+
+        self.assertTrue(exists)
+        self.assertEqual(mock_is_safe.call_count, 2)
+        self.assertEqual(
+            [call_args.args[0] for call_args in mock_post.call_args_list],
+            [
+                f'https://autodiscover.example.com{AUTODISCOVER_PROBE_PATH}',
+                f'https://outlook.example.net{AUTODISCOVER_PROBE_PATH}',
+            ],
+        )
+        self.assertEqual(mock_post.call_args_list[0].kwargs['data'], mock_post.call_args_list[1].kwargs['data'])
+
+    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=False)
+    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
+    def test_does_not_request_unsafe_urls(self, mock_post, mock_is_safe):
+        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+
+        self.assertFalse(exists)
+        self.assertEqual(mock_is_safe.call_count, 2)
+        mock_post.assert_not_called()
+
+    @patch('thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo')
+    def test_raw_ip_url_is_unsafe(self, mock_getaddrinfo):
+        self.assertFalse(_is_safe_autodiscover_url('https://203.0.113.10/autodiscover/autodiscover.xml'))
+        mock_getaddrinfo.assert_not_called()

--- a/src/thunderbird_accounts/mail/tests/test_autodiscover_probe.py
+++ b/src/thunderbird_accounts/mail/tests/test_autodiscover_probe.py
@@ -1,3 +1,4 @@
+import socket
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
@@ -5,7 +6,7 @@ from django.test import SimpleTestCase
 from thunderbird_accounts.mail.autodiscover_probe import (
     AUTODISCOVER_PROBE_PATH,
     AUTODISCOVER_PROBE_TIMEOUT,
-    _is_safe_autodiscover_url,
+    _safe_autodiscover_request_targets,
     exchange_autodiscover_endpoint_exists,
 )
 
@@ -21,81 +22,130 @@ def _response(status_code: int, *, body: bytes = b'', headers: dict | None = Non
 
 
 class TestExchangeAutodiscoverEndpointExists(SimpleTestCase):
-    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
-    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
-    def test_posts_autodiscover_xml_and_accepts_unauthorized(self, mock_post, mock_is_safe):
-        mock_post.return_value = _response(401)
+    def _mock_getaddrinfo(self, ip_address='93.184.216.34'):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip_address, 443))]
 
-        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+    def test_posts_autodiscover_xml_to_vetted_ip_and_accepts_unauthorized(self):
+        with (
+            patch('thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo') as mock_getaddrinfo,
+            patch('thunderbird_accounts.mail.autodiscover_probe.requests.Session') as mock_session_cls,
+        ):
+            mock_getaddrinfo.return_value = self._mock_getaddrinfo()
+            mock_session = mock_session_cls.return_value
+            mock_session.post.return_value = _response(401)
+
+            exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
 
         self.assertTrue(exists)
-        mock_is_safe.assert_called_once_with(f'https://autodiscover.example.com{AUTODISCOVER_PROBE_PATH}')
-        mock_post.assert_called_once()
-        post_kwargs = mock_post.call_args.kwargs
+        self.assertFalse(mock_session.trust_env)
+        self.assertEqual(mock_session.mount.call_args.args[0], 'https://')
+        mock_getaddrinfo.assert_called_once_with('autodiscover.example.com', 443, type=socket.SOCK_STREAM)
+        mock_session.post.assert_called_once()
+        post_kwargs = mock_session.post.call_args.kwargs
         self.assertEqual(post_kwargs['headers']['Content-Type'], 'text/xml; charset=utf-8')
+        self.assertEqual(post_kwargs['headers']['Host'], 'autodiscover.example.com')
         self.assertEqual(post_kwargs['timeout'], AUTODISCOVER_PROBE_TIMEOUT)
         self.assertFalse(post_kwargs['allow_redirects'])
         self.assertIn(b'<EMailAddress>autodiscover-probe@example.com</EMailAddress>', post_kwargs['data'])
         self.assertIn(b'<AcceptableResponseSchema>', post_kwargs['data'])
-        self.assertEqual(mock_post.call_args.args[0], f'https://autodiscover.example.com{AUTODISCOVER_PROBE_PATH}')
+        self.assertEqual(mock_session.post.call_args.args[0], f'https://93.184.216.34:443{AUTODISCOVER_PROBE_PATH}')
 
-    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
-    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
-    def test_does_not_accept_generic_success_response(self, mock_post, mock_is_safe):
-        mock_post.return_value = _response(200, body=b'<html>Wildcard site</html>')
+    def test_does_not_accept_generic_success_response(self):
+        def getaddrinfo(host, port, type):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', port))]
 
-        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+        with (
+            patch('thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo', side_effect=getaddrinfo),
+            patch('thunderbird_accounts.mail.autodiscover_probe.requests.Session') as mock_session_cls,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.post.return_value = _response(200, body=b'<html>Wildcard site</html>')
+
+            exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
 
         self.assertFalse(exists)
-        self.assertEqual(mock_is_safe.call_count, 2)
-        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(mock_session.post.call_count, 2)
 
-    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
-    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
-    def test_accepts_success_response_that_mentions_autodiscover(self, mock_post, mock_is_safe):
-        mock_post.return_value = _response(200, body=b'<Autodiscover><Response /></Autodiscover>')
-
-        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
-
-        self.assertTrue(exists)
-        mock_is_safe.assert_called_once()
-        mock_post.assert_called_once()
-
-    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=True)
-    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
-    def test_follows_redirects_with_post_body(self, mock_post, mock_is_safe):
-        mock_post.side_effect = [
-            _response(
-                302,
-                headers={'Location': 'https://outlook.example.net/autodiscover/autodiscover.xml'},
-                is_redirect=True,
+    def test_accepts_success_response_that_mentions_autodiscover(self):
+        with (
+            patch(
+                'thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo',
+                return_value=self._mock_getaddrinfo(),
             ),
-            _response(401),
-        ]
+            patch('thunderbird_accounts.mail.autodiscover_probe.requests.Session') as mock_session_cls,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.post.return_value = _response(200, body=b'<Autodiscover><Response /></Autodiscover>')
 
-        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+            exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
 
         self.assertTrue(exists)
-        self.assertEqual(mock_is_safe.call_count, 2)
+        mock_session.post.assert_called_once()
+
+    def test_follows_redirects_with_post_body(self):
+        def getaddrinfo(host, port, type):
+            ip_address = '93.184.216.35' if host == 'outlook.example.net' else '93.184.216.34'
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip_address, port))]
+
+        with (
+            patch('thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo', side_effect=getaddrinfo),
+            patch('thunderbird_accounts.mail.autodiscover_probe.requests.Session') as mock_session_cls,
+        ):
+            mock_session = mock_session_cls.return_value
+            mock_session.post.side_effect = [
+                _response(
+                    302,
+                    headers={'Location': 'https://outlook.example.net/autodiscover/autodiscover.xml'},
+                    is_redirect=True,
+                ),
+                _response(401),
+            ]
+
+            exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+
+        self.assertTrue(exists)
         self.assertEqual(
-            [call_args.args[0] for call_args in mock_post.call_args_list],
+            [call_args.args[0] for call_args in mock_session.post.call_args_list],
             [
-                f'https://autodiscover.example.com{AUTODISCOVER_PROBE_PATH}',
-                f'https://outlook.example.net{AUTODISCOVER_PROBE_PATH}',
+                f'https://93.184.216.34:443{AUTODISCOVER_PROBE_PATH}',
+                f'https://93.184.216.35:443{AUTODISCOVER_PROBE_PATH}',
             ],
         )
-        self.assertEqual(mock_post.call_args_list[0].kwargs['data'], mock_post.call_args_list[1].kwargs['data'])
+        self.assertEqual(
+            [call_args.kwargs['headers']['Host'] for call_args in mock_session.post.call_args_list],
+            ['autodiscover.example.com', 'outlook.example.net'],
+        )
+        self.assertEqual(
+            mock_session.post.call_args_list[0].kwargs['data'], mock_session.post.call_args_list[1].kwargs['data']
+        )
 
-    @patch('thunderbird_accounts.mail.autodiscover_probe._is_safe_autodiscover_url', return_value=False)
-    @patch('thunderbird_accounts.mail.autodiscover_probe.requests.post')
-    def test_does_not_request_unsafe_urls(self, mock_post, mock_is_safe):
-        exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
+    def test_does_not_request_unsafe_urls(self):
+        with (
+            patch(
+                'thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo',
+                return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 443))],
+            ),
+            patch('thunderbird_accounts.mail.autodiscover_probe.requests.Session') as mock_session_cls,
+        ):
+            mock_session = mock_session_cls.return_value
+
+            exists = exchange_autodiscover_endpoint_exists('autodiscover.example.com', 'example.com')
 
         self.assertFalse(exists)
-        self.assertEqual(mock_is_safe.call_count, 2)
-        mock_post.assert_not_called()
+        mock_session.post.assert_not_called()
 
     @patch('thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo')
     def test_raw_ip_url_is_unsafe(self, mock_getaddrinfo):
-        self.assertFalse(_is_safe_autodiscover_url('https://203.0.113.10/autodiscover/autodiscover.xml'))
+        self.assertEqual(_safe_autodiscover_request_targets('https://93.184.216.34/autodiscover/autodiscover.xml'), [])
         mock_getaddrinfo.assert_not_called()
+
+    @patch('thunderbird_accounts.mail.autodiscover_probe.socket.getaddrinfo')
+    def test_rejects_mixed_public_and_private_dns_answers(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 443)),
+        ]
+
+        targets = _safe_autodiscover_request_targets('https://autodiscover.example.com/autodiscover/autodiscover.xml')
+
+        self.assertEqual(targets, [])

--- a/src/thunderbird_accounts/mail/tests/test_dns.py
+++ b/src/thunderbird_accounts/mail/tests/test_dns.py
@@ -397,6 +397,10 @@ class TestStaleDNSRecords(SimpleTestCase):
             return_value=mock_resolver,
         )
 
+    def _patch_autodiscover_probe(self, return_value):
+        """Patch the Exchange Autodiscover HTTP probe result."""
+        return patch('thunderbird_accounts.mail.dns.exchange_autodiscover_endpoint_exists', return_value=return_value)
+
     def test_autodiscover_cname_stale(self):
         mock_cname = MagicMock()
         mock_cname.target.to_text.return_value = 'autodiscover.outlook.com.'
@@ -406,7 +410,7 @@ class TestStaleDNSRecords(SimpleTestCase):
                 return [mock_cname]
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(True):
             stale_records = check_stale_dns_records(self.domain)
 
         self.assertEqual(len(stale_records), 1)
@@ -414,22 +418,6 @@ class TestStaleDNSRecords(SimpleTestCase):
         self.assertEqual(stale_records[0]['type'], 'CNAME')
         self.assertEqual(stale_records[0]['name'], f'autodiscover.{self.domain}')
         self.assertEqual(stale_records[0]['existing_values'], ['autodiscover.outlook.com'])
-
-    def test_autodiscover_cname_stale_even_if_pointing_to_our_host(self):
-        """Any autodiscover CNAME is stale - we don't use autodiscover at all."""
-        mock_cname = MagicMock()
-        mock_cname.target.to_text.return_value = 'mail.thundermail.com.'
-
-        def resolve_side_effect(name, record_type):
-            if record_type == 'CNAME':
-                return [mock_cname]
-            raise dns_resolver.NoAnswer()
-
-        with self._patch_resolver(resolve_side_effect):
-            stale_records = check_stale_dns_records(self.domain)
-
-        self.assertEqual(len(stale_records), 1)
-        self.assertEqual(stale_records[0]['code'], StaleDNSRecordCode.AUTODISCOVER_CNAME_UNEXPECTED.value)
 
     def test_autodiscover_cname_via_a_lookup_chain(self):
         mock_cname = MagicMock()
@@ -449,7 +437,7 @@ class TestStaleDNSRecords(SimpleTestCase):
                 return mock_a_answer
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(True):
             stale_records = check_stale_dns_records(self.domain)
 
         self.assertEqual(len(stale_records), 1)
@@ -473,7 +461,7 @@ class TestStaleDNSRecords(SimpleTestCase):
                 return mock_aaaa_answer
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(True):
             stale_records = check_stale_dns_records(self.domain)
 
         self.assertEqual(len(stale_records), 1)
@@ -496,12 +484,32 @@ class TestStaleDNSRecords(SimpleTestCase):
                 raise dns_resolver.NoAnswer()
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(True):
             stale_records = check_stale_dns_records(self.domain)
 
         self.assertEqual(len(stale_records), 1)
         self.assertEqual(stale_records[0]['type'], 'A')
         self.assertEqual(stale_records[0]['existing_values'], ['203.0.113.10'])
+
+    def test_autodiscover_direct_a_record_not_stale_when_probe_is_negative(self):
+        mock_a = MagicMock()
+        mock_a.to_text.return_value = '203.0.113.10'
+
+        def resolve_side_effect(name, record_type):
+            if record_type == 'CNAME':
+                raise dns_resolver.NoAnswer()
+            if record_type == 'A':
+                mock_a_answer = MagicMock()
+                mock_a_answer.response.answer = []
+                mock_a_answer.__iter__ = MagicMock(return_value=iter([mock_a]))
+                return mock_a_answer
+            raise dns_resolver.NoAnswer()
+
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(False) as mock_probe:
+            stale_records = check_stale_dns_records(self.domain)
+
+        self.assertEqual(stale_records, [])
+        mock_probe.assert_called_once_with(f'autodiscover.{self.domain}', self.domain)
 
     def test_autodiscover_direct_a_and_aaaa_records_stale(self):
         mock_a = MagicMock()
@@ -524,7 +532,7 @@ class TestStaleDNSRecords(SimpleTestCase):
                 return make_answer(mock_aaaa)
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(True):
             stale_records = check_stale_dns_records(self.domain)
 
         self.assertEqual(len(stale_records), 2)
@@ -547,7 +555,7 @@ class TestStaleDNSRecords(SimpleTestCase):
                 return [mock_srv]
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(True):
             stale_records = check_stale_dns_records(self.domain)
 
         self.assertEqual(len(stale_records), 1)
@@ -555,13 +563,12 @@ class TestStaleDNSRecords(SimpleTestCase):
         self.assertEqual(stale_records[0]['name'], f'_autodiscover._tcp.{self.domain}')
         self.assertEqual(stale_records[0]['existing_values'], ['0 0 443 cpanelemaildiscovery.cpanel.net'])
 
-    def test_autodiscover_srv_stale_even_if_pointing_to_our_host(self):
-        """Any autodiscover SRV is stale - we don't use autodiscover at all."""
+    def test_autodiscover_srv_not_stale_when_probe_is_negative(self):
         mock_srv = MagicMock()
         mock_srv.priority = 0
         mock_srv.weight = 1
         mock_srv.port = 443
-        mock_srv.target.to_text.return_value = 'mail.thundermail.com.'
+        mock_srv.target.to_text.return_value = 'cpanelemaildiscovery.cpanel.net.'
 
         def resolve_side_effect(name, record_type):
             if record_type == 'CNAME':
@@ -570,11 +577,11 @@ class TestStaleDNSRecords(SimpleTestCase):
                 return [mock_srv]
             raise dns_resolver.NoAnswer()
 
-        with self._patch_resolver(resolve_side_effect):
+        with self._patch_resolver(resolve_side_effect), self._patch_autodiscover_probe(False) as mock_probe:
             stale_records = check_stale_dns_records(self.domain)
 
-        self.assertEqual(len(stale_records), 1)
-        self.assertEqual(stale_records[0]['code'], StaleDNSRecordCode.AUTODISCOVER_SRV_UNEXPECTED.value)
+        self.assertEqual(stale_records, [])
+        mock_probe.assert_called_once_with('cpanelemaildiscovery.cpanel.net', self.domain)
 
     def test_no_stale_records_when_missing(self):
         with self._patch_resolver(lambda name, rdtype: (_ for _ in ()).throw(dns_resolver.NoAnswer())):

--- a/uv.lock
+++ b/uv.lock
@@ -1484,6 +1484,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
 name = "roman-numerals"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1760,6 +1772,7 @@ dependencies = [
     { name = "redis" },
     { name = "regex" },
     { name = "requests" },
+    { name = "requests-toolbelt" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "servestatic" },
     { name = "ua-parser" },
@@ -1823,6 +1836,7 @@ requires-dist = [
     { name = "redis", specifier = "==5.2.1" },
     { name = "regex", specifier = ">=2025.9.1" },
     { name = "requests", specifier = ">=2.34.2" },
+    { name = "requests-toolbelt", specifier = ">=0.7.0" },
     { name = "ruff", marker = "extra == 'cli'" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.60.0" },
     { name = "servestatic", specifier = ">=4.3.0" },


### PR DESCRIPTION

## What changed?

Here in the event that an `autodiscover` subdomain is present, we perform additional HTTP-based checks to see if it's actually an Exchange server that would be problematic.

Because the user controls the domain that we are making HTTP and DNS requests do, some care is taken to avoid server-side request-forgery vulns. (SSRF).

The detection approach is based some on what Thunderbird Desktop does.

## Why?

Wildcard DNS is common, which can currently result in a false report of a problematic `autodiscover` subdomain.

## QA Log

- Automated testing 

## Limitations and Notes

As described in #943, a linked KB article is recommended to clarify the edge case a "tombstone" DNS TXT record is a necessary fix IF they 1. Use wildcard DNS
2. Their `autodiscover` subdomain manages to sufficiently appear to us to an Exchange server
without actually being one.

Though, maybe that case is so rare we shouldn't bother with it.

## Applicable Issues

Closes #943