### PR TITLE
Temporarily disable failing E2E sign-up tests

### DIFF
--- a/test/e2e/tests/desktop/sign-up.spec.ts
+++ b/test/e2e/tests/desktop/sign-up.spec.ts
@@ -11,6 +11,9 @@ import {
 
 let signUpPage: TbAcctsSignUpPage;
 
+// be sure to re-enable these tests once 986 is resolved
+test.skip(true, 'Temporarily disabled due to issue 986');
+
 test.beforeEach(async ({ page }) => {
   // Remove any authentication cookies before passing it to our page
   await page.context().clearCookies();

--- a/test/e2e/tests/mobile/sign-up.spec.ts
+++ b/test/e2e/tests/mobile/sign-up.spec.ts
@@ -11,6 +11,9 @@ import {
 
 let signUpPage: TbAcctsSignUpPage;
 
+// be sure to re-enable these tests once 986 is resolved
+test.skip(true, 'Temporarily disabled due to issue 986');
+
 test.beforeEach(async ({ page }, testInfo) => {
   // Remove any authentication cookies before passing it to our page
   await page.context().clearCookies();


### PR DESCRIPTION
## What changed?
Adding a skip to temporarily disable the sign-up E2E tests until issue #986 is resolved.

## Why?
To prevent the E2E tests jobs from failing due to this known issue, causing developers having to investigate whether their changes caused the failures or not.

## Limitations and Notes
We will re-enable the tests once #986  is fixed.

## Applicable Issues
Fixes #1015.

## QA Log
Ran the nightly E2E tests job against this branch and verified the sign-up tests are now skipped:
- Firefox desktop [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Firefox+Desktop/146?testListView=spec)
- Android mobile [in Browserstack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Android+Chrome/77?tab=sessions&testListView=spec)

