### PR TITLE
Pin to older playwright-firefox to get E2E tests running again

### DIFF
--- a/test/e2e/browserstack-desktop-nightly.yml
+++ b/test/e2e/browserstack-desktop-nightly.yml
@@ -28,7 +28,7 @@ platforms:
   - os: OS X
     osVersion: Sequoia
     browserName: playwright-firefox
-    browserVersion: latest
+    browserVersion: 139.0
     playwrightConfigOptions:
       name: Firefox-OSX
       setup:

--- a/test/e2e/browserstack-desktop.yml
+++ b/test/e2e/browserstack-desktop.yml
@@ -28,7 +28,7 @@ platforms:
   - os: OS X
     osVersion: Sequoia
     browserName: playwright-firefox
-    browserVersion: latest
+    browserVersion: 139.0
     playwrightConfigOptions:
       name: Firefox-OSX
       setup:


### PR DESCRIPTION
## What changed?
Pin the version of Firefox (playwright-firefox) that the E2E tests use to version `139.0` instead of latest.

## Why?
There is a problem with the latest playwright-firefox `150.0` that is causing the browser to close before the E2E tests can sign in to TB Accounts, so the E2E tests are currently failing on Firefox (but passing on other browsers).

## Applicable Issues
Fixes #982.

## QA Log
Ran the nightly E2E tests on this branch via GHA, and here's the [BrowserStack link](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Firefox+Desktop/138?tab=sessions&testListView=spec) showing the tests running successfully on Firefox 139.0.