### PR TITLE
Update password reset email sent message

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -58,7 +58,7 @@ export default {
     </div>
     <div class="buttons">
       <template v-if="loginUrl">
-        <a :href="loginUrl" data-testid="back-url">{{ $t('backToLogin') }}</a>
+        <primary-button variant="outline" :href="loginUrl" data-testid="back-url">{{ $t('backToLogin') }}</primary-button>
       </template>
 
       <primary-button class="submit" @click="onSubmit" data-testid="submit">{{ $t('doSubmit') }}</primary-button>

--- a/keycloak/themes/tbpro/login/messages/messages_en.properties
+++ b/keycloak/themes/tbpro/login/messages/messages_en.properties
@@ -349,7 +349,7 @@ resetPasswordMessage=You need to change your password.
 verifyEmailMessage=You need to verify your email address to activate your account.
 linkIdpMessage=You need to verify your email address to link your account with {0}.
 
-emailSentMessage=You should receive an email shortly with further instructions.
+emailSentMessage=Please check your recovery email for further instructions.
 emailSendErrorMessage=Failed to send email, please try again later.
 
 accountUpdatedMessage=Your account has been updated.


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Updated message in Keycloak's password recovery email sent screen
- Updated "back to login" button to be `PrimaryButton variant="outline"`


## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- New message enhances understanding according to Marketing
- Button "Back to Login" looked out of place according to the rest of the UI

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/987

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

### Updated message on password reset email sent

Before
<img width="3840" height="1876" alt="image" src="https://github.com/user-attachments/assets/6cffbcf1-30c7-468d-9f80-a505151693b0" />


After
<img width="3840" height="1876" alt="Screenshot 2026-06-29 at 08-26-34 Sign in to Thunderbird Accounts" src="https://github.com/user-attachments/assets/498c8f63-3a2d-4d03-a6ed-3b5df091d863" />



### Back to login button change

Before
<img width="3840" height="1876" alt="image" src="https://github.com/user-attachments/assets/7f41c71d-078e-4cdd-8637-f7639c46a853" />


After
<img width="3840" height="1876" alt="image" src="https://github.com/user-attachments/assets/b7aeb623-9eff-4584-9905-68b2b2f11b93" />

