### PR TITLE
fix(keycloak-theme): ?no_esc on action URLs embedded in window._page JS strings

### DIFF
--- a/keycloak/themes/tbpro/login/delete-credential.ftl
+++ b/keycloak/themes/tbpro/login/delete-credential.ftl
@@ -3,7 +3,7 @@
     <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         deleteCredentialTitle: '${msg("deleteCredentialTitle", credentialLabel)}',
         deleteCredentialMessage: '${msg("deleteCredentialMessage", credentialLabel)}',
 

--- a/keycloak/themes/tbpro/login/error.ftl
+++ b/keycloak/themes/tbpro/login/error.ftl
@@ -8,7 +8,7 @@
         actionText: '',
         // <#else>
           // <#if client?? && client.baseUrl?has_content>
-          actionUrl: '${client.baseUrl}',
+          actionUrl: '${client.baseUrl?no_esc}',
           actionText: '${kcSanitize(msg("backToApplication"))?no_esc}',
           // </#if>
         // </#if>

--- a/keycloak/themes/tbpro/login/info.ftl
+++ b/keycloak/themes/tbpro/login/info.ftl
@@ -14,7 +14,7 @@
           actionUrl: '${actionUri}',
           actionText: '${kcSanitize(msg("proceedWithAction"))?no_esc}',
           // <#elseif (client.baseUrl)?has_content>
-          actionUrl: '${client.baseUrl}',
+          actionUrl: '${client.baseUrl?no_esc}',
           actionText: '${kcSanitize(msg("backToApplication"))?no_esc}',
           // </#if>
         // </#if>

--- a/keycloak/themes/tbpro/login/login-config-totp.ftl
+++ b/keycloak/themes/tbpro/login/login-config-totp.ftl
@@ -4,7 +4,7 @@
     <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         errors: {
           totp: '${kcSanitize(messagesPerField.get("totp"))?no_esc}',
           userLabel: '${kcSanitize(messagesPerField.get("userLabel"))?no_esc}',

--- a/keycloak/themes/tbpro/login/login-otp.ftl
+++ b/keycloak/themes/tbpro/login/login-otp.ftl
@@ -3,7 +3,7 @@
 <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         errors: {
           totp: '${kcSanitize(messagesPerField.get("totp"))?no_esc}',
         },

--- a/keycloak/themes/tbpro/login/login-page-expired.ftl
+++ b/keycloak/themes/tbpro/login/login-page-expired.ftl
@@ -3,9 +3,9 @@
 <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.registrationAction}',
-        restartFlowUrl: '${url.loginRestartFlowUrl}',
-        loginUrl: '${url.loginAction}',
+        formAction: '${url.registrationAction?no_esc}',
+        restartFlowUrl: '${url.loginRestartFlowUrl?no_esc}',
+        loginUrl: '${url.loginAction?no_esc}',
       };
       window._l10n = {
         ...window._l10n,

--- a/keycloak/themes/tbpro/login/login-recovery-authn-code-input.ftl
+++ b/keycloak/themes/tbpro/login/login-recovery-authn-code-input.ftl
@@ -3,7 +3,7 @@
 <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         recoveryCodePrompt: '${msg("auth-recovery-code-prompt", recoveryAuthnCodesInputBean.codeNumber?c)?js_string}',
         showTryAnotherWay: '${(auth?has_content && auth.showTryAnotherWayLink())?c}',
         errors: {

--- a/keycloak/themes/tbpro/login/login-reset-password.ftl
+++ b/keycloak/themes/tbpro/login/login-reset-password.ftl
@@ -3,12 +3,12 @@
     <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         attemptedUserName: '${(auth.attemptedUsername!)}',
         errors: {
           username: '${kcSanitize(messagesPerField.get("username"))?no_esc}',
         },
-        loginUrl: '${url.loginUrl}',
+        loginUrl: '${url.loginUrl?no_esc}',
       };
       window._l10n = {
         ...window._l10n,

--- a/keycloak/themes/tbpro/login/login-update-password.ftl
+++ b/keycloak/themes/tbpro/login/login-update-password.ftl
@@ -4,7 +4,7 @@
 <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         errors: {
           password: '${kcSanitize(messagesPerField.get("password"))?no_esc}',
           passwordConfirm: '${kcSanitize(messagesPerField.get("password-confirm"))?no_esc}',

--- a/keycloak/themes/tbpro/login/login-username.ftl
+++ b/keycloak/themes/tbpro/login/login-username.ftl
@@ -4,16 +4,16 @@
     <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         supportUrl: '${properties.tbproContactUrl}',
-        clientUrl: '${client.baseUrl}',
+        clientUrl: '${client.baseUrl?no_esc}',
         // <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-        registerUrl: '${url.registrationUrl}',
+        registerUrl: '${url.registrationUrl?no_esc}',
         // <#else>
         registerUrl: null,
         // </#if>
         // <#if realm.resetPasswordAllowed>
-        forgotPasswordUrl: '${url.loginResetCredentialsUrl}',
+        forgotPasswordUrl: '${url.loginResetCredentialsUrl?no_esc}',
         // <#else>
         forgotPasswordUrl: null,
         // </#if>
@@ -24,7 +24,7 @@
           {
             name: '${p.displayName!}',
             alias: '${p.alias}',
-            loginUrl: '${p.loginUrl}',
+            loginUrl: '${p.loginUrl?no_esc}',
             iconName: '${properties.kcCommonLogoIdP!}',
             className: '${properties.kcFormSocialAccountNameClass!}',
           },

--- a/keycloak/themes/tbpro/login/login-verify-email.ftl
+++ b/keycloak/themes/tbpro/login/login-verify-email.ftl
@@ -3,7 +3,7 @@
 <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         // <#if verifyEmail??>
         verifyEmailInstruction: '${msg("emailVerifyInstruction1",verifyEmail)}',
         submitText: '${msg("emailVerifyResend")}',

--- a/keycloak/themes/tbpro/login/login.ftl
+++ b/keycloak/themes/tbpro/login/login.ftl
@@ -4,16 +4,16 @@
     <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         supportUrl: '${properties.tbproContactUrl}',
-        clientUrl: '${client.baseUrl}',
+        clientUrl: '${client.baseUrl?no_esc}',
         // <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
-        registerUrl: '${url.registrationUrl}',
+        registerUrl: '${url.registrationUrl?no_esc}',
         // <#else>
         registerUrl: '${properties.tbproSignupUrl}',
         // </#if>
         // <#if realm.resetPasswordAllowed>
-        forgotPasswordUrl: '${url.loginResetCredentialsUrl}',
+        forgotPasswordUrl: '${url.loginResetCredentialsUrl?no_esc}',
         // <#else>
         forgotPasswordUrl: null,
         // </#if>
@@ -25,7 +25,7 @@
           {
             name: '${p.displayName!}',
             alias: '${p.alias}',
-            loginUrl: '${p.loginUrl}',
+            loginUrl: '${p.loginUrl?no_esc}',
             iconName: '${properties.kcCommonLogoIdP!}',
             className: '${properties.kcFormSocialAccountNameClass!}',
           },

--- a/keycloak/themes/tbpro/login/logout-confirm.ftl
+++ b/keycloak/themes/tbpro/login/logout-confirm.ftl
@@ -3,9 +3,9 @@
   <#if section = "js">
   <script>
       window._page['currentView'] = {
-        formAction: '${url.logoutConfirmAction}',
+        formAction: '${url.logoutConfirmAction?no_esc}',
         sessionCode: '${logoutConfirm.code}',
-        clientUrl: '${client.baseUrl}',
+        clientUrl: '${client.baseUrl?no_esc}',
       };
       window._l10n = {
         ...window._l10n,

--- a/keycloak/themes/tbpro/login/register.ftl
+++ b/keycloak/themes/tbpro/login/register.ftl
@@ -5,7 +5,7 @@
     <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.registrationAction}',
+        formAction: '${url.registrationAction?no_esc}',
         messageHeader: '${kcSanitize(msg("${messageHeader!}"))?no_esc}',
         errors: {
           email: '${kcSanitize(messagesPerField.get("email"))?no_esc}',
@@ -13,7 +13,7 @@
           password: '${kcSanitize(messagesPerField.get("password"))?no_esc}',
           passwordConfirm: '${kcSanitize(messagesPerField.get("password-confirm"))?no_esc}',
         },
-        clientUrl: '${client.baseUrl}',
+        clientUrl: '${client.baseUrl?no_esc}',
         currentLocale: '${(locale.currentLanguageTag)!"en"}',
         tbProPrimaryDomain: '${properties.tbproPrimaryDomain}',
         attributes: {

--- a/keycloak/themes/tbpro/login/select-authenticator.ftl
+++ b/keycloak/themes/tbpro/login/select-authenticator.ftl
@@ -3,7 +3,7 @@
 <#if section = "js">
     <script>
       window._page['currentView'] = {
-        formAction: '${url.loginAction}',
+        formAction: '${url.loginAction?no_esc}',
         authenticationSelections: [
           //<#list auth.authenticationSelections as selection>
           {

--- a/keycloak/themes/tbpro/login/template.ftl
+++ b/keycloak/themes/tbpro/login/template.ftl
@@ -103,7 +103,7 @@
         pageId: '${pageId}',
         realmTitle: '${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!"")))?no_esc}',
         //<#if client?? && client.baseUrl?has_content>
-        clientUrl: '${client.baseUrl}',
+        clientUrl: '${client.baseUrl?no_esc}',
         //<#else>
         clientUrl: null,
         //</#if>


### PR DESCRIPTION
## Problem

Keycloak **26.5.7** HTML-escapes Freemarker output. The tbpro login theme renders server-generated URLs into `window._page` JS objects, e.g.:

```ftl
formAction: '${url.loginAction}',
```

On 26.5.7 that renders as a JS string containing `…&amp;execution=…`. The Vue login app uses `formAction` as a **raw URL**, so the browser POSTs to a URL with a literal `&amp;`. Keycloak then parses `amp;execution` (the `execution` param is **lost**) and returns **400**, which the browser surfaces as `cookie_not_found` / `invalid_code`. This breaks the cross-app OIDC login — and every other flow that posts an action URL (update-password, OTP, reset, verify-email, register, logout-confirm, …).

### Why auth-stage.tb.pro isn't broken (yet)

The theme is identical there. The difference is the **Keycloak base image**: `Dockerfile.keycloak` pins the moving tag `quay.io/keycloak/keycloak:26.5`. The stage image was built on an **earlier 26.5.x** that did not auto-escape Freemarker; this build pulled **26.5.7**, which does. **Stage will hit the same bug on its next rebuild.**

## Fix

Add `?no_esc` to the Keycloak-generated server URLs embedded in **single-quoted JS strings** across the login theme (`url.*`, `p.loginUrl`, `client.baseUrl`). These are server-provided URL values (not user input), so disabling HTML escaping is the correct behavior in a JS-string context. Native double-quoted HTML form actions (`action="${url.loginAction}"`) are **untouched** — the browser decodes `&amp;` in HTML attributes, so those already work.

16 templates touched (`formAction`/`loginUrl`/`registerUrl`/`forgotPasswordUrl`/`restartFlowUrl`/`clientUrl`/`actionUrl`).

## Recommended follow-up

Pin `Dockerfile.keycloak` to a specific `26.5.x` tag instead of the moving `:26.5`, so Freemarker escaping behavior can't drift silently between builds. (Not included here to keep this PR scoped to the theme fix.)

## Validation

Verified on the EKS dev Customer Auth Keycloak (26.5.7): with these templates applied, the rendered `formAction` carries raw `&` (with `execution` intact) and the browser login completes the OIDC round-trip. (Dev is running an equivalent `?no_esc` override via keycloak-customer-deploy until this image ships.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)