### PR TITLE
ci: build accounts image multi-arch (amd64+arm64) for Graviton EKS

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -118,28 +118,32 @@ jobs:
           curl -fsSL https://get.pulumi.com | sh
           pip install -Ur requirements.txt
 
-      # Produce the accounts container image (only when accounts/IaC changed)
+      # Both the accounts and keycloak images are built multi-arch via Buildx +
+      # QEMU (linux/amd64 for ECS Fargate today, linux/arm64 for the Thunderbird
+      # Pro EKS clusters on Graviton). Each <tag> is a manifest list, so every
+      # runtime pulls its matching variant. Set these up whenever either image
+      # is (re)built; they must run before the build steps below.
+      - name: Set up QEMU
+        if: env.BUILD_ACCOUNTS == 'true' || env.BUILD_KEYCLOAK == 'true'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: env.BUILD_ACCOUNTS == 'true' || env.BUILD_KEYCLOAK == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Produce the accounts container image (only when accounts/IaC changed).
       - name: Build, tag, and push accounts image to Amazon ECR
         id: build-accounts
         if: env.BUILD_ACCOUNTS == 'true'
         env:
           ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:${{ github.sha }}"
         run: |
-          # Build a docker container and push it to ECR so that it can be deployed to ECS.
-          docker build -t $ECR_TAG --platform="linux/amd64" .
-          docker push $ECR_TAG
+          # Build a multi-arch image (amd64 for ECS, arm64 for EKS) and push the
+          # manifest list to ECR. buildx --push publishes directly (no docker push).
+          docker buildx build -t $ECR_TAG \
+            --platform linux/amd64,linux/arm64 --push .
           echo "accounts-image=$ECR_TAG" >> $GITHUB_OUTPUT
 
       # Produce the keycloak container image (only when keycloak/IaC changed).
-      # Built multi-arch: linux/amd64 for ECS Fargate (current) and linux/arm64
-      # for the Thunderbird Pro EKS clusters (Graviton). The same keycloak-<sha>
-      # tag is a manifest list, so each runtime pulls its matching variant.
-      - name: Set up QEMU
-        if: env.BUILD_KEYCLOAK == 'true'
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        if: env.BUILD_KEYCLOAK == 'true'
-        uses: docker/setup-buildx-action@v3
       - name: Build, tag, and push keycloak image to Amazon ECR
         id: build-keycloak
         if: env.BUILD_KEYCLOAK == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Extract deployment values
         id: deployment-data
         run: |
-          echo "ecr-tag=$(jq .ecr_tag < deployment.json)" >> $GITHUB_OUTPUT
-          echo "semver=$(jq .version < deployment.json)" >> $GITHUB_OUTPUT
+          # Use jq -r so the outputs are raw strings (no surrounding JSON
+          # quotes); the retag step consumes them via env vars.
+          echo "ecr-tag=$(jq -r .ecr_tag < deployment.json)" >> "$GITHUB_OUTPUT"
+          echo "semver=$(jq -r .version < deployment.json)" >> "$GITHUB_OUTPUT"
       
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -45,24 +47,27 @@ jobs:
         with:
           mask-password: "true"
 
-      - name: Retag docker image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Retag docker image (preserve multi-arch manifest list)
         id: retag-image
+        env:
+          # Source tag = the git-sha image built on stage; SEMVER from pyproject.
+          SOURCE_TAG: ${{ steps.deployment-data.outputs.ecr-tag }}
+          SEMVER: ${{ steps.deployment-data.outputs.semver }}
         run: |
-          # Pull the image we want to deploy; its tag is the git commit hash that caused it to exist
-          SOURCE_TAG="${{ steps.deployment-data.outputs.ecr-tag }}"
-          docker pull $SOURCE_TAG
-
-          # Get the URL for the image, replacing the tag for the semantic version
-          IMAGE_BASE=$(echo $SOURCE_TAG | cut -d: -f1)
-          SEMVER="v${{ steps.deployment-data.outputs.semver }}"
-          TARGET_TAG="$IMAGE_BASE:$SEMVER"
-          docker tag $SOURCE_TAG $TARGET_TAG
-
-          # Push the new image
-          docker push $TARGET_TAG
+          # Re-tag the stage image to its semantic version for prod. Use
+          # `buildx imagetools create` to COPY the full manifest list: a
+          # `docker pull` + `docker tag` + `docker push` on this amd64 runner
+          # would flatten the multi-arch image down to amd64 only and drop the
+          # arm64 variant the Thunderbird Pro EKS (Graviton) clusters need.
+          IMAGE_BASE="${SOURCE_TAG%%:*}"
+          TARGET_TAG="${IMAGE_BASE}:v${SEMVER}"
+          docker buildx imagetools create -t "$TARGET_TAG" "$SOURCE_TAG"
 
           # Output the target tag
-          echo "target-tag=$TARGET_TAG" >> $GITHUB_OUTPUT
+          echo "target-tag=$TARGET_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download Pulumi artifact
         uses: dsaltares/fetch-gh-release-asset@master


### PR DESCRIPTION
The `thunderbird-accounts` image is currently built **amd64-only** (`merge.yml`: `docker build --platform=linux/amd64`), so it cannot run on the Thunderbird Pro EKS clusters (`mzla-eks-tb-dev01` / `mzla-eks-tb-prod01`), which run on **arm64/Graviton** nodes. This makes the accounts image multi-arch, mirroring the keycloak image which is already built that way.

## Changes

**`merge.yml` (stage build)**

- Hoist the QEMU + Buildx setup ahead of both image builds and fire it for either image (`BUILD_ACCOUNTS || BUILD_KEYCLOAK`).
- Switch the accounts build from `docker build --platform=linux/amd64` + `docker push` to `docker buildx build --platform linux/amd64,linux/arm64 --push` (publishes a manifest list directly).

**`release.yml` (prod retag)**

- The prod promotion retagged via `docker pull` → `docker tag` → `docker push`. On an amd64 runner that **flattens the multi-arch manifest list down to amd64 only**, dropping the arm64 variant the EKS clusters need. Switch to `docker buildx imagetools create -t <semver-tag> <sha-tag>`, which **copies the full manifest list** without pulling/flattening.
- `jq -r` the `deployment.json` values so they are raw strings, letting the retag step consume them safely via `env:`.

## Compatibility

- ECS Fargate (current prod/stage) keeps pulling the `linux/amd64` variant from the same manifest list — no behavior change for the existing runtime.
- The `linux/arm64` variant unblocks the EKS deployment tracked in `thunderbird/platform-infrastructure#593`.

## Verification

- After merge to main (stage build), `docker manifest inspect <registry>/<project>:<sha>` should list both `amd64` and `arm64`.
- After a prod release, the `:v<semver>` tag should likewise be a two-platform manifest list.

Part of thunderbird/platform-infrastructure#593