### PR TITLE
ci(keycloak): build the keycloak image multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -130,16 +130,26 @@ jobs:
           docker push $ECR_TAG
           echo "accounts-image=$ECR_TAG" >> $GITHUB_OUTPUT
 
-      # Produce the keycloak container image (only when keycloak/IaC changed)
+      # Produce the keycloak container image (only when keycloak/IaC changed).
+      # Built multi-arch: linux/amd64 for ECS Fargate (current) and linux/arm64
+      # for the Thunderbird Pro EKS clusters (Graviton). The same keycloak-<sha>
+      # tag is a manifest list, so each runtime pulls its matching variant.
+      - name: Set up QEMU
+        if: env.BUILD_KEYCLOAK == 'true'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: env.BUILD_KEYCLOAK == 'true'
+        uses: docker/setup-buildx-action@v3
       - name: Build, tag, and push keycloak image to Amazon ECR
         id: build-keycloak
         if: env.BUILD_KEYCLOAK == 'true'
         env:
           ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:keycloak-${{ github.sha }}"
         run: |
-          # Build a docker container and push it to ECR so that it can be deployed to ECS.
-          docker build -f Dockerfile.keycloak -t $ECR_TAG --platform="linux/amd64" .
-          docker push $ECR_TAG
+          # Build a multi-arch image (amd64 for ECS, arm64 for EKS) and push the
+          # manifest list to ECR. buildx --push publishes directly (no docker push).
+          docker buildx build -f Dockerfile.keycloak -t $ECR_TAG \
+            --platform linux/amd64,linux/arm64 --push .
           echo "keycloak-image=$ECR_TAG" >> $GITHUB_OUTPUT
 
       - name: Get version from pyproject.toml


### PR DESCRIPTION
## What

Builds the Keycloak image (`<repo>:keycloak-<sha>`) as a **multi-arch manifest list** (`linux/amd64` + `linux/arm64`) via `docker buildx`, instead of amd64-only.

```diff
- docker build -f Dockerfile.keycloak -t $ECR_TAG --platform="linux/amd64" .
- docker push $ECR_TAG
+ docker buildx build -f Dockerfile.keycloak -t $ECR_TAG \
+   --platform linux/amd64,linux/arm64 --push .
```
Plus `docker/setup-qemu-action` + `docker/setup-buildx-action` (guarded by the existing `BUILD_KEYCLOAK` condition).

## Why

The Thunderbird Pro **EKS** clusters (Graviton / arm64) are the migration target for Customer Auth Keycloak ([platform-infrastructure#132](https://github.com/thunderbird/platform-infrastructure/issues/132), [#531](https://github.com/thunderbird/platform-infrastructure/issues/531)). The current amd64-only image can't be scheduled on arm64 nodes. A manifest list keeps **ECS Fargate (amd64) working unchanged** while letting the **same `keycloak-<sha>` tag** run on EKS arm64.

## Notes
- Theme stage (`FROM node:*`) is arch-independent; base `quay.io/keycloak/keycloak:26.5` is already multi-arch, so arm64 builds cleanly (QEMU on the amd64 runner; modest extra build time).
- No change to the accounts app image (stays amd64 for ECS) or to the deployment artifact contract (`build-keycloak.outputs.keycloak-image` unchanged).