### PR TITLE
Add Django Admin action to back-fill recovery_email from Keycloak

### DIFF
--- a/src/thunderbird_accounts/authentication/admin/actions.py
+++ b/src/thunderbird_accounts/authentication/admin/actions.py
@@ -221,8 +221,8 @@ def admin_backfill_recovery_email(modeladmin, request, queryset):
     skipped = 0
     failed = 0
 
-    for user in queryset.filter(Q(recovery_email__isnull=True) | Q(recovery_email='')):
-        if not user.oidc_id:
+    for user in queryset.filter(Q(recovery_email__isnull=True) | Q(recovery_email='')).exclude(oidc_id__isnull=True):
+
             skipped += 1
             continue
 

--- a/src/thunderbird_accounts/authentication/admin/actions.py
+++ b/src/thunderbird_accounts/authentication/admin/actions.py
@@ -216,6 +216,14 @@ def admin_sync_plan_to_keycloak(modeladmin, request, queryset):
 
 @admin.action(description=_('Backfill recovery email from Keycloak'))
 def admin_backfill_recovery_email(modeladmin, request, queryset):
+"""Backfill's recovery emails from user with ``null`` recovery emails in this system and a valid one in Keycloak.
+
+Displays the following messages on the admin panel after the action is performed:
+* Updated: The number of user's that have been successfully updated with their recovery email.
+* Skipped: The number of user's who were skipped because they don't have a valid recovery email in Keycloak.
+* Failed: The number of user's that exist in this system but do not exist in Keycloak.
+
+"""
     keycloak = KeycloakClient()
     updated = 0
     skipped = 0

--- a/src/thunderbird_accounts/authentication/admin/actions.py
+++ b/src/thunderbird_accounts/authentication/admin/actions.py
@@ -4,9 +4,11 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages, admin
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _, ngettext
 
-from thunderbird_accounts.authentication.exceptions import UpdateUserPlanInfoError
+from thunderbird_accounts.authentication.clients import KeycloakClient
+from thunderbird_accounts.authentication.exceptions import GetUserError, UpdateUserPlanInfoError
 from thunderbird_accounts.mail.clients import MailClient
 from thunderbird_accounts.mail import utils as mail_utils
 from thunderbird_accounts.mail.exceptions import AccountNotFoundError
@@ -205,6 +207,75 @@ def admin_sync_plan_to_keycloak(modeladmin, request, queryset):
             messages.ERROR,
         )
     if sum([success_activate, success_deactivate, errors]) == 0:
+        modeladmin.message_user(
+            request,
+            _('Nothing to update!'),
+            messages.INFO,
+        )
+
+
+@admin.action(description=_('Backfill recovery email from Keycloak'))
+def admin_backfill_recovery_email(modeladmin, request, queryset):
+    keycloak = KeycloakClient()
+    updated = 0
+    skipped = 0
+    failed = 0
+
+    for user in queryset.filter(Q(recovery_email__isnull=True) | Q(recovery_email='')):
+        if not user.oidc_id:
+            skipped += 1
+            continue
+
+        try:
+            keycloak_user = keycloak.get_user(user.oidc_id).json()
+        except GetUserError as exc:
+            failed += 1
+            logging.warning('admin_backfill_recovery_email: failed to fetch Keycloak user %s: %s', user.uuid, exc)
+            continue
+
+        recovery_email = keycloak_user.get('email')
+        if not isinstance(recovery_email, str) or not recovery_email.strip():
+            skipped += 1
+            continue
+
+        user.recovery_email = recovery_email
+        user.save(update_fields=['recovery_email', 'updated_at'])
+        updated += 1
+
+    if updated:
+        modeladmin.message_user(
+            request,
+            ngettext(
+                'Backfilled recovery email for %d user.',
+                'Backfilled recovery email for %d users.',
+                updated,
+            )
+            % updated,
+            messages.SUCCESS,
+        )
+    if skipped:
+        modeladmin.message_user(
+            request,
+            ngettext(
+                'Skipped %d user without a Keycloak email or oidc_id.',
+                'Skipped %d users without a Keycloak email or oidc_id.',
+                skipped,
+            )
+            % skipped,
+            messages.WARNING,
+        )
+    if failed:
+        modeladmin.message_user(
+            request,
+            ngettext(
+                'Failed to backfill recovery email for %d user.',
+                'Failed to backfill recovery email for %d users.',
+                failed,
+            )
+            % failed,
+            messages.ERROR,
+        )
+    if sum([updated, skipped, failed]) == 0:
         modeladmin.message_user(
             request,
             _('Nothing to update!'),

--- a/src/thunderbird_accounts/authentication/admin/actions.py
+++ b/src/thunderbird_accounts/authentication/admin/actions.py
@@ -216,24 +216,20 @@ def admin_sync_plan_to_keycloak(modeladmin, request, queryset):
 
 @admin.action(description=_('Backfill recovery email from Keycloak'))
 def admin_backfill_recovery_email(modeladmin, request, queryset):
-"""Backfill's recovery emails from user with ``null`` recovery emails in this system and a valid one in Keycloak.
+    """Backfill's recovery emails from user with ``null`` recovery emails in this system and a valid one in Keycloak.
 
-Displays the following messages on the admin panel after the action is performed:
-* Updated: The number of user's that have been successfully updated with their recovery email.
-* Skipped: The number of user's who were skipped because they don't have a valid recovery email in Keycloak.
-* Failed: The number of user's that exist in this system but do not exist in Keycloak.
+    Displays the following messages on the admin panel after the action is performed:
+    * Updated: The number of user's that have been successfully updated with their recovery email.
+    * Skipped: The number of user's who were skipped because they don't have a valid recovery email in Keycloak.
+    * Failed: The number of user's that exist in this system but do not exist in Keycloak.
 
-"""
+    """
     keycloak = KeycloakClient()
     updated = 0
     skipped = 0
     failed = 0
 
     for user in queryset.filter(Q(recovery_email__isnull=True) | Q(recovery_email='')).exclude(oidc_id__isnull=True):
-
-            skipped += 1
-            continue
-
         try:
             keycloak_user = keycloak.get_user(user.oidc_id).json()
         except GetUserError as exc:

--- a/src/thunderbird_accounts/authentication/admin/models.py
+++ b/src/thunderbird_accounts/authentication/admin/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import gettext_lazy as _
 
 from thunderbird_accounts.authentication.admin.actions import (
+    admin_backfill_recovery_email,
     admin_fix_broken_stalwart_account,
     admin_sync_plan_to_keycloak,
     admin_manual_activate_subscription_features,
@@ -80,6 +81,7 @@ class CustomUserAdmin(UserAdmin):
         'updated_at',
     )
     actions = [
+        admin_backfill_recovery_email,
         admin_fix_broken_stalwart_account,
         admin_sync_plan_to_keycloak,
         admin_manual_activate_subscription_features,

--- a/src/thunderbird_accounts/authentication/tests/test_admin.py
+++ b/src/thunderbird_accounts/authentication/tests/test_admin.py
@@ -501,3 +501,38 @@ class AdminBackfillRecoveryEmailActionTest(TestCase):
         user.refresh_from_db()
         self.assertEqual(user.recovery_email, 'existing@example.com')
 
+    def test_backfills_only_eligible_users_when_multiple_selected(self, mock_keycloak_cls, mock_message_user):
+        missing_recovery = User.objects.create(
+            username=f'missing-recovery@{self.subdomain}',
+            email=f'missing-recovery@{self.subdomain}',
+            oidc_id='oidc-missing-recovery',
+        )
+        has_recovery = User.objects.create(
+            username=f'has-recovery@{self.subdomain}',
+            email=f'has-recovery@{self.subdomain}',
+            recovery_email='existing@example.com',
+            oidc_id='oidc-has-recovery',
+        )
+        missing_oidc = User.objects.create(
+            username=f'missing-oidc@{self.subdomain}',
+            email=f'missing-oidc@{self.subdomain}',
+        )
+
+        mock_keycloak = mock_keycloak_cls.return_value
+        mock_keycloak.get_user.return_value = MagicMock(json=lambda: {'email': 'recovery@example.com'})
+
+        admin_backfill_recovery_email(
+            self.user_admin,
+            self.request,
+            User.objects.filter(pk__in=[missing_recovery.pk, has_recovery.pk, missing_oidc.pk]),
+        )
+
+        missing_recovery.refresh_from_db()
+        has_recovery.refresh_from_db()
+        missing_oidc.refresh_from_db()
+
+        self.assertEqual(missing_recovery.recovery_email, 'recovery@example.com')
+        self.assertEqual(has_recovery.recovery_email, 'existing@example.com')
+        self.assertIsNone(missing_oidc.recovery_email)
+        mock_keycloak.get_user.assert_called_once_with('oidc-missing-recovery')
+

--- a/src/thunderbird_accounts/authentication/tests/test_admin.py
+++ b/src/thunderbird_accounts/authentication/tests/test_admin.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from requests import Response
 
 from thunderbird_accounts.authentication.admin import CustomUserAdmin
+from thunderbird_accounts.authentication.admin.actions import admin_backfill_recovery_email
 from thunderbird_accounts.authentication.clients import RequestMethods
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.models import Account, Email
@@ -462,4 +463,41 @@ class AdminDeleteUserTestCase(TestCase):
         self.assertEqual(method, RequestMethods.DELETE)
 
         mock_delete_principal.assert_not_called()
+
+
+@patch.object(CustomUserAdmin, 'message_user')
+@patch('thunderbird_accounts.authentication.admin.actions.KeycloakClient')
+class AdminBackfillRecoveryEmailActionTest(TestCase):
+    def setUp(self):
+        self.subdomain = settings.PRIMARY_EMAIL_DOMAIN
+        self.user_admin = CustomUserAdmin(User, AdminSite())
+        self.request = HttpRequest()
+
+    def test_backfills_selected_users_missing_recovery_email(self, mock_keycloak_cls, mock_message_user):
+        user = User.objects.create(
+            username=f'missing-recovery@{self.subdomain}',
+            email=f'missing-recovery@{self.subdomain}',
+            oidc_id='oidc-missing-recovery',
+        )
+        mock_keycloak = mock_keycloak_cls.return_value
+        mock_keycloak.get_user.return_value = MagicMock(json=lambda: {'email': 'recovery@example.com'})
+
+        admin_backfill_recovery_email(self.user_admin, self.request, User.objects.filter(pk=user.pk))
+
+        user.refresh_from_db()
+        self.assertEqual(user.recovery_email, 'recovery@example.com')
+
+    def test_skips_users_with_existing_recovery_email(self, mock_keycloak_cls, mock_message_user):
+        user = User.objects.create(
+            username=f'has-recovery@{self.subdomain}',
+            email=f'has-recovery@{self.subdomain}',
+            recovery_email='existing@example.com',
+            oidc_id='oidc-has-recovery',
+        )
+
+        admin_backfill_recovery_email(self.user_admin, self.request, User.objects.filter(pk=user.pk))
+
+        mock_keycloak_cls.return_value.get_user.assert_not_called()
+        user.refresh_from_db()
+        self.assertEqual(user.recovery_email, 'existing@example.com')
 


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Added a new Django Admin action to back-fill `recovery_email` for Users.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We've introduced the `recovery_email` field in the User model after having onboarded several emails so we need to back-fill this field. Since we have this info in Keycloak, we should source it from there.

## How to test

Thankfully, our `admin@example.org` user that is created automagically when spinning up a local environment from scratch doesn't have a recovery email set so we can simply do a `docker compose down -v` and a `docker compose up -d --build` and then:

- Navigate to `localhost:8087/admin/authentication/user/`
- See that the recovery email field for the admin user is empty
- Select the admin user and run the `Backfill recovery email from Keycloak` action
- See that the recovery email field is filled!

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Related with https://github.com/thunderbird/thunderbird-accounts/issues/821
Closes https://github.com/thunderbird/thunderbird-accounts/issues/836


## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

<img width="699" height="347" alt="image" src="https://github.com/user-attachments/assets/11dd07b4-4e70-46be-9a55-ded34ddf1b87" />
