### PR TITLE
HOTFIX: Redirect users from /sign-up?email= to /login if account exists

### DIFF
--- a/src/thunderbird_accounts/authentication/utils.py
+++ b/src/thunderbird_accounts/authentication/utils.py
@@ -77,6 +77,13 @@ def is_email_reserved(email: str):
     return is_reserved(email)
 
 
+def get_user_by_contact_email(email: str):
+    """Return a user whose recovery email or account email matches the given address."""
+    from thunderbird_accounts.authentication.models import User
+
+    return User.objects.filter(Q(email__iexact=email) | Q(recovery_email__iexact=email)).first()
+
+
 def can_register_with_username(username: str):
     """Can a user register with this username.
     This checks primary username and any mirrored aliases for our allowed domains
@@ -102,6 +109,18 @@ def create_aia_url(action: KeycloakRequiredAction):
         f'?response_type=code'
         f'&client_id={settings.OIDC_RP_CLIENT_ID}'
         f'&kc_action={action.value}'
+        f'&redirect_uri={redirect_uri}',
+    )
+
+
+def create_login_hint_url(login_hint: str):
+    """Create an authorization URL that prefills the username on Keycloak's login page."""
+    redirect_uri = quote(get_absolute_url(reverse('login')))
+    return urljoin(
+        settings.KEYCLOAK_AIA_ENDPOINT,
+        f'?response_type=code'
+        f'&client_id={settings.OIDC_RP_CLIENT_ID}'
+        f'&login_hint={quote(login_hint)}'
         f'&redirect_uri={redirect_uri}',
     )
 

--- a/src/thunderbird_accounts/core/tests/test_views.py
+++ b/src/thunderbird_accounts/core/tests/test_views.py
@@ -63,6 +63,23 @@ class HomeViewRedirectTestCase(TestCase):
         self.assertIn('existing-recovery%40example.com', response.url)
 
     @patch('thunderbird_accounts.authentication.middleware.gethostbyname', return_value='127.0.0.1')
+    def test_sign_up_redirects_existing_user_without_recovery_email(self, _mock_dns):
+        """An existing user without recovery_email is redirected using the email query param."""
+        contact_email = 'contact-only@example.com'
+        User.objects.create(
+            username=f'existing@{settings.PRIMARY_EMAIL_DOMAIN}',
+            email=contact_email,
+            recovery_email=None,
+            oidc_id='existing-oidc',
+        )
+
+        response = self.client.get('/sign-up', {'email': contact_email})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('login_hint=', response.url)
+        self.assertIn('contact-only%40example.com', response.url)
+
+    @patch('thunderbird_accounts.authentication.middleware.gethostbyname', return_value='127.0.0.1')
     def test_sign_up_no_redirect_for_unknown_email(self, _mock_dns):
         """An unknown email on /sign-up should render the sign-up page normally."""
         response = self.client.get('/sign-up', {'email': 'nobody@example.com'})

--- a/src/thunderbird_accounts/core/tests/test_views.py
+++ b/src/thunderbird_accounts/core/tests/test_views.py
@@ -46,6 +46,38 @@ class HomeViewRedirectTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'index.html')
 
+    @patch('thunderbird_accounts.authentication.middleware.gethostbyname', return_value='127.0.0.1')
+    def test_sign_up_redirects_existing_user_to_login_hint(self, _mock_dns):
+        """An existing user visiting /sign-up?email=<recovery> is redirected to Keycloak with login_hint."""
+        User.objects.create(
+            username=f'existing@{settings.PRIMARY_EMAIL_DOMAIN}',
+            email='existing-recovery@example.com',
+            recovery_email='existing-recovery@example.com',
+            oidc_id='existing-oidc',
+        )
+
+        response = self.client.get('/sign-up', {'email': 'existing-recovery@example.com'})
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('login_hint=', response.url)
+        self.assertIn('existing-recovery%40example.com', response.url)
+
+    @patch('thunderbird_accounts.authentication.middleware.gethostbyname', return_value='127.0.0.1')
+    def test_sign_up_no_redirect_for_unknown_email(self, _mock_dns):
+        """An unknown email on /sign-up should render the sign-up page normally."""
+        response = self.client.get('/sign-up', {'email': 'nobody@example.com'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'index.html')
+
+    @patch('thunderbird_accounts.authentication.middleware.gethostbyname', return_value='127.0.0.1')
+    def test_sign_up_no_redirect_without_email_param(self, _mock_dns):
+        """Visiting /sign-up without an email param should render normally."""
+        response = self.client.get('/sign-up')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'index.html')
+
     def test_authenticated_user_can_access_home(self):
         """Test that authenticated users can access home without redirect."""
         self.client.force_login(self.user)

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -75,7 +75,7 @@ def home(request: HttpRequest):
         if email:
             existing_user = get_user_by_contact_email(email)
             if existing_user:
-                return HttpResponseRedirect(create_login_hint_url(email))
+                return HttpResponseRedirect(create_login_hint_url(existing_user.recovery_email))
 
     if request.user.is_authenticated and request.user.has_active_subscription:
         try:

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -25,6 +25,7 @@ from thunderbird_accounts.mail.utils import decode_app_password, filter_app_pass
 
 from thunderbird_accounts.core.zendesk import ZendeskClient
 from thunderbird_accounts.legal.models import LegalDocument, LegalDocumentResponse
+from thunderbird_accounts.authentication.utils import create_login_hint_url, get_user_by_contact_email
 
 
 def handle_500(request: HttpRequest, template_name=None):
@@ -66,6 +67,15 @@ def home(request: HttpRequest):
     # use these conditions to ship the user to logout and thus "fixing" the redirect loop.
     if request.session.get('oidc_access_token') and not request.user.is_authenticated:
         return HttpResponseRedirect(reverse('logout'))
+
+    # abandoned_cart tagged users have a subscribe CTA button that points to /sign-up?email=email
+    # however, we should instead redirect them to login if they already have an account with that email
+    if not request.user.is_authenticated and request.path == '/sign-up':
+        email = request.GET.get('email')
+        if email:
+            existing_user = get_user_by_contact_email(email)
+            if existing_user:
+                return HttpResponseRedirect(create_login_hint_url(email))
 
     if request.user.is_authenticated and request.user.has_active_subscription:
         try:

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -75,7 +75,8 @@ def home(request: HttpRequest):
         if email:
             existing_user = get_user_by_contact_email(email)
             if existing_user:
-                return HttpResponseRedirect(create_login_hint_url(existing_user.recovery_email))
+                login_hint = existing_user.recovery_email or email
+                return HttpResponseRedirect(create_login_hint_url(login_hint))
 
     if request.user.is_authenticated and request.user.has_active_subscription:
         try:


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

When navigating to `/sign-up?email=`, if the user already has an account, redirect them to `/login` instead with the email pre-filled.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

The `abandoned_cart` email automation has a link to `/sign-up?email=` which is the sign up flow. These users already have accounts so they would be misled into thinking they need to recreate it or they have to manually change it to the login flow.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->
Closes https://github.com/thunderbird/thunderbird-accounts/issues/976