### PR TITLE
MFA UI FIxes for #1007, #1011, #1012

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -387,7 +387,6 @@
       "multiFactorAuthenticationDescription": "Multi-factor authentication (MFA) adds an extra layer of security by requiring more than a password to sign in. We recommend setting up at least two methods to avoid lockout. You can change or remove MFA methods anytime on this screen.",
       "multiFactorAuthenticationLearnMore": "Learn more about MFA",
       "authenticationMethods": "Authentication Methods",
-      "loading": "Loading multi-factor authentication methods...",
       "confirmRemoveAuthenticatorApp": "Remove authenticator app?",
       "confirmRemoveAuthenticatorAppDescription": "Your recovery codes will also be removed, and you will need to set up a new authenticator app before multi-factor authentication is enabled again.",
       "confirmRemoveRecoveryCodes": "Remove recovery codes?",

--- a/assets/app/vue/views/ManageMfaView/components/AuthenticationMethods.vue
+++ b/assets/app/vue/views/ManageMfaView/components/AuthenticationMethods.vue
@@ -2,7 +2,7 @@
 import { onMounted, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { PhCheckCircle } from '@phosphor-icons/vue';
-import { BaseBadge, BaseBadgeTypes, VisualDivider, PrimaryButton, LinkButton, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
+import { BaseBadge, BaseBadgeTypes, VisualDivider, PrimaryButton, LinkButton, LoadingSkeleton, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 
 // Modals
 import ManageAuthenticatorAppModal from './ManageAuthenticatorAppModal.vue';
@@ -22,7 +22,7 @@ const removeMfaMethodModal = useTemplateRef<InstanceType<typeof RemoveMfaMethodM
 const {
   authenticationMethods,
   authenticationMethodEntries,
-  isLoading,
+  hasLoaded,
   errorMessage,
   reauthenticationUrl,
   isRemoving,
@@ -89,7 +89,6 @@ onMounted(loadMfaMethods);
 
     <div class="authentication-methods-content">
       <notice-bar :type="NoticeBarTypes.Critical" v-if="errorMessage">{{ errorMessage }}</notice-bar>
-      <p v-if="isLoading">{{ t('views.manageMfa.loading') }}</p>
 
       <template v-for="([method, methodData], index) in authenticationMethodEntries" :key="method">
         <div class="authentication-method">
@@ -97,13 +96,15 @@ onMounted(loadMfaMethods);
             <div class="authentication-method-header">
               <h3>{{ t(`views.manageMfa.${method}.title`) }}</h3>
     
-              <base-badge :type="methodData.set ? BaseBadgeTypes.Set : BaseBadgeTypes.NotSet">
-                {{ methodData.set ? t('views.manageMfa.states.set') : t('views.manageMfa.states.notSet') }}
-    
-                <template #icon v-if="methodData.set">
-                  <ph-check-circle size="16" weight="fill" />
-                </template>
-              </base-badge>
+              <loading-skeleton :is-loading="!hasLoaded" border-radius="1rem">
+                <base-badge :type="methodData.set ? BaseBadgeTypes.Set : BaseBadgeTypes.NotSet">
+                  {{ methodData.set ? t('views.manageMfa.states.set') : t('views.manageMfa.states.notSet') }}
+
+                  <template #icon v-if="methodData.set">
+                    <ph-check-circle size="16" weight="fill" />
+                  </template>
+                </base-badge>
+              </loading-skeleton>
             </div>
   
             <p :class="{ 'block-margin': methodData.set }">
@@ -129,7 +130,10 @@ onMounted(loadMfaMethods);
           </div>
 
           <div class="authentication-method-actions">
-            <template v-if="methodData.set">
+            <!-- Until methods load, the real state is unknown; show a button-sized skeleton
+                 rather than a (possibly wrong) "Set up"/"Edit" control. -->
+            <loading-skeleton v-if="!hasLoaded" width="5.5rem" height="2.25rem" />
+            <template v-else-if="methodData.set">
               <!-- When a method has an Edit action, Remove sits beneath it as a subtle
                    underlined link (matches the designs). When there's no Edit (e.g. the
                    authenticator app, which is enrollment-only), a lone underlined link

--- a/assets/app/vue/views/ManageMfaView/useMfaMethods.ts
+++ b/assets/app/vue/views/ManageMfaView/useMfaMethods.ts
@@ -74,6 +74,8 @@ export function useMfaMethods(options: MfaMethodsOptions) {
     [AUTHENTICATION_METHODS.RECOVERY_EMAIL_ADDRESS]: { set: false },
   });
 
+  const hasLoaded = ref(false);
+
   const reauthenticationUrl = ref('');
   const isRemoving = ref(false);
   const pendingRemove = ref<{ method: AUTHENTICATION_METHODS; credentialId: string } | null>(null);
@@ -135,6 +137,7 @@ export function useMfaMethods(options: MfaMethodsOptions) {
 
     setAuthenticatorCredentials(response.methods.authenticatorApp.credentials);
     setRecoveryCodesCredentials(response.methods.recoveryCodes.credentials);
+    hasLoaded.value = true;
   };
 
   // Per-method config for the remove flow: which API to call, how to reset state on
@@ -217,6 +220,7 @@ export function useMfaMethods(options: MfaMethodsOptions) {
     authenticationMethods,
     authenticationMethodEntries,
     isLoading,
+    hasLoaded,
     errorMessage,
     reauthenticationUrl,
     isRemoving,

--- a/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
@@ -40,7 +40,9 @@ export default {
           @keyup.enter="onSubmit">
       <message-bar/>
       <div class="form-elements">
-        <select-input name="device-input" data-testid="device-input" :options="userOtpCredentials" v-model="OtpCredentialModel">{{
+        <!-- #1011: with a single credential there's nothing to choose, so hide the
+             selector (matches stock Keycloak's `userOtpCredentials?size gt 1` guard). -->
+        <select-input v-if="userOtpCredentials.length > 1" name="device-input" data-testid="device-input" :options="userOtpCredentials" v-model="OtpCredentialModel">{{
             $t('loginTotpDeviceName')
           }}
         </select-input>

--- a/keycloak/themes/tbpro/login/template.ftl
+++ b/keycloak/themes/tbpro/login/template.ftl
@@ -107,7 +107,9 @@
         //<#else>
         clientUrl: null,
         //</#if>
-        //<#if message?has_content>
+        //<#-- Honor displayMessage: pages that show an error per-field (e.g. login-otp) set it -->
+        //<#-- false to suppress the global banner, avoiding a duplicate message. -->
+        //<#if displayMessage && message?has_content>
         message: {
           type: '${message.type}',
           summary: window._page.decodeHtmlEntities('${kcSanitize(message.summary)?no_esc}')


### PR DESCRIPTION
Preview is updated: https://mfa-accounts.thunderbird.dev

## Summary

Three commits:

### Skeleton MFA method state while loading (Fixes #1007)
Instead of text, we add a `hasLoaded` flag and render badge/button-sized shimmer skeletons until the first load resolves. This looks cleaner and eliminates any need to delay a loading message.

### Don't duplicate per-field errors in the global banner (Fixes #1012)
The theme template now honors Keycloak's `displayMessage` flag, so pages that surface a field-level error (e.g. `login-otp`) only show that error and not an info banner.

### Hide the OTP credential dropdown when there's only one (Fixes #1011)
The OTP login page always showed a device-selection dropdown, even for users with a single authenticator (nothing to choose). The selector is now gated on `userOtpCredentials.length > 1`, matching stock Keycloak's `userOtpCredentials?size gt 1` guard.

## Test plan

Verified on the preview environment (`https://mfa-accounts.thunderbird.dev`) signed in as an MFA-enrolled account.

**#1011 — OTP dropdown**
- [x] Sign in with a user that has a single authenticator → on the OTP page, confirm **no** device dropdown is shown.

**#1012 — duplicate error**
- [x] On the OTP page, enter an incorrect code → confirm a **single** inline error under the field and **no** duplicate global banner at the top.
<img width="776" height="472" alt="image" src="https://github.com/user-attachments/assets/655d8695-440a-40af-b340-de2093dc08b8" />

**#1007 — loading state**
- [x] Enter a valid code and open **Manage MFA** → confirm methods load without a "Not set"/"Set up" flash and without a "Loading…" text flash.
- [x] Throttle/delay the `…/auth/mfa/methods/` request → confirm the badge and action render as shimmer skeletons (titles visible) and swap to the real state once the request resolves.

<img width="1117" height="526" alt="image" src="https://github.com/user-attachments/assets/08249fb7-70a5-4d00-a2cc-899c55ecdff4" />

