### PR TITLE
Don't display an html response for drj api endpoints on non-debug envs (Fixes #993)

### DIFF
--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -287,6 +287,11 @@ REST_FRAMEWORK = {
     },
 }
 
+if not DEBUG:
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = [
+        'rest_framework.renderers.JSONRenderer',
+    ]
+
 REDIS_URL = os.getenv('REDIS_URL')
 AVAILABLE_CACHES = {
     'dev': {


### PR DESCRIPTION
Fixes #993