### PR TITLE
ci: rebuild Pulumi venv on prod runner; exclude it from artifact

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -197,7 +197,12 @@ jobs:
         if: env.BUILD_ACCOUNTS == 'true'
         shell: bash
         run: |
-          tar -cvjf pulumi.tbz pulumi/
+          # Exclude the venv: it was built on THIS runner with bin/python as an
+          # absolute symlink into /opt/hostedtoolcache/Python/<patch>/..., so it
+          # isn't portable to the prod runner (different cached patch version =>
+          # dangling symlink => pulumi fails on venv/bin/python). release.yml
+          # rebuilds the venv from requirements.txt on the prod runner.
+          tar --exclude='pulumi/venv' -cvjf pulumi.tbz pulumi/
 
       - name: Archive the Pulumi artifact
         id: iac-archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,29 @@ jobs:
         shell: bash
         run: |
           tar -xvf pulumi.tbz
-      
+
       - name: Set up Python ${{ vars.PYTHON_VERSION}}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ vars.PYTHON_VERSION}}
+
+      # Build the Pulumi venv on THIS runner. Older pulumi.tbz artifacts shipped
+      # a venv built on the stage runner, whose bin/python was an absolute
+      # symlink into /opt/hostedtoolcache/Python/<patch>/... — that path doesn't
+      # exist on the prod runner whenever the cached patch version differs, and
+      # pulumi blows up trying to call venv/bin/python. We now exclude the venv
+      # from the artifact (see merge.yml) and rebuild here. The `rm -rf venv`
+      # handles already-published drafts whose artifact still contains the
+      # stage-runner venv.
+      - name: Rebuild Pulumi venv on prod runner
+        shell: bash
+        run: |
+          cd pulumi
+          rm -rf venv
+          python -m pip install virtualenv
+          virtualenv ./venv
+          source ./venv/bin/activate
+          pip install -Ur requirements.txt
 
       - name: Install Pulumi
         shell: bash


### PR DESCRIPTION
## Summary

Fixes the [Pulumi prod deploy failure on r-0437](https://github.com/thunderbird/thunderbird-accounts/actions/runs/27723066505/job/82012984536):

> Failed to resolve python version command: fork/exec /home/runner/work/.../pulumi/venv/bin/python: no such file or directory

### Root cause

`merge.yml` creates `pulumi/venv` on the stage runner via `virtualenv`, then `tar -cvjf pulumi.tbz pulumi/` packages it whole — venv included — and uploads it to the draft release. The venv's `bin/python` is an **absolute symlink** to the stage runner's Python install:

```
$ cat pulumi/venv/pyvenv.cfg
home = /opt/hostedtoolcache/Python/3.13.14/x64/bin
executable = /opt/hostedtoolcache/Python/3.13.14/x64/bin/python3.13
$ ls -la pulumi/venv/bin/python
python -> /opt/hostedtoolcache/Python/3.13.14/x64/bin/python
```

When `release.yml` extracts the tarball on the prod runner, `actions/setup-python@v5` installs the latest 3.13.x — but GitHub-hosted runners' tool caches drift, and if the prod runner's cache has e.g. `3.13.15` while the stage runner had `3.13.14`, the symlink target doesn't exist on the prod runner. Pulumi calls `venv/bin/python` and gets ENOENT.

Prior releases only worked when the stage and prod runners happened to have the same cached patch version. r-0433 (v1.14.2) two days ago: lucky. r-0437 (v1.14.3) today: unlucky.

## Changes

**`.github/workflows/merge.yml`** — exclude `pulumi/venv` when tarring the artifact. Shrinks `pulumi.tbz` from ~55 MB to ~10 KB and stops shipping a non-portable venv between runners.

```yaml
tar --exclude='pulumi/venv' -cvjf pulumi.tbz pulumi/
```

**`.github/workflows/release.yml`** — rebuild the venv from `requirements.txt` on the prod runner after extraction. `rm -rf venv` first so already-published drafts (which still contain the stage-runner venv) work without re-cutting the release.

```yaml
- name: Rebuild Pulumi venv on prod runner
  run: |
    cd pulumi
    rm -rf venv
    python -m pip install virtualenv
    virtualenv ./venv
    source ./venv/bin/activate
    pip install -Ur requirements.txt
```

## Recovery for r-0437

Once this lands on main:

1. Open the r-0437 release on GitHub → "Edit release" → "Save as draft" (unpublishes it).
2. Open the draft again → "Publish release".
3. The new publish event re-fires `release.yml` against the updated workflow on main. Prod deploy succeeds.

## Test plan

- [ ] Merge to main → existing `merge.yml` workflow builds a new draft (r-0438?) whose `pulumi.tbz` is now ~10 KB (no venv inside) and does not contain `pulumi/venv/*`
- [ ] Unpublish + republish r-0437 → `release.yml` "Rebuild Pulumi venv on prod runner" step succeeds and "Deploy version-tagged image to prod" completes the Pulumi update
- [ ] Subsequent normal release flow (next version bump → new draft → publish) works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)