### PR TITLE
Pin dotenv to earlier ver to avoid console adverts

### DIFF
--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -13,7 +13,7 @@
         "@playwright/test": "1.59.1",
         "@types/node": "^24.10.1",
         "browserstack-node-sdk": "1.52.3",
-        "dotenv": "^17.2.1",
+        "dotenv": "16.6.1",
         "form-data": ">=4.0.4",
         "tmp": ">=0.2.4"
       }
@@ -1377,19 +1377,6 @@
         "setup": "src/bin/setup.js"
       }
     },
-    "node_modules/browserstack-node-sdk/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -2260,9 +2247,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -24,7 +24,7 @@
     "@playwright/test": "1.59.1",
     "@types/node": "^24.10.1",
     "browserstack-node-sdk": "1.52.3",
-    "dotenv": "^17.2.1",
+    "dotenv": "16.6.1",
     "form-data": ">=4.0.4",
     "tmp": ">=0.2.4"
   }


### PR DESCRIPTION
## What changed?
Pin the node `dotenv` package to an earlier version that doesn't post adverts to the console log.

## Why?
@MelissaAutumn Noticed that the dotenv package was posting an advert in the console output. Turns out this is something that was added to the `dotenv` package in version 17.x and forward; but earlier versions of the package don't post to the console.

## Applicable Issues
Fixes #999.

## QA Log
Ran the E2E tests locally and confirmed that the dotenv output line (including the advert) no longer appears in the console.