### PR TITLE
Fix custom-domain outbound mail not being DKIM-signed (signature id must match Stalwart signing expression)

### DIFF
--- a/src/thunderbird_accounts/mail/clients.py
+++ b/src/thunderbird_accounts/mail/clients.py
@@ -257,11 +257,17 @@ class MailClient:
         Response objects may used for testing.
         Throws exception if request fails.
         """
+        from thunderbird_accounts.mail.dkim import _normalize_domain
+
         response_data = []
         dkim_algorithms = settings.STALWART_DKIM_ALGOS if algorithms is None else algorithms
+        normalized_domain = _normalize_domain(domain)
         for algorithm in dkim_algorithms:
+            # The signature id must match Stalwart's signing expression ('<prefix>-<domain>',
+            # e.g. rsa-example.com); otherwise outbound mail for this domain is sent unsigned.
+            id_prefix = settings.STALWART_DKIM_ALGO_ID_PREFIXES.get(algorithm)
             data = {
-                'id': None,
+                'id': f'{id_prefix}-{normalized_domain}' if id_prefix else None,
                 'algorithm': algorithm,
                 'domain': domain,
                 'selector': settings.STALWART_DKIM_ALGO_SELECTORS.get(algorithm),

--- a/src/thunderbird_accounts/mail/tests/test_clients.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients.py
@@ -236,14 +236,14 @@ class TestMailClientCreateDkim(TestCase):
         self.assertEqual(
             [
                 {
-                    'id': None,
+                    'id': f'ed25519-{self.domain}',
                     'algorithm': 'Ed25519',
                     'domain': self.domain,
                     'selector': 'tm2',
                     'stage': DkimSignatureStage.PENDING.value,
                 },
                 {
-                    'id': None,
+                    'id': f'rsa-{self.domain}',
                     'algorithm': 'Rsa',
                     'domain': self.domain,
                     'selector': 'tm1',

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -443,6 +443,14 @@ STALWART_DKIM_ALGO_SELECTORS = {
     'Rsa': 'tm1',
     'Ed25519': 'tm2',
 }
+# Stalwart's outbound signing expression selects signatures *by id*, e.g.
+#   if is_local_domain('*', sender_domain) then ['rsa-' + sender_domain, 'ed25519-' + sender_domain] else false
+# so each signature's id must be '<prefix>-<domain>' (e.g. rsa-example.com) or Stalwart finds
+# no matching signature for the sender domain and sends the message unsigned.
+STALWART_DKIM_ALGO_ID_PREFIXES = {
+    'Rsa': 'rsa',
+    'Ed25519': 'ed25519',
+}
 # Stalwart 0.15 does not expose the admin JMAP DKIM signature lifecycle API.
 STALWART_DKIM_STAGE_MANAGEMENT_ENABLED = os.getenv('STALWART_DKIM_STAGE_MANAGEMENT_ENABLED', '').lower() == 'true'
 STALWART_WEBHOOK_SECRET = os.getenv('STALWART_WEBHOOK_SECRET')


### PR DESCRIPTION
## Problem

Outbound mail from **verified custom domains** in Thundermail is sent **without a DKIM signature**, so it fails DKIM and breaks DMARC alignment at receiving providers. The customer's DNS (CNAMEs -> `dkim.thunderhosted.com`, published public keys) is correct; the gap is server-side signature selection.

Reported via thunderbird/platform-infrastructure#591 (customer `theokell.com`).

## Root cause

`MailClient.create_dkim()` created Stalwart DKIM signatures with `'id': None`, so Stalwart auto-assigned an id that does **not** match its outbound signing expression:

```
if is_local_domain('*', sender_domain)
  then ['rsa-' + sender_domain, 'ed25519-' + sender_domain] else false
```

The expression selects signatures **by id** (`rsa-<domain>` / `ed25519-<domain>`). With a non-matching id, Stalwart finds no signature for the sender domain and sends the message unsigned. This affects **every** custom domain; the primary domain works only because its signatures were seeded with matching ids during server setup.

## Fix

Build the signature id as `'<prefix>-<normalized-domain>'` (e.g. `rsa-theokell.com`) via a new `STALWART_DKIM_ALGO_ID_PREFIXES` map, so created signatures match the signing expression. Domain is normalized (lowercase, no trailing dot) to match `sender_domain` at signing time.

- `settings.py`: add `STALWART_DKIM_ALGO_ID_PREFIXES = {'Rsa': 'rsa', 'Ed25519': 'ed25519'}`
- `mail/clients.py`: set `id` from `<prefix>-<normalized_domain>`
- `mail/tests/test_clients.py`: update expected payload ids

## Backfill required (not in this PR)

Signatures already created for existing custom domains have non-matching ids and will remain unsigned until recreated with correct ids (delete + recreate, or rename the `signature.<id>.*` keys). Recreation regenerates the keypair but is **customer-transparent**: customer CNAMEs point at our `dkim.thunderhosted.com` zone and `publish_hosted_dkim_dns_records` re-pushes the new public keys. Tracking in platform-infrastructure#591.

## Testing

- Updated `TestMailClientCreateDkim.test_success` to assert the constructed ids.
- Verified id construction + domain normalization in isolation (`_normalize_domain` is pure): `theokell.com`, uppercase, and trailing-dot inputs all yield `rsa-theokell.com` / `ed25519-theokell.com`.
- Full Django suite runs in the project's docker stack (CI); not run locally (local venv lacks `paddle_billing`).

## Post-merge verification

1. Add/re-provision a custom domain; confirm `signature.rsa-<domain>` and `signature.ed25519-<domain>` exist in Stalwart with the right selectors (tm1/tm2).
2. Send from `@<domain>` -> message has `DKIM-Signature` (`d=<domain>`, `s=tm1`/`tm2`); DKIM `pass`, DMARC aligned (learndmarc.com / mail-tester).
