### PR TITLE
Fix all-other-session logout option in MFA flow. (Fixes #1005)

### DIFF
--- a/src/thunderbird_accounts/authentication/clients.py
+++ b/src/thunderbird_accounts/authentication/clients.py
@@ -133,10 +133,6 @@ class KeycloakClient:
         self.request(f'users/{oidc_id}/credentials/{credential_id}', RequestMethods.DELETE)
         return True
 
-    def logout_user_sessions(self, oidc_id: str) -> bool:
-        self.request(f'users/{oidc_id}/logout', RequestMethods.POST)
-        return True
-
     def get_recovery_codes_credentials(self, oidc_id: str) -> list[dict]:
         return [
             credential
@@ -393,11 +389,12 @@ class KeycloakClient:
 
 
 class KeycloakMfaClient:
-    """Client for the self-service keycloak-mfa-rest provider.
+    """Client for self-service, realm-scoped Keycloak calls made as the end user.
 
-    These calls use the end user's forwarded OIDC access token and operate on the
-    token subject. Keep this separate from the admin API client so the two trust
-    boundaries cannot accidentally share auth or endpoint routing.
+    These use the end user's forwarded OIDC access token and operate on the token subject:
+    the keycloak-mfa-rest provider (/realms/{realm}/mfa/) plus Keycloak's built-in Account
+    REST API (/realms/{realm}/account/). Keep this separate from the admin API client so
+    the two trust boundaries cannot accidentally share auth or endpoint routing.
     """
 
     def request(
@@ -485,3 +482,21 @@ class KeycloakMfaClient:
             RequestMethods.POST,
             json_data=json_data,
         )
+
+    def logout_other_sessions(self, user_access_token: str) -> bool:
+        """Sign the user out of all sessions except the one this token belongs to.
+
+        Uses Keycloak's built-in Account REST API (realm-scoped, self-service), whose
+        `DELETE account/sessions` preserves the calling session — unlike the admin
+        user-logout, which is logout-all and would evict the current session too (#1005).
+        """
+        response = requests.request(
+            method=RequestMethods.DELETE.value,
+            url=urljoin(settings.KEYCLOAK_REALM_ENDPOINT, 'account/sessions'),
+            headers={
+                'Accept': 'application/json',
+                'Authorization': f'Bearer {user_access_token}',
+            },
+        )
+        response.raise_for_status()
+        return True

--- a/src/thunderbird_accounts/authentication/mfa_management.py
+++ b/src/thunderbird_accounts/authentication/mfa_management.py
@@ -315,7 +315,7 @@ class MfaManagementService:
             raise MfaSaveAuthenticatorUnavailableError() from exc
 
         if logout_other_sessions:
-            self._logout_other_sessions(oidc_id)
+            self._logout_other_sessions(user_access_token)
 
         self.request.session[MFA_MANAGEMENT_AUTH_SESSION_KEY] = int(time.time())
         cache.delete(make_pending_totp_cache_key(self.request.user.pk))
@@ -441,8 +441,12 @@ class MfaManagementService:
             sentry_sdk.capture_exception(exc)
             return []
 
-    def _logout_other_sessions(self, oidc_id: str) -> None:
+    def _logout_other_sessions(self, user_access_token: str) -> None:
+        """Best-effort wrapper: report logout failures to Sentry instead of failing the request."""
+        # The TOTP credential is already saved, so a logout failure must not fail the
+        # request. Keycloak's Account API preserves the current session (the admin
+        # user-logout would evict it too — issue #1005).
         try:
-            self.keycloak.logout_user_sessions(oidc_id)
+            self.provider.logout_other_sessions(user_access_token)
         except RequestException as exc:
             sentry_sdk.capture_exception(exc)

--- a/src/thunderbird_accounts/authentication/tests/test_mfa.py
+++ b/src/thunderbird_accounts/authentication/tests/test_mfa.py
@@ -228,6 +228,54 @@ class MfaApiTestCase(TestCase):
         self.assertIsNone(cache.get(make_pending_totp_cache_key(self.user.pk)))
 
     @patch('thunderbird_accounts.authentication.mfa_management.KeycloakClient')
+    def test_confirm_totp_setup_logout_other_sessions_uses_account_api(self, mock_keycloak_client: Mock):
+        # logoutOtherSessions delegates to the Account REST API with the user's own token,
+        # which preserves the current session (unlike the admin logout-all). See #1005.
+        cache.set(make_pending_totp_cache_key(self.user.pk), {'secret': 'rawsecretvalue123456'})
+        self.mock_mfa_client.return_value.register_totp_credential.return_value = {'success': True}
+        mock_keycloak_client.return_value.get_totp_credentials.return_value = [{'id': 'new-credential-id'}]
+
+        response = self.client.post(
+            reverse('api_confirm_totp_setup'),
+            data={'code': '123456', 'logoutOtherSessions': True},
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.mock_mfa_client.return_value.logout_other_sessions.assert_called_once_with('test-user-access-token')
+
+    @patch('thunderbird_accounts.authentication.mfa_management.KeycloakClient')
+    def test_confirm_totp_setup_without_logout_flag_skips_account_api(self, mock_keycloak_client: Mock):
+        cache.set(make_pending_totp_cache_key(self.user.pk), {'secret': 'rawsecretvalue123456'})
+        self.mock_mfa_client.return_value.register_totp_credential.return_value = {'success': True}
+        mock_keycloak_client.return_value.get_totp_credentials.return_value = [{'id': 'new-credential-id'}]
+
+        response = self.client.post(
+            reverse('api_confirm_totp_setup'),
+            data={'code': '123456'},
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.mock_mfa_client.return_value.logout_other_sessions.assert_not_called()
+
+    @patch('thunderbird_accounts.authentication.mfa_management.KeycloakClient')
+    def test_confirm_totp_setup_succeeds_when_logout_fails(self, mock_keycloak_client: Mock):
+        # The credential is already saved, so a logout failure must not fail the request.
+        cache.set(make_pending_totp_cache_key(self.user.pk), {'secret': 'rawsecretvalue123456'})
+        self.mock_mfa_client.return_value.register_totp_credential.return_value = {'success': True}
+        mock_keycloak_client.return_value.get_totp_credentials.return_value = [{'id': 'new-credential-id'}]
+        self.mock_mfa_client.return_value.logout_other_sessions.side_effect = RequestException('boom')
+
+        response = self.client.post(
+            reverse('api_confirm_totp_setup'),
+            data={'code': '123456', 'logoutOtherSessions': True},
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch('thunderbird_accounts.authentication.mfa_management.KeycloakClient')
     def test_start_totp_setup_requires_user_access_token(self, mock_keycloak_client: Mock):
         # No TOTP configured (no step-up), but the user's OIDC access token is missing.
         session = self.client.session

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -401,18 +401,24 @@ if AUTH_SCHEME == 'oidc':
     KEYCLOAK_ADMIN_CLIENT_SECRET = os.getenv('KEYCLOAK_ADMIN_CLIENT_SECRET')
     KEYCLOAK_ADMIN_TOKEN_ENDPOINT = os.getenv('KEYCLOAK_ADMIN_URL_TOKEN')
 
-    # Base URL for the keycloak-mfa-rest provider, mounted on the realm path
-    # (/realms/{realm}/mfa/). Defaults to the admin API host with the admin path
-    # swapped for the realm path; override with KEYCLOAK_URL_MFA if they differ.
-    #
-    # The provider is self-service: accounts forwards the end user's OIDC access token
-    # (session 'oidc_access_token') as the bearer, and the provider operates on the token
-    # subject. The provider's authorized-clients allowlist is set (Keycloak-side) to this
-    # app's OIDC client (OIDC_RP_CLIENT_ID), since that's the user token's azp.
-    KEYCLOAK_MFA_API_ENDPOINT = os.getenv('KEYCLOAK_URL_MFA') or (
-        f'{KEYCLOAK_API_ENDPOINT.replace("/admin/realms/", "/realms/").rstrip("/")}/mfa/'
+    # Realm base URL (/realms/{realm}/). The keycloak-mfa-rest provider and Keycloak's
+    # built-in self-service endpoints (e.g. the Account REST API) both hang off this, and
+    # all take the end user's forwarded OIDC access token (session 'oidc_access_token') as
+    # the bearer — Keycloak scopes them to the token subject. Defaults to the admin API
+    # host with the admin path swapped for the realm path; override with KEYCLOAK_URL_REALM.
+    KEYCLOAK_REALM_ENDPOINT = os.getenv('KEYCLOAK_URL_REALM') or (
+        f'{KEYCLOAK_API_ENDPOINT.replace("/admin/realms/", "/realms/").rstrip("/")}/'
         if KEYCLOAK_API_ENDPOINT
         else None
+    )
+
+    # Base URL for the keycloak-mfa-rest provider, mounted on the realm path
+    # (/realms/{realm}/mfa/). It's a custom SPI plugin so it can be relocated; override
+    # with KEYCLOAK_URL_MFA if it differs from the realm base. The provider's
+    # authorized-clients allowlist is set (Keycloak-side) to this app's OIDC client
+    # (OIDC_RP_CLIENT_ID), since that's the user token's azp.
+    KEYCLOAK_MFA_API_ENDPOINT = os.getenv('KEYCLOAK_URL_MFA') or (
+        f'{KEYCLOAK_REALM_ENDPOINT}mfa/' if KEYCLOAK_REALM_ENDPOINT else None
     )
 
     OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = os.getenv('OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS', 60 * 15)

--- a/test/e2e/tests/mfa.spec.ts
+++ b/test/e2e/tests/mfa.spec.ts
@@ -11,6 +11,7 @@ import {
 import {
   fetchKeycloakCredentials,
   getRecoveryCodesCredentialMetadata,
+  getUserSessionIds,
   MFA_CREDENTIAL_TYPES,
   removeExistingMfaCredentials,
 } from '../utils/keycloak-admin';
@@ -218,6 +219,50 @@ test.describe('multi-factor authentication', {
     expect(replacedCredential[0].id).not.toBe(initialCredential[0].id);
 
     await removeExistingMfaCredentials();
+  });
+
+  test('"sign out from other devices" during setup ends other sessions but keeps the current one', async ({
+    page,
+    browser,
+  }) => {
+    // Regression guard for #1005: the old "logout other sessions" call was logout-ALL and
+    // evicted the enrolling device too, so the user hit "session expired" moments later.
+    await ensureWeAreSignedIn(page);
+    await acceptLegalPoliciesIfRequired(page);
+    await page.goto(`${ACCTS_HUB_URL}/manage-mfa`);
+    await waitForVueApp(page);
+    await removeExistingMfaCredentials();
+    await page.reload();
+    await waitForVueApp(page);
+
+    // Second device: a separate context with its own Keycloak session. The account has no
+    // MFA yet, so a password-only sign-in succeeds.
+    const otherDevice = await browser.newContext();
+    try {
+      const idsBeforeOtherDevice = new Set(await getUserSessionIds());
+      const otherPage = await otherDevice.newPage();
+      await signInWithPassword(otherPage);
+      await expect(otherPage.getByRole('banner').locator('.avatar')).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+
+      const otherDeviceSessionId = (await getUserSessionIds()).find((id) => !idsBeforeOtherDevice.has(id));
+      expect(otherDeviceSessionId, 'second device should create a new Keycloak session').toBeTruthy();
+
+      // Enrol the authenticator on the current device with "sign out from other devices" on.
+      await setUpAuthenticatorApp(page, { logoutOtherSessions: true });
+
+      // The recovery-codes step immediately follows and calls the provider with the
+      // current access token. This is the exact next interaction that failed "session
+      // expired" before the fix; it succeeding proves the current device stayed signed in.
+      const codes = await captureRecoveryCodesAndConfirm(page);
+      expect(codes).toHaveLength(12);
+
+      // ...and the other device's session is terminated.
+      await expect
+        .poll(async () => await getUserSessionIds(), { timeout: TIMEOUT_30_SECONDS })
+        .not.toContain(otherDeviceSessionId);
+    } finally {
+      await otherDevice.close();
+    }
   });
 
   test('"try another way" lists the authenticator first and signs in via a recovery code', async ({ page }) => {

--- a/test/e2e/utils/keycloak-admin.ts
+++ b/test/e2e/utils/keycloak-admin.ts
@@ -75,6 +75,18 @@ export const removeExistingMfaCredentials = async () => {
   }
 };
 
+export const getUserSessionIds = async (): Promise<string[]> => {
+  const { userId, headers } = await fetchKeycloakCredentials();
+  const response = await fetch(`${KEYCLOAK_ADMIN_BASE_URL}/admin/realms/tbpro/users/${userId}/sessions`, { headers });
+  const sessions = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`Could not load Keycloak sessions: ${JSON.stringify(sessions)}`);
+  }
+
+  return (sessions as Array<{ id: string }>).map((session) => session.id);
+};
+
 export const getRecoveryCodesCredentialMetadata = async () => {
   const { credentials } = await fetchKeycloakCredentials();
   return credentials

--- a/test/e2e/utils/mfa.ts
+++ b/test/e2e/utils/mfa.ts
@@ -67,14 +67,23 @@ export const signInWithPassword = async (page: Page) => {
 };
 
 // Sets up an authenticator app via the management UI and leaves the auto-chained
-// recovery-codes modal open on its confirmation step.
-export const setUpAuthenticatorApp = async (page: Page) => {
+// recovery-codes modal open on its confirmation step. Pass logoutOtherSessions to also
+// tick "Sign out from other devices" before submitting the enrollment code.
+export const setUpAuthenticatorApp = async (
+  page: Page,
+  { logoutOtherSessions = false }: { logoutOtherSessions?: boolean } = {},
+) => {
   await page.getByRole('button', { name: 'Set up' }).first().click();
   await page.getByRole('button', { name: 'Enter code manually' }).click();
   const manualSecret = await page.getByTestId('totp-manual-secret').innerText();
   await page.getByRole('button', { name: 'Continue' }).click();
   const enrollmentCode = makeTotpCode(manualSecret);
   await page.getByTestId('totp-code-input').fill(enrollmentCode);
+  if (logoutOtherSessions) {
+    // The native input is screen-reader-only; its label's click handler drives the v-model.
+    await page.locator('label[for="Sign out from other devices"]').click();
+    await expect(page.getByRole('checkbox', { name: 'Sign out from other devices' })).toBeChecked();
+  }
   await page.getByRole('button', { name: 'Continue' }).click();
   return { manualSecret, enrollmentCode };
 };


### PR DESCRIPTION
## Summary
This patch fixes nuking of the current session and also switches to an endpoint that is restricted to the user's token for session logout, which is a net positive for security. Also added tests for this option.

## Manual Testing

1.  https://mfa-accounts.thunderbird.dev uses your credentials from stage-thundermail.com for auth and is updated for these changes. 
2. Go through the MFA setup flow, check "sign out all other devices" when verifying your authenticator app. 
3. Note that you do NOT immediately receive a session expired error and can continue normally.

## Notes
The way we set Keycloak URL in settings is weird, it should be a base domain endpoint and then add whatever paths(realm, interface, etc) as necessary, but instead we start off with a full URL including path.

Fixing this creates a bunch of extraneous changes though so I decided it was out of scope for this patch. Thus we have to derive the URL for the accounts REST API in a weird way.

Fixes #1005
