### PR TITLE
Update oidc middleware with two new feature flags that introspect and allow posting

### DIFF
--- a/assets/app/vue/composables/useFetch.test.ts
+++ b/assets/app/vue/composables/useFetch.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthRedirectError, AuthSessionError, useAuthFetch } from './useFetch';
+
+describe('useAuthFetch', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('adds the default Accept header and preserves request options', async () => {
+    const response = new Response('{}', { status: 200 });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await useAuthFetch('/api/example', {
+      method: 'POST',
+      headers: { 'X-CSRFToken': 'csrf-token' },
+    });
+
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(options.headers);
+    expect(result.response.value).toBe(response);
+    expect(options.method).toBe('POST');
+    expect(headers.get('Accept')).toBe('application/json');
+    expect(headers.get('X-CSRFToken')).toBe('csrf-token');
+  });
+
+  it('starts reauthentication and rejects instead of resuming the caller', async () => {
+    const assign = vi.fn();
+    vi.stubGlobal('window', { location: { assign } });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ type: 'auth_error', refresh_url: '/oidc/authenticate/' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    await expect(useAuthFetch('/api/example')).rejects.toBeInstanceOf(AuthRedirectError);
+    expect(assign).toHaveBeenCalledWith('/oidc/authenticate/');
+  });
+
+  it('rejects auth errors that cannot redirect', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ type: 'auth_error', error: 'Session expired' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    await expect(useAuthFetch('/api/example')).rejects.toEqual(new AuthSessionError('Session expired'));
+  });
+
+  it('preserves non-session 403 responses', async () => {
+    const response = new Response(JSON.stringify({ reauthUrl: '/oidc/mfa-reauth/' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    const result = await useAuthFetch('/api/example');
+    expect(result.response.value).toBe(response);
+  });
+});

--- a/assets/app/vue/composables/useFetch.ts
+++ b/assets/app/vue/composables/useFetch.ts
@@ -1,0 +1,34 @@
+import { createFetch } from "@vueuse/core"
+
+//const { isFetching, error, data } = useMyFetch('users')
+export const useAuthfulFetch = createFetch({
+  options: {
+    async beforeFetch(ctx) {
+      // If we don't explicitly set an accept header, make sure it's set to application/json
+      if (!ctx.options?.headers['Accept']) {
+        ctx.options.headers['Accept'] = 'application/json';
+      }
+      return ctx;
+    },
+    async onFetchError(ctx) {
+      // Try and handle reauth responses (this happens if the refresh token is also invalid.)
+      try {
+        const data = JSON.parse(ctx.data);
+        // If it's a 403 we need to ship them to auth
+        if (ctx.response.status === 403 && data?.type === 'auth_error') {
+          if (data?.refresh_url) {
+            window.location = data?.refresh_url;
+            return ctx;
+          }
+        }
+      } catch {
+        // ...
+      } 
+
+      return ctx;
+    },
+  },
+  fetchOptions: {
+    mode: 'cors',
+  },
+});

--- a/assets/app/vue/composables/useFetch.ts
+++ b/assets/app/vue/composables/useFetch.ts
@@ -1,7 +1,7 @@
 import { createFetch } from "@vueuse/core"
 
 //const { isFetching, error, data } = useMyFetch('users')
-export const useAuthfulFetch = createFetch({
+export const useAuthFetch = createFetch({
   options: {
     async beforeFetch(ctx) {
       // If we don't explicitly set an accept header, make sure it's set to application/json

--- a/assets/app/vue/composables/useFetch.ts
+++ b/assets/app/vue/composables/useFetch.ts
@@ -1,30 +1,32 @@
-import { createFetch } from "@vueuse/core"
+import { createFetch } from '@vueuse/core';
 
-//const { isFetching, error, data } = useMyFetch('users')
-export const useAuthFetch = createFetch({
+interface AuthenticationErrorResponse {
+  error?: string;
+  type?: string;
+  refresh_url?: string;
+}
+
+export class AuthRedirectError extends Error {
+  constructor() {
+    super('Redirecting to authentication');
+    this.name = 'AuthRedirectError';
+  }
+}
+
+export class AuthSessionError extends Error {
+  constructor(message = 'The authentication session has expired') {
+    super(message);
+    this.name = 'AuthSessionError';
+  }
+}
+
+const useAuthFetchRequest = createFetch({
   options: {
     async beforeFetch(ctx) {
-      // If we don't explicitly set an accept header, make sure it's set to application/json
-      if (!ctx.options?.headers['Accept']) {
+      // JSON auth failures include a refresh URL instead of redirecting the fetch request.
+      if (!ctx.options.headers['Accept']) {
         ctx.options.headers['Accept'] = 'application/json';
       }
-      return ctx;
-    },
-    async onFetchError(ctx) {
-      // Try and handle reauth responses (this happens if the refresh token is also invalid.)
-      try {
-        const data = JSON.parse(ctx.data);
-        // If it's a 403 we need to ship them to auth
-        if (ctx.response.status === 403 && data?.type === 'auth_error') {
-          if (data?.refresh_url) {
-            window.location = data?.refresh_url;
-            return ctx;
-          }
-        }
-      } catch {
-        // ...
-      } 
-
       return ctx;
     },
   },
@@ -32,3 +34,33 @@ export const useAuthFetch = createFetch({
     mode: 'cors',
   },
 });
+
+export const useAuthFetch = async (url: string, options: RequestInit = {}) => {
+  const result = await useAuthFetchRequest(url, options);
+  const response = result.response.value;
+  if (!response) {
+    throw new Error(result.error.value || 'Request failed');
+  }
+
+  // VueUse stores HTTP errors in reactive state, so session failures must be handled explicitly.
+  if (response.status !== 403) {
+    return result;
+  }
+
+  const data = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as AuthenticationErrorResponse | null;
+  if (data?.type !== 'auth_error') {
+    // Feature-specific 403 responses, including MFA reauthentication, stay with their callers.
+    return result;
+  }
+
+  if (data.refresh_url) {
+    window.location.assign(data.refresh_url);
+    // Prevent the caller from consuming the 403 after navigation starts.
+    throw new AuthRedirectError();
+  }
+
+  throw new AuthSessionError(data.error);
+};

--- a/assets/app/vue/views/DashboardView/api.ts
+++ b/assets/app/vue/views/DashboardView/api.ts
@@ -1,7 +1,7 @@
-import { useAuthfulFetch } from "@/composables/useFetch";
+import { useAuthFetch } from "@/composables/useFetch";
 
 export const getSubscriptionPortalLink = async () => {
-  const { response } = await useAuthfulFetch('/api/v1/subscription/paddle/portal/', {
+  const { response } = await useAuthFetch('/api/v1/subscription/paddle/portal/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -13,7 +13,7 @@ export const getSubscriptionPortalLink = async () => {
 }
 
 export const getSubscriptionPlanInfo = async () => {
-  const { response } = await useAuthfulFetch('/api/v1/subscription/plan/info/', {
+  const { response } = await useAuthFetch('/api/v1/subscription/plan/info/', {
     method: 'POST',
     headers: {
       'Accept': 'application/json',

--- a/assets/app/vue/views/DashboardView/api.ts
+++ b/assets/app/vue/views/DashboardView/api.ts
@@ -1,5 +1,7 @@
+import { useAuthfulFetch } from "@/composables/useFetch";
+
 export const getSubscriptionPortalLink = async () => {
-  const response = await fetch('/api/v1/subscription/paddle/portal/', {
+  const { response } = await useAuthfulFetch('/api/v1/subscription/paddle/portal/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -7,11 +9,11 @@ export const getSubscriptionPortalLink = async () => {
     },
   });
 
-  return await response.json();
+  return await response.value.json();
 }
 
 export const getSubscriptionPlanInfo = async () => {
-  const response = await fetch('/api/v1/subscription/plan/info/', {
+  const { response } = await useAuthfulFetch('/api/v1/subscription/plan/info/', {
     method: 'POST',
     headers: {
       'Accept': 'application/json',
@@ -21,9 +23,9 @@ export const getSubscriptionPlanInfo = async () => {
   });
 
   // If we're not getting a application/json response then return the status text
-  if (!response.headers.get('content-type')?.includes('application/json')) {
-    throw new Error(response.statusText);
+  if (!response.value.headers.get('content-type')?.includes('application/json')) {
+    throw new Error(response.value.statusText);
   }
 
-  return await response.json();
+  return await response.value.json();
 }

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
@@ -1,7 +1,7 @@
-import { useAuthfulFetch } from "@/composables/useFetch";
+import { useAuthFetch } from "@/composables/useFetch";
 
 export const addCustomDomain = async (domainName: string) => {
-  const { response } = await useAuthfulFetch(`/custom-domains/add`, {
+  const { response } = await useAuthFetch(`/custom-domains/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -14,12 +14,12 @@ export const addCustomDomain = async (domainName: string) => {
 };
 
 export const getRemoteDNSRecords = async (domainName: string) => {
-  const response = await useAuthfulFetch(`/custom-domains/dns-records?domain-name=${domainName}`);
-  return await response.json();
+  const { response } = await useAuthFetch(`/custom-domains/dns-records?domain-name=${domainName}`);
+  return await response.value.json();
 };
 
 export const verifyDomain = async (domainName: string) => {
-  const { response } = await useAuthfulFetch(`/custom-domains/verify`, {
+  const { response } = await useAuthFetch(`/custom-domains/verify`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -32,7 +32,7 @@ export const verifyDomain = async (domainName: string) => {
 };
 
 export const removeCustomDomain = async (domainName: string) => {
-  const { response } = await useAuthfulFetch(`/custom-domains/remove`, {
+  const { response } = await useAuthFetch(`/custom-domains/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
@@ -1,5 +1,7 @@
+import { useAuthfulFetch } from "@/composables/useFetch";
+
 export const addCustomDomain = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/add`, {
+  const { response } = await useAuthfulFetch(`/custom-domains/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -8,16 +10,16 @@ export const addCustomDomain = async (domainName: string) => {
     body: JSON.stringify({ 'domain-name': domainName }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const getRemoteDNSRecords = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/dns-records?domain-name=${domainName}`);
+  const response = await useAuthfulFetch(`/custom-domains/dns-records?domain-name=${domainName}`);
   return await response.json();
 };
 
 export const verifyDomain = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/verify`, {
+  const { response } = await useAuthfulFetch(`/custom-domains/verify`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -26,11 +28,11 @@ export const verifyDomain = async (domainName: string) => {
     body: JSON.stringify({ 'domain-name': domainName }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const removeCustomDomain = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/remove`, {
+  const { response } = await useAuthfulFetch(`/custom-domains/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -38,5 +40,5 @@ export const removeCustomDomain = async (domainName: string) => {
     },
     body: JSON.stringify({ 'domain-name': domainName }),
   });
-  return await response.json();
+  return await response.value.json();
 };

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
@@ -1,4 +1,4 @@
-import { useAuthfulFetch } from "@/composables/useFetch";
+import { useAuthFetch } from "@/composables/useFetch";
 
 type AddCustomDomainResponse = {
   success: boolean;
@@ -8,7 +8,7 @@ type AddCustomDomainResponse = {
 };
 
 export const addCustomDomain = async (domainName: string): Promise<AddCustomDomainResponse> => {
-  const { response } = await useAuthfulFetch(`/custom-domains/add`, {
+  const { response } = await useAuthFetch(`/custom-domains/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -21,12 +21,12 @@ export const addCustomDomain = async (domainName: string): Promise<AddCustomDoma
 };
 
 export const getRemoteDNSRecords = async (domainName: string) => {
-  const { response } = await useAuthfulFetch(`/custom-domains/dns-records?domain-name=${domainName}`);
+  const { response } = await useAuthFetch(`/custom-domains/dns-records?domain-name=${domainName}`);
   return await response.value.json();
 };
 
 export const verifyDomain = async (domainName: string) => {
-  const { response } = await useAuthfulFetch(`/custom-domains/verify`, {
+  const { response } = await useAuthFetch(`/custom-domains/verify`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -39,7 +39,7 @@ export const verifyDomain = async (domainName: string) => {
 };
 
 export const removeCustomDomain = async (domainName: string) => {
-  const { response } = await useAuthfulFetch(`/custom-domains/remove`, {
+  const { response } = await useAuthFetch(`/custom-domains/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
@@ -1,3 +1,5 @@
+import { useAuthfulFetch } from "@/composables/useFetch";
+
 type AddCustomDomainResponse = {
   success: boolean;
   domain_name?: string;
@@ -6,7 +8,7 @@ type AddCustomDomainResponse = {
 };
 
 export const addCustomDomain = async (domainName: string): Promise<AddCustomDomainResponse> => {
-  const response = await fetch(`/custom-domains/add`, {
+  const { response } = await useAuthfulFetch(`/custom-domains/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -15,16 +17,16 @@ export const addCustomDomain = async (domainName: string): Promise<AddCustomDoma
     body: JSON.stringify({ 'domain-name': domainName }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const getRemoteDNSRecords = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/dns-records?domain-name=${domainName}`);
-  return await response.json();
+  const { response } = await useAuthfulFetch(`/custom-domains/dns-records?domain-name=${domainName}`);
+  return await response.value.json();
 };
 
 export const verifyDomain = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/verify`, {
+  const { response } = await useAuthfulFetch(`/custom-domains/verify`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -33,11 +35,11 @@ export const verifyDomain = async (domainName: string) => {
     body: JSON.stringify({ 'domain-name': domainName }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const removeCustomDomain = async (domainName: string) => {
-  const response = await fetch(`/custom-domains/remove`, {
+  const { response } = await useAuthfulFetch(`/custom-domains/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -45,5 +47,5 @@ export const removeCustomDomain = async (domainName: string) => {
     },
     body: JSON.stringify({ 'domain-name': domainName }),
   });
-  return await response.json();
+  return await response.value.json();
 };

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/api.ts
@@ -1,3 +1,5 @@
+import { useAuthfulFetch } from "@/composables/useFetch";
+
 interface SettingsApiResponse {
   success: boolean;
   message?: string;
@@ -5,7 +7,7 @@ interface SettingsApiResponse {
 }
 
 export const setAppPassword = async (name: string, password: string): Promise<SettingsApiResponse> => {
-  const response = await fetch('/api/v1/mail/app-passwords/set/', {
+  const { response } = await useAuthfulFetch('/api/v1/mail/app-passwords/set/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -14,11 +16,11 @@ export const setAppPassword = async (name: string, password: string): Promise<Se
     body: JSON.stringify({ name, password }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const setDisplayName = async (displayName: string): Promise<SettingsApiResponse> => {
-  const response = await fetch('/api/v1/mail/display-name/set/', {
+  const { response } = await useAuthfulFetch('/api/v1/mail/display-name/set/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -27,11 +29,11 @@ export const setDisplayName = async (displayName: string): Promise<SettingsApiRe
     body: JSON.stringify({ 'display-name': displayName }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const addEmailAlias = async (emailAlias: string, domain: string) => {
-  const response = await fetch(`/email-aliases/add`, {
+  const { response } = await useAuthfulFetch(`/email-aliases/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -40,11 +42,11 @@ export const addEmailAlias = async (emailAlias: string, domain: string) => {
     body: JSON.stringify({ 'email-alias': emailAlias, 'domain': domain }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };
 
 export const removeEmailAlias = async (emailAlias: string) => {
-  const response = await fetch(`/email-aliases/remove`, {
+  const { response } = await useAuthfulFetch(`/email-aliases/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -53,5 +55,5 @@ export const removeEmailAlias = async (emailAlias: string) => {
     body: JSON.stringify({ 'email-alias': emailAlias }),
   });
 
-  return await response.json();
+  return await response.value.json();
 };

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/api.ts
@@ -1,4 +1,4 @@
-import { useAuthfulFetch } from "@/composables/useFetch";
+import { useAuthFetch } from "@/composables/useFetch";
 
 interface SettingsApiResponse {
   success: boolean;
@@ -7,7 +7,7 @@ interface SettingsApiResponse {
 }
 
 export const setAppPassword = async (name: string, password: string): Promise<SettingsApiResponse> => {
-  const { response } = await useAuthfulFetch('/api/v1/mail/app-passwords/set/', {
+  const { response } = await useAuthFetch('/api/v1/mail/app-passwords/set/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -20,7 +20,7 @@ export const setAppPassword = async (name: string, password: string): Promise<Se
 };
 
 export const setDisplayName = async (displayName: string): Promise<SettingsApiResponse> => {
-  const { response } = await useAuthfulFetch('/api/v1/mail/display-name/set/', {
+  const { response } = await useAuthFetch('/api/v1/mail/display-name/set/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -33,7 +33,7 @@ export const setDisplayName = async (displayName: string): Promise<SettingsApiRe
 };
 
 export const addEmailAlias = async (emailAlias: string, domain: string) => {
-  const { response } = await useAuthfulFetch(`/email-aliases/add`, {
+  const { response } = await useAuthFetch(`/email-aliases/add`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -46,7 +46,7 @@ export const addEmailAlias = async (emailAlias: string, domain: string) => {
 };
 
 export const removeEmailAlias = async (emailAlias: string) => {
-  const { response } = await useAuthfulFetch(`/email-aliases/remove`, {
+  const { response } = await useAuthFetch(`/email-aliases/remove`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/assets/app/vue/views/ManageMfaView/api.ts
+++ b/assets/app/vue/views/ManageMfaView/api.ts
@@ -1,3 +1,5 @@
+import { useAuthfulFetch } from "@/composables/useFetch";
+
 export interface TotpCredential {
   id: string;
   label: string;
@@ -85,56 +87,56 @@ const parseJsonResponse = async <T>(response: Response): Promise<T> => {
 };
 
 export const getMfaMethods = async () => {
-  const response = await fetch('/api/v1/auth/mfa/methods/', {
+  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/methods/', {
     method: 'GET',
     headers: jsonHeaders,
   });
 
-  return parseJsonResponse<MfaMethodsResponse>(response);
+  return parseJsonResponse<MfaMethodsResponse>(response.value);
 };
 
 export const startTotpSetup = async () => {
-  const response = await fetch('/api/v1/auth/mfa/totp/setup/start/', {
+  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/totp/setup/start/', {
     method: 'POST',
     headers: jsonHeaders,
   });
 
-  return parseJsonResponse<TotpSetupResponse>(response);
+  return parseJsonResponse<TotpSetupResponse>(response.value);
 };
 
 export const confirmTotpSetup = async (code: string, logoutOtherSessions: boolean) => {
-  const response = await fetch('/api/v1/auth/mfa/totp/setup/confirm/', {
+  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/totp/setup/confirm/', {
     method: 'POST',
     headers: jsonHeaders,
     body: JSON.stringify({ code, logoutOtherSessions }),
   });
 
-  return parseJsonResponse<TotpConfirmResponse>(response);
+  return parseJsonResponse<TotpConfirmResponse>(response.value);
 };
 
 export const removeTotpCredential = async (credentialId: string) => {
-  const response = await fetch(`/api/v1/auth/mfa/totp/credentials/${credentialId}/`, {
+  const { response } = await useAuthfulFetch(`/api/v1/auth/mfa/totp/credentials/${credentialId}/`, {
     method: 'DELETE',
     headers: jsonHeaders,
   });
 
-  return parseJsonResponse<{ success: boolean }>(response);
+  return parseJsonResponse<{ success: boolean }>(response.value);
 };
 
 export const regenerateRecoveryCodes = async () => {
-  const response = await fetch('/api/v1/auth/mfa/recovery-codes/regenerate/', {
+  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/recovery-codes/regenerate/', {
     method: 'POST',
     headers: jsonHeaders,
   });
 
-  return parseJsonResponse<RegenerateRecoveryCodesResponse>(response);
+  return parseJsonResponse<RegenerateRecoveryCodesResponse>(response.value);
 };
 
 export const removeRecoveryCodesCredential = async (credentialId: string) => {
-  const response = await fetch(`/api/v1/auth/mfa/recovery-codes/credentials/${credentialId}/`, {
+  const { response } = await useAuthfulFetch(`/api/v1/auth/mfa/recovery-codes/credentials/${credentialId}/`, {
     method: 'DELETE',
     headers: jsonHeaders,
   });
 
-  return parseJsonResponse<{ success: boolean }>(response);
+  return parseJsonResponse<{ success: boolean }>(response.value);
 };

--- a/assets/app/vue/views/ManageMfaView/api.ts
+++ b/assets/app/vue/views/ManageMfaView/api.ts
@@ -1,4 +1,4 @@
-import { useAuthfulFetch } from "@/composables/useFetch";
+import { useAuthFetch } from "@/composables/useFetch";
 
 export interface TotpCredential {
   id: string;
@@ -87,7 +87,7 @@ const parseJsonResponse = async <T>(response: Response): Promise<T> => {
 };
 
 export const getMfaMethods = async () => {
-  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/methods/', {
+  const { response } = await useAuthFetch('/api/v1/auth/mfa/methods/', {
     method: 'GET',
     headers: jsonHeaders,
   });
@@ -96,7 +96,7 @@ export const getMfaMethods = async () => {
 };
 
 export const startTotpSetup = async () => {
-  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/totp/setup/start/', {
+  const { response } = await useAuthFetch('/api/v1/auth/mfa/totp/setup/start/', {
     method: 'POST',
     headers: jsonHeaders,
   });
@@ -105,7 +105,7 @@ export const startTotpSetup = async () => {
 };
 
 export const confirmTotpSetup = async (code: string, logoutOtherSessions: boolean) => {
-  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/totp/setup/confirm/', {
+  const { response } = await useAuthFetch('/api/v1/auth/mfa/totp/setup/confirm/', {
     method: 'POST',
     headers: jsonHeaders,
     body: JSON.stringify({ code, logoutOtherSessions }),
@@ -115,7 +115,7 @@ export const confirmTotpSetup = async (code: string, logoutOtherSessions: boolea
 };
 
 export const removeTotpCredential = async (credentialId: string) => {
-  const { response } = await useAuthfulFetch(`/api/v1/auth/mfa/totp/credentials/${credentialId}/`, {
+  const { response } = await useAuthFetch(`/api/v1/auth/mfa/totp/credentials/${credentialId}/`, {
     method: 'DELETE',
     headers: jsonHeaders,
   });
@@ -124,7 +124,7 @@ export const removeTotpCredential = async (credentialId: string) => {
 };
 
 export const regenerateRecoveryCodes = async () => {
-  const { response } = await useAuthfulFetch('/api/v1/auth/mfa/recovery-codes/regenerate/', {
+  const { response } = await useAuthFetch('/api/v1/auth/mfa/recovery-codes/regenerate/', {
     method: 'POST',
     headers: jsonHeaders,
   });
@@ -133,7 +133,7 @@ export const regenerateRecoveryCodes = async () => {
 };
 
 export const removeRecoveryCodesCredential = async (credentialId: string) => {
-  const { response } = await useAuthfulFetch(`/api/v1/auth/mfa/recovery-codes/credentials/${credentialId}/`, {
+  const { response } = await useAuthFetch(`/api/v1/auth/mfa/recovery-codes/credentials/${credentialId}/`, {
     method: 'DELETE',
     headers: jsonHeaders,
   });

--- a/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
@@ -6,6 +6,7 @@ import CardContainer from '@/components/CardContainer.vue';
 import { onUnmounted, ref } from 'vue';
 import { useLocalStorage } from '@vueuse/core';
 import { PADDLE_TRANSACTION_STORAGE_KEY } from '@/defines';
+import { useAuthFetch } from '@/composables/useFetch';
 
 const { t } = useI18n();
 
@@ -75,7 +76,7 @@ onUnmounted(() => {
  */
 const areWeDoneHere = async () => {
   try {
-    const response = await fetch('/api/v1/subscription/paddle/tx/is-done/', {
+    const { response } = await useAuthFetch('/api/v1/subscription/paddle/tx/is-done/', {
       mode: 'same-origin',
       credentials: 'include',
       method: 'POST',
@@ -83,7 +84,7 @@ const areWeDoneHere = async () => {
         'X-CSRFToken': csrfToken,
       },
     });
-    const data = await response.json();
+    const data = await response.value.json();
     const { status } = data;
 
     // For some reason PaddleJS has paid's constant as undefined. Hmmm...
@@ -191,7 +192,7 @@ const onPaddleEvent = async (evt: PaddleEventData) => {
     }
 
     if (backendNeedsUpdate) {
-      await fetch('/api/v1/subscription/paddle/tx/set/', {
+      await useAuthFetch('/api/v1/subscription/paddle/tx/set/', {
         mode: 'same-origin',
         credentials: 'include',
         method: 'PUT',
@@ -233,7 +234,7 @@ const onPaddleEvent = async (evt: PaddleEventData) => {
  * module.
  */
 const setupPaddle = async () => {
-  const response = await fetch('/api/v1/subscription/paddle/info/', {
+  const { response } = await useAuthFetch('/api/v1/subscription/paddle/info/', {
     mode: 'same-origin',
     credentials: 'include',
     method: 'POST',
@@ -248,7 +249,7 @@ const setupPaddle = async () => {
     paddle_token: paddleToken,
     signed_user_id: signedUserId,
     discount_id: discountId,
-  } = await response.json();
+  } = await response.value.json();
 
   if (paddlePlanInfo.length === 0) {
     planSystemError.value = true;

--- a/assets/app/vue/views/TosPrivacyView/api.ts
+++ b/assets/app/vue/views/TosPrivacyView/api.ts
@@ -1,4 +1,4 @@
-import { useAuthfulFetch } from "@/composables/useFetch";
+import { useAuthFetch } from "@/composables/useFetch";
 
 export interface LegalDocMeta {
   uuid: string;
@@ -19,7 +19,7 @@ export interface AcceptedDoc {
 }
 
 export const getCurrentLegalDocs = async (locale: string): Promise<CurrentLegalDocsResponse> => {
-  const { response } = await useAuthfulFetch(`/api/v1/legal/current/?locale=${encodeURIComponent(locale)}`, {
+  const { response } = await useAuthFetch(`/api/v1/legal/current/?locale=${encodeURIComponent(locale)}`, {
     headers: {
       'Content-Type': 'application/json',
       'X-CSRFToken': window._page?.csrfToken,
@@ -29,7 +29,7 @@ export const getCurrentLegalDocs = async (locale: string): Promise<CurrentLegalD
 };
 
 export const acceptLegalDocs = async (sourceContext: string): Promise<{ responses: AcceptedDoc[] }> => {
-  const { response } = await useAuthfulFetch('/api/v1/legal/accept/', {
+  const { response } = await useAuthFetch('/api/v1/legal/accept/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -41,7 +41,7 @@ export const acceptLegalDocs = async (sourceContext: string): Promise<{ response
 };
 
 export const declineLegalDocs = async (sourceContext: string): Promise<{ redirect_url: string }> => {
-  const { response } = await useAuthfulFetch('/api/v1/legal/decline/', {
+  const { response } = await useAuthFetch('/api/v1/legal/decline/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/assets/app/vue/views/TosPrivacyView/api.ts
+++ b/assets/app/vue/views/TosPrivacyView/api.ts
@@ -1,3 +1,5 @@
+import { useAuthfulFetch } from "@/composables/useFetch";
+
 export interface LegalDocMeta {
   uuid: string;
   document_type: 'tos' | 'privacy';
@@ -17,17 +19,17 @@ export interface AcceptedDoc {
 }
 
 export const getCurrentLegalDocs = async (locale: string): Promise<CurrentLegalDocsResponse> => {
-  const response = await fetch(`/api/v1/legal/current/?locale=${encodeURIComponent(locale)}`, {
+  const { response } = await useAuthfulFetch(`/api/v1/legal/current/?locale=${encodeURIComponent(locale)}`, {
     headers: {
       'Content-Type': 'application/json',
       'X-CSRFToken': window._page?.csrfToken,
     },
   });
-  return await response.json();
+  return await response.value.json();
 };
 
 export const acceptLegalDocs = async (sourceContext: string): Promise<{ responses: AcceptedDoc[] }> => {
-  const response = await fetch('/api/v1/legal/accept/', {
+  const { response } = await useAuthfulFetch('/api/v1/legal/accept/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -35,11 +37,11 @@ export const acceptLegalDocs = async (sourceContext: string): Promise<{ response
     },
     body: JSON.stringify({ source_context: sourceContext }),
   });
-  return await response.json();
+  return await response.value.json();
 };
 
 export const declineLegalDocs = async (sourceContext: string): Promise<{ redirect_url: string }> => {
-  const response = await fetch('/api/v1/legal/decline/', {
+  const { response } = await useAuthfulFetch('/api/v1/legal/decline/', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -47,5 +49,5 @@ export const declineLegalDocs = async (sourceContext: string): Promise<{ redirec
     },
     body: JSON.stringify({ source_context: sourceContext }),
   });
-  return await response.json();
+  return await response.value.json();
 };

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -38,11 +38,11 @@
 .hosted_dkim_cloudflare_enabled: &VAR_HOSTED_DKIM_CLOUDFLARE_ENABLED {name: "HOSTED_DKIM_CLOUDFLARE_ENABLED", value: "True"}
 .hosted_dkim_cloudflare_ttl: &VAR_HOSTED_DKIM_CLOUDFLARE_TTL {name: "HOSTED_DKIM_CLOUDFLARE_TTL", value: "3600"}
 .hosted_dkim_cloudflare_zone_id: &VAR_HOSTED_DKIM_CLOUDFLARE_ZONE_ID {name: "HOSTED_DKIM_CLOUDFLARE_ZONE_ID", value: "c6e8d56e54e126edb68c1e8f1bbafe49"}
-.oidc_url_auth: &VAR_OIDC_URL_AUTH {name: "OIDC_URL_AUTH", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/auth"}
-.oidc_url_jwks: &VAR_OIDC_URL_JWKS {name: "OIDC_URL_JWKS", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/certs"}
-.oidc_url_logout: &VAR_OIDC_URL_LOGOUT {name: "OIDC_URL_LOGOUT", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/logout"}
-.oidc_url_token: &VAR_OIDC_URL_TOKEN {name: "OIDC_URL_TOKEN", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/token"}
-.oidc_url_user: &VAR_OIDC_URL_USER {name: "OIDC_URL_USER", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/userinfo"}
+.oidc_url_auth: &VAR_OIDC_URL_AUTH {name: "OIDC_URL_AUTH", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/auth/"}
+.oidc_url_jwks: &VAR_OIDC_URL_JWKS {name: "OIDC_URL_JWKS", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/certs/"}
+.oidc_url_logout: &VAR_OIDC_URL_LOGOUT {name: "OIDC_URL_LOGOUT", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/logout/"}
+.oidc_url_token: &VAR_OIDC_URL_TOKEN {name: "OIDC_URL_TOKEN", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/token/"}
+.oidc_url_user: &VAR_OIDC_URL_USER {name: "OIDC_URL_USER", value: "https://auth-stage.tb.pro/realms/tbpro/protocol/openid-connect/userinfo/"}
 .paddle_env: &VAR_PADDLE_ENV {name: "PADDLE_ENV", value: "sandbox"}
 .public_base_url: &VAR_PUBLIC_BASE_URL {name: "PUBLIC_BASE_URL", value: "https://accounts-stage.tb.pro"}
 .redis_celery_db: &VAR_REDIS_CELERY_DB {name: "REDIS_CELERY_DB", value: "5"}

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -459,6 +459,7 @@ class OIDCRefreshSession(SessionRefresh):
         access_token = token_info.get('access_token')
         refresh_token = token_info.get('refresh_token')
         store_tokens(request, access_token, id_token, refresh_token)
+        logging.debug('access token has been refreshed!')
         self.set_exit_state(self.EXIT_STATES.TOKEN_IS_STORED)
 
     def finish(self, request, prompt_reauth=True):

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -4,7 +4,7 @@ from django.utils.module_loading import import_string
 from django.contrib.auth import BACKEND_SESSION_KEY
 from requests.auth import HTTPBasicAuth
 from json import JSONDecodeError
-from urllib.parse import urlencode, quote
+from urllib.parse import urlencode, quote, urljoin
 from django.utils.crypto import get_random_string
 import requests
 from time import time
@@ -18,7 +18,7 @@ from typing import Optional
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
-from django.http import HttpRequest, JsonResponse, HttpResponseRedirect, HttpResponseForbidden
+from django.http import HttpRequest, JsonResponse, HttpResponseRedirect, HttpResponseForbidden, HttpResponse
 from django.utils.translation import gettext_lazy as _
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from sentry_sdk import capture_exception
@@ -34,23 +34,20 @@ from .utils import is_email_in_allow_list
 
 from mozilla_django_oidc.utils import add_state_and_verifier_and_nonce_to_session
 
+OIDC_ID_TOKEN_EXP_KEY = 'oidc_id_token_expiration'
 OIDC_ACCESS_TOKEN_KEY = 'oidc_access_token'
 OIDC_ID_TOKEN_KEY = 'oidc_id_token'
 OIDC_REFRESH_TOKEN_KEY = 'oidc_refresh_token'
+EXIT_STATE_KEY = '__exit_state'
 
 
-class TokenHintType(StrEnum):
-    ACCESS_TOKEN = 'access_token'
-    REFRESH_TOKEN = 'refresh_token'
-
-
-def _is_token_active(token: str, token_hint: TokenHintType = TokenHintType.ACCESS_TOKEN) -> bool:
+def _is_token_active(token: str) -> bool:
     """POST the introspect route to and see if it returns 'active': True."""
     if not token:
         return False
 
     token_payload = {
-        'token_type_hint': str(token_hint),
+        'token_type_hint': 'access_token',
         'client_id': import_from_settings('OIDC_RP_CLIENT_ID'),
         'client_secret': import_from_settings('OIDC_RP_CLIENT_SECRET'),
         'token': token,
@@ -61,8 +58,9 @@ def _is_token_active(token: str, token_hint: TokenHintType = TokenHintType.ACCES
         # Basic-auth clients send credentials in the header, not the body.
         req_auth = HTTPBasicAuth(token_payload['client_id'], token_payload.pop('client_secret'))
 
+    introspect_url = urljoin(import_from_settings('OIDC_OP_TOKEN_ENDPOINT'), 'introspect')
     response = requests.post(
-        f'{import_from_settings("OIDC_OP_TOKEN_ENDPOINT")}introspect',
+        introspect_url,
         auth=req_auth,
         data=token_payload,
         verify=import_from_settings('OIDC_VERIFY_SSL', True),
@@ -87,7 +85,7 @@ def store_tokens(request, access_token, id_token, refresh_token):
         request.session[OIDC_REFRESH_TOKEN_KEY] = refresh_token
 
     expiration_interval = import_from_settings('OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS', 60 * 15)
-    request.session['oidc_id_token_expiration'] = time() + expiration_interval
+    request.session[OIDC_ID_TOKEN_EXP_KEY] = time() + expiration_interval
 
 
 def _request_refreshed_tokens(refresh_token):
@@ -348,29 +346,28 @@ class OIDCRefreshSession(SessionRefresh):
         ACCESS_TOKEN_IS_ACTIVE = 'access-token-is-active'
         TOKEN_IS_STORED = 'token-is-stored'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.enable_per_request_introspect = False
-        self.allow_post_reauth = False
-        self.exit_state = None
-
-    def set_exit_state(self, state: EXIT_STATES):
+    def set_exit_state(self, request, state: EXIT_STATES):
         """Sets an exit state on the middleware, and by using the power of code you can inspect it later!
 
         This function is a noop outside of testing environments."""
         if not import_from_settings('IS_TEST'):
             return
-        self.exit_state = state
+        request.session[EXIT_STATE_KEY] = state
 
     def is_refreshable_url(self, request):
         """Is the session refreshable, and do we have a refresh token?"""
+        post_reauth_flag_name = import_from_settings('WAFFLE_FLAG_ALLOW_POST_REAUTH')
+        allow_post_reauth = False
+        if post_reauth_flag_name:
+            allow_post_reauth = waffle.flag_is_active(request, post_reauth_flag_name)
+
         backend_session = request.session.get(BACKEND_SESSION_KEY)
         is_oidc_enabled = True
         if backend_session:
             auth_backend = import_string(backend_session)
             is_oidc_enabled = issubclass(auth_backend, OIDCAuthenticationBackend)
 
-        maybe_require_get = not self.allow_post_reauth and request.method != 'GET'
+        maybe_require_get = not allow_post_reauth and request.method != 'GET'
         is_refreshable = (
             not maybe_require_get
             and request.user.is_authenticated
@@ -381,52 +378,45 @@ class OIDCRefreshSession(SessionRefresh):
         return is_refreshable and request.session.get(OIDC_REFRESH_TOKEN_KEY)
 
     def is_expired(self, request):
-        expiration = request.session.get('oidc_id_token_expiration', 0)
+        expiration = request.session.get(OIDC_ID_TOKEN_EXP_KEY, 0)
         now = time()
         return expiration > 0 and now >= expiration
 
-    def process_request(self, request):
+    def process_request(self, request) -> Optional[HttpResponse]:
         """Handle a refresh session request. If it's not refreshable or the token is not expired then we skip this
         and deal with the consequences elsewhere"""
 
         # Load and check feature flags
         introspect_flag_name = import_from_settings('WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST')
-        post_reauth_flag_name = import_from_settings('WAFFLE_FLAG_ALLOW_POST_REAUTH')
+        enable_per_request_introspect = False
         if introspect_flag_name:
-            self.enable_per_request_introspect = waffle.flag_is_active(request, introspect_flag_name)
-        if post_reauth_flag_name:
-            self.allow_post_reauth = waffle.flag_is_active(request, post_reauth_flag_name)
+            enable_per_request_introspect = waffle.flag_is_active(request, introspect_flag_name)
 
         if not self.is_refreshable_url(request):
-            self.set_exit_state(self.EXIT_STATES.NOT_REFRESHABLE)
+            self.set_exit_state(request, self.EXIT_STATES.NOT_REFRESHABLE)
             logging.debug('request is not refreshable')
-            return
+            return None
 
         refresh_token = request.session.get(OIDC_REFRESH_TOKEN_KEY)
         access_token = request.session.get(OIDC_ACCESS_TOKEN_KEY)
         is_expired = self.is_expired(request)
 
-        # Only introspect the token if the local exp claim is expired (and the feature flag is enabled.)
-        if not is_expired and self.enable_per_request_introspect:
-            if _is_token_active(access_token):
-                self.set_exit_state(self.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
-                logging.debug('access token introspect is active')
-                return
-
-            # If the refresh token does not exist, or if it's not active then we need a reauth
-            refresh_token_is_active = _is_token_active(refresh_token, TokenHintType.REFRESH_TOKEN)
-            if not refresh_token_is_active:
-                logging.debug('refresh token is not active')
-                return self.finish(request, prompt_reauth=True)
-        elif not is_expired:
-            self.set_exit_state(self.EXIT_STATES.NOT_EXPIRED)
-            return
+        # The request is ok, we can exit early.
+        if not is_expired and not enable_per_request_introspect:
+            self.set_exit_state(request, self.EXIT_STATES.NOT_EXPIRED)
+            return None
 
         if not refresh_token:
             logging.debug('no refresh token stored')
             return self.finish(request, prompt_reauth=True)
 
         try:
+            # Check to see if we need to refresh the request
+            if enable_per_request_introspect and _is_token_active(access_token):
+                self.set_exit_state(request, self.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
+                logging.debug('access token introspect is active')
+                return None
+
             token_info = _request_refreshed_tokens(refresh_token)
         except requests.exceptions.Timeout:
             logging.debug('timed out refreshing access token')
@@ -460,9 +450,10 @@ class OIDCRefreshSession(SessionRefresh):
         refresh_token = token_info.get('refresh_token')
         store_tokens(request, access_token, id_token, refresh_token)
         logging.debug('access token has been refreshed!')
-        self.set_exit_state(self.EXIT_STATES.TOKEN_IS_STORED)
+        self.set_exit_state(request, self.EXIT_STATES.TOKEN_IS_STORED)
+        return None
 
-    def finish(self, request, prompt_reauth=True):
+    def finish(self, request, prompt_reauth=True) -> Optional[HttpResponse]:
         """Finish request handling and handle sending downstream responses for XHR.
 
         This function should only be run if the session is determined to
@@ -486,8 +477,7 @@ class OIDCRefreshSession(SessionRefresh):
             default_response = HttpResponseRedirect(refresh_url)
             xhr_response_json['refresh_url'] = refresh_url
 
-        if (request.headers.get('x-requested-with') == 'XMLHttpRequest' or 
-            'application/json' in request.headers.get('Accept', '')):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest' or request.accepts('application/json'):
             return JsonResponse(xhr_response_json, status=403)
         else:
             return default_response

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -1,3 +1,7 @@
+import waffle
+from enum import StrEnum
+from django.utils.module_loading import import_string
+from django.contrib.auth import BACKEND_SESSION_KEY
 from requests.auth import HTTPBasicAuth
 from json import JSONDecodeError
 from urllib.parse import urlencode, quote
@@ -14,7 +18,7 @@ from typing import Optional
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
-from django.http import HttpRequest, JsonResponse, HttpResponseRedirect
+from django.http import HttpRequest, JsonResponse, HttpResponseRedirect, HttpResponseForbidden
 from django.utils.translation import gettext_lazy as _
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from sentry_sdk import capture_exception
@@ -33,6 +37,39 @@ from mozilla_django_oidc.utils import add_state_and_verifier_and_nonce_to_sessio
 OIDC_ACCESS_TOKEN_KEY = 'oidc_access_token'
 OIDC_ID_TOKEN_KEY = 'oidc_id_token'
 OIDC_REFRESH_TOKEN_KEY = 'oidc_refresh_token'
+
+
+class TokenHintType(StrEnum):
+    ACCESS_TOKEN = 'access_token'
+    REFRESH_TOKEN = 'refresh_token'
+
+
+def _is_token_active(token: str, token_hint: TokenHintType = TokenHintType.ACCESS_TOKEN) -> bool:
+    """POST the introspect route to and see if it returns 'active': True."""
+    if not token:
+        return False
+
+    token_payload = {
+        'token_type_hint': str(token_hint),
+        'client_id': import_from_settings('OIDC_RP_CLIENT_ID'),
+        'client_secret': import_from_settings('OIDC_RP_CLIENT_SECRET'),
+        'token': token,
+    }
+
+    req_auth = None
+    if import_from_settings('OIDC_TOKEN_USE_BASIC_AUTH', False):
+        # Basic-auth clients send credentials in the header, not the body.
+        req_auth = HTTPBasicAuth(token_payload['client_id'], token_payload.pop('client_secret'))
+
+    response = requests.post(
+        f'{import_from_settings("OIDC_OP_TOKEN_ENDPOINT")}introspect',
+        auth=req_auth,
+        data=token_payload,
+        verify=import_from_settings('OIDC_VERIFY_SSL', True),
+    )
+    response.raise_for_status()
+    resp = response.json()
+    return resp.get('active') or False
 
 
 def store_tokens(request, access_token, id_token, refresh_token):
@@ -301,9 +338,44 @@ class OIDCRefreshSession(SessionRefresh):
     Code is based on https://github.com/mozilla/mozilla-django-oidc/pull/377
     """
 
+    class EXIT_STATES(StrEnum):
+        """Exit states because for process_request.
+        If process_request doesn't return falsey it'll be treated as override response. 
+        We want to test for positions...
+
+        This is only used in testing."""
+        NOT_REFRESHABLE = 'not-refreshable'
+        NOT_EXPIRED = 'not-expired'
+        ACCESS_TOKEN_IS_ACTIVE = 'access-token-is-active'
+        TOKEN_IS_STORED = 'token-is-stored'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.enable_per_request_introspect = False
+        self.allow_post_reauth = False
+        self.exit_state = None
+
+    def set_exit_state(self, state: EXIT_STATES):
+        if not import_from_settings('IS_TEST'):
+            return
+        self.exit_state = state
+
     def is_refreshable_url(self, request):
         """Is the session refreshable, and do we have a refresh token?"""
-        is_refreshable = super().is_refreshable_url(request)
+        backend_session = request.session.get(BACKEND_SESSION_KEY)
+        is_oidc_enabled = True
+        if backend_session:
+            auth_backend = import_string(backend_session)
+            is_oidc_enabled = issubclass(auth_backend, OIDCAuthenticationBackend)
+
+        maybe_require_get = not self.allow_post_reauth and request.method != 'GET'
+        is_refreshable = (
+            not maybe_require_get
+            and request.user.is_authenticated
+            and is_oidc_enabled
+            and request.path not in self.exempt_urls
+            and not any(pat.match(request.path) for pat in self.exempt_url_patterns)
+        )
         return is_refreshable and request.session.get(OIDC_REFRESH_TOKEN_KEY)
 
     def is_expired(self, request):
@@ -314,14 +386,38 @@ class OIDCRefreshSession(SessionRefresh):
     def process_request(self, request):
         """Handle a refresh session request. If it's not refreshable or the token is not expired then we skip this
         and deal with the consequences elsewhere"""
+
+        # Load and check feature flags
+        introspect_flag_name = import_from_settings('WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST')
+        post_reauth_flag_name = import_from_settings('WAFFLE_FLAG_ALLOW_POST_REAUTH')
+        if introspect_flag_name:
+            self.enable_per_request_introspect = waffle.flag_is_active(request, introspect_flag_name)
+        if post_reauth_flag_name:
+            self.allow_post_reauth = waffle.flag_is_active(request, post_reauth_flag_name)
+
         if not self.is_refreshable_url(request):
+            self.set_exit_state(self.EXIT_STATES.NOT_REFRESHABLE)
             logging.debug('request is not refreshable')
             return
 
-        if not self.is_expired(request):
-            return
-
         refresh_token = request.session.get(OIDC_REFRESH_TOKEN_KEY)
+        is_expired = self.is_expired(request)
+
+        # Only introspect the token if the local exp claim is expired (and the feature flag is enabled.)
+        if not is_expired and self.enable_per_request_introspect:
+            if _is_token_active(request.session.get(OIDC_ACCESS_TOKEN_KEY)):
+                self.set_exit_state(self.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
+                logging.debug('access token introspect is active')
+                return
+
+            # If the refresh token does not exist, or if it's not active then we need a reauth
+            refresh_token_is_active = not _is_token_active(refresh_token, TokenHintType.REFRESH_TOKEN)
+            if not refresh_token or not refresh_token_is_active:
+                logging.debug('refresh token is not active')
+                return self.finish(request, prompt_reauth=True)
+        elif not is_expired:
+            self.set_exit_state(self.EXIT_STATES.NOT_EXPIRED)
+            return
 
         if not refresh_token:
             logging.debug('no refresh token stored')
@@ -334,7 +430,12 @@ class OIDCRefreshSession(SessionRefresh):
             # Don't prompt for reauth as this could be a temporary problem
             return self.finish(request, prompt_reauth=False)
         except requests.exceptions.HTTPError as exc:
-            status_code = exc.response.status_code
+            # exc.response can return None here if we check it despite it returning a value...
+            # So wrap this in a try/except to keep errors at bay.
+            try:
+                status_code = exc.response.status_code
+            except AttributeError:
+                status_code = 400 # Force a 400
             logging.debug('http error %s when refreshing access token', status_code)
             # OAuth error response will be a 400 for various situations, including
             # an expired token. https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
@@ -355,11 +456,12 @@ class OIDCRefreshSession(SessionRefresh):
         access_token = token_info.get('access_token')
         refresh_token = token_info.get('refresh_token')
         store_tokens(request, access_token, id_token, refresh_token)
+        self.set_exit_state(self.EXIT_STATES.TOKEN_IS_STORED)
 
     def finish(self, request, prompt_reauth=True):
         """Finish request handling and handle sending downstream responses for XHR.
 
-        This function should only be run if the session is determind to
+        This function should only be run if the session is determined to
         be expired.
 
         Almost all XHR request handling in client-side code struggles
@@ -372,9 +474,10 @@ class OIDCRefreshSession(SessionRefresh):
         middleware doesn't really want the user in if they don't
         refresh their session.
         """
-        default_response = None
+        # is_redirectable = request.method == 'GET'
+        default_response = HttpResponseForbidden()
         xhr_response_json = {'error': 'the authentication session has expired'}
-        if prompt_reauth:
+        if prompt_reauth:  # and is_redirectable:
             # The id_token has expired, so we have to re-authenticate silently.
             refresh_url = self._prepare_reauthorization(request)
             default_response = HttpResponseRedirect(refresh_url)

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -77,16 +77,14 @@ def store_tokens(request, access_token, id_token, refresh_token):
     Mostly copy and paste from base package, but adjusted to live outside of OIDCAuthenticationBackend,
     and take in refresh_token
     """
-    session = request.session
-
     if import_from_settings('OIDC_STORE_ACCESS_TOKEN', False):
-        session[OIDC_ACCESS_TOKEN_KEY] = access_token
+        request.session[OIDC_ACCESS_TOKEN_KEY] = access_token
 
     if import_from_settings('OIDC_STORE_ID_TOKEN', False):
-        session[OIDC_ID_TOKEN_KEY] = id_token
+        request.session[OIDC_ID_TOKEN_KEY] = id_token
 
     if import_from_settings('OIDC_STORE_REFRESH_TOKEN', False):
-        session[OIDC_REFRESH_TOKEN_KEY] = refresh_token
+        request.session[OIDC_REFRESH_TOKEN_KEY] = refresh_token
 
     expiration_interval = import_from_settings('OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS', 60 * 15)
     request.session['oidc_id_token_expiration'] = time() + expiration_interval
@@ -340,10 +338,11 @@ class OIDCRefreshSession(SessionRefresh):
 
     class EXIT_STATES(StrEnum):
         """Exit states because for process_request.
-        If process_request doesn't return falsey it'll be treated as override response. 
+        If process_request doesn't return falsey it'll be treated as override response.
         We want to test for positions...
 
         This is only used in testing."""
+
         NOT_REFRESHABLE = 'not-refreshable'
         NOT_EXPIRED = 'not-expired'
         ACCESS_TOKEN_IS_ACTIVE = 'access-token-is-active'
@@ -356,6 +355,9 @@ class OIDCRefreshSession(SessionRefresh):
         self.exit_state = None
 
     def set_exit_state(self, state: EXIT_STATES):
+        """Sets an exit state on the middleware, and by using the power of code you can inspect it later!
+
+        This function is a noop outside of testing environments."""
         if not import_from_settings('IS_TEST'):
             return
         self.exit_state = state
@@ -401,18 +403,19 @@ class OIDCRefreshSession(SessionRefresh):
             return
 
         refresh_token = request.session.get(OIDC_REFRESH_TOKEN_KEY)
+        access_token = request.session.get(OIDC_ACCESS_TOKEN_KEY)
         is_expired = self.is_expired(request)
 
         # Only introspect the token if the local exp claim is expired (and the feature flag is enabled.)
         if not is_expired and self.enable_per_request_introspect:
-            if _is_token_active(request.session.get(OIDC_ACCESS_TOKEN_KEY)):
+            if _is_token_active(access_token):
                 self.set_exit_state(self.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
                 logging.debug('access token introspect is active')
                 return
 
             # If the refresh token does not exist, or if it's not active then we need a reauth
-            refresh_token_is_active = not _is_token_active(refresh_token, TokenHintType.REFRESH_TOKEN)
-            if not refresh_token or not refresh_token_is_active:
+            refresh_token_is_active = _is_token_active(refresh_token, TokenHintType.REFRESH_TOKEN)
+            if not refresh_token_is_active:
                 logging.debug('refresh token is not active')
                 return self.finish(request, prompt_reauth=True)
         elif not is_expired:
@@ -435,8 +438,8 @@ class OIDCRefreshSession(SessionRefresh):
             try:
                 status_code = exc.response.status_code
             except AttributeError:
-                status_code = 400 # Force a 400
-            logging.debug('http error %s when refreshing access token', status_code)
+                status_code = 400  # Force a 400
+            logging.debug(f'http error {status_code} when refreshing access token')
             # OAuth error response will be a 400 for various situations, including
             # an expired token. https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
             return self.finish(request, prompt_reauth=(status_code == 400))
@@ -445,7 +448,7 @@ class OIDCRefreshSession(SessionRefresh):
             # Don't prompt for reauth as this could be a temporary problem
             return self.finish(request, prompt_reauth=False)
         except Exception as exc:
-            logging.debug('unknown error occurred when refreshing access token: %s', exc)
+            logging.debug(f'unknown error occurred when refreshing access token: {exc}')
             # Don't prompt for reauth as this could be a temporary problem
             return self.finish(request, prompt_reauth=False)
 
@@ -474,20 +477,17 @@ class OIDCRefreshSession(SessionRefresh):
         middleware doesn't really want the user in if they don't
         refresh their session.
         """
-        # is_redirectable = request.method == 'GET'
         default_response = HttpResponseForbidden()
-        xhr_response_json = {'error': 'the authentication session has expired'}
-        if prompt_reauth:  # and is_redirectable:
+        xhr_response_json = {'error': 'the authentication session has expired', 'type': 'auth_error'}
+        if prompt_reauth:
             # The id_token has expired, so we have to re-authenticate silently.
             refresh_url = self._prepare_reauthorization(request)
             default_response = HttpResponseRedirect(refresh_url)
             xhr_response_json['refresh_url'] = refresh_url
 
-        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
-            xhr_response = JsonResponse(xhr_response_json, status=403)
-            if 'refresh_url' in xhr_response_json:
-                xhr_response['refresh_url'] = xhr_response_json['refresh_url']
-            return xhr_response
+        if (request.headers.get('x-requested-with') == 'XMLHttpRequest' or 
+            'application/json' in request.headers.get('Accept', '')):
+            return JsonResponse(xhr_response_json, status=403)
         else:
             return default_response
 
@@ -541,7 +541,11 @@ class OIDCRefreshSession(SessionRefresh):
 
         add_state_and_verifier_and_nonce_to_session(request, state, params, code_verifier)
 
-        request.session['oidc_login_next'] = request.get_full_path()
+        # Send json requests home after refresh, it sucks but this shouldn't happen often
+        if 'application/json' in request.headers.get('Accept', ''):
+            request.session['oidc_login_next'] = reverse('vue_app')
+        else:
+            request.session['oidc_login_next'] = request.get_full_path()
 
         query = urlencode(params, quote_via=quote)
         return f'{auth_url}?{query}'

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -350,6 +350,7 @@ class OIDCRefreshSession(SessionRefresh):
         """Sets an exit state on the middleware, and by using the power of code you can inspect it later!
 
         This function is a noop outside of testing environments."""
+        logging.debug(f'Setting exit state to [{state.value}]')
         if not import_from_settings('IS_TEST'):
             return
         request.session[EXIT_STATE_KEY] = state
@@ -477,7 +478,9 @@ class OIDCRefreshSession(SessionRefresh):
             default_response = HttpResponseRedirect(refresh_url)
             xhr_response_json['refresh_url'] = refresh_url
 
-        if request.headers.get('x-requested-with') == 'XMLHttpRequest' or request.accepts('application/json'):
+        preferred_response = request.get_preferred_type(['text/html', 'application/json'])
+
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest' or preferred_response == 'application/json':
             return JsonResponse(xhr_response_json, status=403)
         else:
             return default_response

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -140,7 +140,7 @@ class OIDCRefreshSessionTestCase(TestCase):
         self.assertIsNone(self.middleware.exit_state)
         self.assertIsNotNone(resp)
         # Ensure that we're redirecting to auth
-        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.status_code, 403)
 
     @patch('thunderbird_accounts.authentication.middleware.requests.post')
     @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -19,6 +19,7 @@ from thunderbird_accounts.authentication.middleware import (
     AccountsOIDCBackend,
     refresh_user_access_token,
     OIDCRefreshSession,
+    EXIT_STATE_KEY, OIDC_ACCESS_TOKEN_KEY, OIDC_REFRESH_TOKEN_KEY, OIDC_ID_TOKEN_EXP_KEY,
 )
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.authentication.models import AllowListEntry
@@ -81,9 +82,9 @@ class OIDCRefreshSessionTestCase(TestCase):
     def test_introspect_does_not_happen_without_feature_flag(self, mock_post: MagicMock):
         """This should hit the 'not expired' check and do nothing."""
         session = {
-            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
-            'oidc_access_token': 'abc123',
-            'oidc_refresh_token': 'abc456',
+            OIDC_ID_TOKEN_EXP_KEY: (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            OIDC_ACCESS_TOKEN_KEY: 'abc123',
+            OIDC_REFRESH_TOKEN_KEY: 'abc456',
         }
 
         mock_post.side_effect = AssertionError('request.post should not get called!')
@@ -92,7 +93,7 @@ class OIDCRefreshSessionTestCase(TestCase):
         request.session = session
         request.user = self.user
         resp = self.middleware.process_request(request)
-        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.NOT_EXPIRED)
+        self.assertEqual(request.session.get(EXIT_STATE_KEY), OIDCRefreshSession.EXIT_STATES.NOT_EXPIRED)
         self.assertIsNone(resp)
 
     @patch('thunderbird_accounts.authentication.middleware.requests.post')
@@ -101,9 +102,9 @@ class OIDCRefreshSessionTestCase(TestCase):
     def test_introspect_does_happen_if_feature_flag_is_set(self, mock_post: MagicMock):
         """This should hit a request.post, and our expected result for this test is the token is active."""
         session = {
-            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
-            'oidc_access_token': 'abc123',
-            'oidc_refresh_token': 'abc456',
+            OIDC_ID_TOKEN_EXP_KEY: (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            OIDC_ACCESS_TOKEN_KEY: 'abc123',
+            OIDC_REFRESH_TOKEN_KEY: 'abc456',
         }
 
         mock_post.return_value = SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True})
@@ -112,35 +113,37 @@ class OIDCRefreshSessionTestCase(TestCase):
         request.session = session
         request.user = self.user
         resp = self.middleware.process_request(request)
-        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
+        self.assertEqual(request.session.get(EXIT_STATE_KEY), OIDCRefreshSession.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
         self.assertIsNone(resp)
 
     @patch('thunderbird_accounts.authentication.middleware.requests.post')
     @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)
     @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, True)
     def test_introspect_if_access_token_is_inactive(self, mock_post: MagicMock):
-        """This should hit a request.post, and our expected result for this test is the token is active."""
+        """This should hit a request.post fail due to token being inactive, and refresh successfully."""
         session = {
-            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
-            'oidc_access_token': 'abc123',
-            'oidc_refresh_token': 'abc456',
+            OIDC_ID_TOKEN_EXP_KEY: (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            OIDC_ACCESS_TOKEN_KEY: 'abc123',
+            OIDC_REFRESH_TOKEN_KEY: 'abc456',
         }
+        original_access_token = session.get(OIDC_ACCESS_TOKEN_KEY)
 
         mock_post.side_effect = [
             # Access token check
             SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
-            # Refresh token check
-            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True}),
+            # Refreshing access token
+            SimpleNamespace(
+                raise_for_status=lambda: None,
+                json=lambda: {'access_token': 'abc789', 'refresh_token': session.get('oidc_refresh_token')},
+            ),
         ]
 
         request = self.factory.get('/')
         request.session = session
         request.user = self.user
         resp = self.middleware.process_request(request)
-        self.assertIsNone(self.middleware.exit_state)
-        self.assertIsNotNone(resp)
-        # Ensure that we're redirecting to auth
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(request.session.get(EXIT_STATE_KEY), OIDCRefreshSession.EXIT_STATES.TOKEN_IS_STORED)
+        self.assertNotEqual(request.session.get(OIDC_ACCESS_TOKEN_KEY), original_access_token)
 
     @patch('thunderbird_accounts.authentication.middleware.requests.post')
     @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)
@@ -148,48 +151,51 @@ class OIDCRefreshSessionTestCase(TestCase):
     def test_allow_post_reauth_does_not_happen_without_feature_flag(self, mock_post: MagicMock):
         """Try posting without this feature flag. It should set a "not refreshable" state."""
         session = {
-            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
-            'oidc_access_token': 'abc123',
-            'oidc_refresh_token': 'abc456',
+            OIDC_ID_TOKEN_EXP_KEY: (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            OIDC_ACCESS_TOKEN_KEY: 'abc123',
+            OIDC_REFRESH_TOKEN_KEY: 'abc456',
         }
 
         mock_post.side_effect = [
             # Access token check
             SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
-            # Refresh token check
-            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True}),
+            # Refreshing access token
+            AssertionError('This request should not happen!')
         ]
 
         request = self.factory.post('/')
         request.session = session
         request.user = self.user
         resp = self.middleware.process_request(request)
-        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.NOT_REFRESHABLE)
+        self.assertEqual(request.session.get(EXIT_STATE_KEY), OIDCRefreshSession.EXIT_STATES.NOT_REFRESHABLE)
         self.assertIsNone(resp)
 
     @patch('thunderbird_accounts.authentication.middleware.requests.post')
     @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, True)
     @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, False)
     def test_allow_post_reauth_does_happen_with_feature_flag(self, mock_post: MagicMock):
-        """Try posting without this feature flag. It should set a "not refreshable" state."""
+        """Try posting with this feature flag. It should mention it's not expired."""
         session = {
-            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
-            'oidc_access_token': 'abc123',
-            'oidc_refresh_token': 'abc456',
+            OIDC_ID_TOKEN_EXP_KEY: (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            OIDC_ACCESS_TOKEN_KEY: 'abc123',
+            OIDC_REFRESH_TOKEN_KEY: 'abc456',
         }
 
         mock_post.side_effect = [
             # Access token check
             SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
-            # Refresh token check
-            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True}),
+            # Refreshing access token
+            SimpleNamespace(
+                raise_for_status=lambda: None,
+                json=lambda: {'access_token': 'abc789', 'refresh_token': session.get('oidc_refresh_token')},
+            ),
         ]
 
         request = self.factory.post('/')
         request.session = session
         request.user = self.user
         resp = self.middleware.process_request(request)
-        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.NOT_EXPIRED)
+        self.assertEqual(request.session.get(EXIT_STATE_KEY), OIDCRefreshSession.EXIT_STATES.NOT_EXPIRED)
         self.assertIsNone(resp)
 
 

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -1,3 +1,7 @@
+from django.contrib.auth.models import AnonymousUser
+import uuid
+import datetime
+from waffle.testutils import override_flag
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -8,10 +12,14 @@ from django.core.exceptions import PermissionDenied
 from django.forms import model_to_dict
 from django.http import HttpRequest
 from django.test import override_settings
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 
 
-from thunderbird_accounts.authentication.middleware import AccountsOIDCBackend, refresh_user_access_token
+from thunderbird_accounts.authentication.middleware import (
+    AccountsOIDCBackend,
+    refresh_user_access_token,
+    OIDCRefreshSession,
+)
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.authentication.models import AllowListEntry
 
@@ -48,6 +56,141 @@ class RefreshUserAccessTokenTestCase(TestCase):
         # A dead SSO session yields a 400 from the token endpoint.
         mock_post.side_effect = requests.exceptions.HTTPError('400 Bad Request')
         self.assertIsNone(refresh_user_access_token(self._request(oidc_refresh_token='dead-refresh')))
+
+
+@override_settings(
+    OIDC_STORE_ACCESS_TOKEN=True,
+    OIDC_STORE_REFRESH_TOKEN=True,
+    OIDC_OP_TOKEN_ENDPOINT='https://keycloak.example/token',
+    OIDC_RP_CLIENT_ID='client',
+    OIDC_RP_CLIENT_SECRET='secret',
+)
+class OIDCRefreshSessionTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        get_response = MagicMock()
+        self.middleware = OIDCRefreshSession(get_response)
+
+        email = f'{uuid.uuid4()}@example.org'
+        self.user = User.objects.create(username=f'{email}@example.org', email=f'{email}@example.org')
+        self.anonymous_user = AnonymousUser()
+
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)
+    @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, False)
+    def test_introspect_does_not_happen_without_feature_flag(self, mock_post: MagicMock):
+        """This should hit the 'not expired' check and do nothing."""
+        session = {
+            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            'oidc_access_token': 'abc123',
+            'oidc_refresh_token': 'abc456',
+        }
+
+        mock_post.side_effect = AssertionError('request.post should not get called!')
+
+        request = self.factory.get('/')
+        request.session = session
+        request.user = self.user
+        resp = self.middleware.process_request(request)
+        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.NOT_EXPIRED)
+        self.assertIsNone(resp)
+
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)
+    @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, True)
+    def test_introspect_does_happen_if_feature_flag_is_set(self, mock_post: MagicMock):
+        """This should hit a request.post, and our expected result for this test is the token is active."""
+        session = {
+            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            'oidc_access_token': 'abc123',
+            'oidc_refresh_token': 'abc456',
+        }
+
+        mock_post.return_value = SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True})
+
+        request = self.factory.get('/')
+        request.session = session
+        request.user = self.user
+        resp = self.middleware.process_request(request)
+        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.ACCESS_TOKEN_IS_ACTIVE)
+        self.assertIsNone(resp)
+
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)
+    @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, True)
+    def test_introspect_if_access_token_is_inactive(self, mock_post: MagicMock):
+        """This should hit a request.post, and our expected result for this test is the token is active."""
+        session = {
+            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            'oidc_access_token': 'abc123',
+            'oidc_refresh_token': 'abc456',
+        }
+
+        mock_post.side_effect = [
+            # Access token check
+            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
+            # Refresh token check
+            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True}),
+        ]
+
+        request = self.factory.get('/')
+        request.session = session
+        request.user = self.user
+        resp = self.middleware.process_request(request)
+        self.assertIsNone(self.middleware.exit_state)
+        self.assertIsNotNone(resp)
+        # Ensure that we're redirecting to auth
+        self.assertEqual(resp.status_code, 302)
+
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, False)
+    @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, False)
+    def test_allow_post_reauth_does_not_happen_without_feature_flag(self, mock_post: MagicMock):
+        """Try posting without this feature flag. It should set a "not refreshable" state."""
+        session = {
+            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            'oidc_access_token': 'abc123',
+            'oidc_refresh_token': 'abc456',
+        }
+
+        mock_post.side_effect = [
+            # Access token check
+            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
+            # Refresh token check
+            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True}),
+        ]
+
+        request = self.factory.post('/')
+        request.session = session
+        request.user = self.user
+        resp = self.middleware.process_request(request)
+        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.NOT_REFRESHABLE)
+        self.assertIsNone(resp)
+
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    @override_flag(settings.WAFFLE_FLAG_ALLOW_POST_REAUTH, True)
+    @override_flag(settings.WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST, False)
+    def test_allow_post_reauth_does_happen_with_feature_flag(self, mock_post: MagicMock):
+        """Try posting without this feature flag. It should set a "not refreshable" state."""
+        session = {
+            'oidc_id_token_expiration': (datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30)).timestamp(),
+            'oidc_access_token': 'abc123',
+            'oidc_refresh_token': 'abc456',
+        }
+
+        mock_post.side_effect = [
+            # Access token check
+            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
+            # Refresh token check
+            SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': True}),
+        ]
+
+        request = self.factory.post('/')
+        request.session = session
+        request.user = self.user
+        resp = self.middleware.process_request(request)
+        self.assertEqual(self.middleware.exit_state, OIDCRefreshSession.EXIT_STATES.NOT_EXPIRED)
+        self.assertIsNone(resp)
 
 
 @override_settings(USE_ALLOW_LIST=True)

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -141,7 +141,7 @@ class OIDCRefreshSessionTestCase(TestCase):
         request = self.factory.get('/')
         request.session = session
         request.user = self.user
-        resp = self.middleware.process_request(request)
+        self.middleware.process_request(request)
         self.assertEqual(request.session.get(EXIT_STATE_KEY), OIDCRefreshSession.EXIT_STATES.TOKEN_IS_STORED)
         self.assertNotEqual(request.session.get(OIDC_ACCESS_TOKEN_KEY), original_access_token)
 

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -19,7 +19,10 @@ from thunderbird_accounts.authentication.middleware import (
     AccountsOIDCBackend,
     refresh_user_access_token,
     OIDCRefreshSession,
-    EXIT_STATE_KEY, OIDC_ACCESS_TOKEN_KEY, OIDC_REFRESH_TOKEN_KEY, OIDC_ID_TOKEN_EXP_KEY,
+    EXIT_STATE_KEY,
+    OIDC_ACCESS_TOKEN_KEY,
+    OIDC_REFRESH_TOKEN_KEY,
+    OIDC_ID_TOKEN_EXP_KEY,
 )
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.authentication.models import AllowListEntry
@@ -160,7 +163,7 @@ class OIDCRefreshSessionTestCase(TestCase):
             # Access token check
             SimpleNamespace(raise_for_status=lambda: None, json=lambda: {'active': False}),
             # Refreshing access token
-            AssertionError('This request should not happen!')
+            AssertionError('This request should not happen!'),
         ]
 
         request = self.factory.post('/')

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -412,9 +412,7 @@ if AUTH_SCHEME == 'oidc':
     # the bearer — Keycloak scopes them to the token subject. Defaults to the admin API
     # host with the admin path swapped for the realm path; override with KEYCLOAK_URL_REALM.
     KEYCLOAK_REALM_ENDPOINT = os.getenv('KEYCLOAK_URL_REALM') or (
-        f'{KEYCLOAK_API_ENDPOINT.replace("/admin/realms/", "/realms/").rstrip("/")}/'
-        if KEYCLOAK_API_ENDPOINT
-        else None
+        f'{KEYCLOAK_API_ENDPOINT.replace("/admin/realms/", "/realms/").rstrip("/")}/' if KEYCLOAK_API_ENDPOINT else None
     )
 
     # Base URL for the keycloak-mfa-rest provider, mounted on the realm path
@@ -624,8 +622,8 @@ CELERY_BEAT_SCHEDULE = {
     },
     'purge-stale-test-allow-list-entries': {
         'task': 'thunderbird_accounts.authentication.tasks.purge_stale_test_allow_list_entries',
-        'schedule': crontab(), # Every minute
-    }
+        'schedule': crontab(),  # Every minute
+    },
 }
 
 if POSTHOG_API_KEY:
@@ -700,3 +698,12 @@ CONTACT_SUPPORT_ONLY_FOR_ALLOW_LISTED_USERS = True
 # Allow list entries (and user's created from those entries) with ``is_test_account=True``
 # become stale and are removed in a cron job after this many hours
 TEST_ALLOW_LIST_ENTRIES_STALE_TIME_IN_MINS = 5
+
+# Waffle flag constants
+# These still have to be created on each environment to be True.
+
+# POST OIDC's token introspect route to see if a token is actually active.
+WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST = 'auth-introspect-token-per-request'
+
+# Allow auth middleware to try and refresh an inactive access token with an active refresh token during non-get requests
+WAFFLE_FLAG_ALLOW_POST_REAUTH = 'auth-allow-post-reauth'

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -708,3 +708,12 @@ CONTACT_SUPPORT_ONLY_FOR_ALLOW_LISTED_USERS = True
 # Allow list entries (and user's created from those entries) with ``is_test_account=True``
 # become stale and are removed in a cron job after this many hours
 TEST_ALLOW_LIST_ENTRIES_STALE_TIME_IN_MINS = 5
+
+# Waffle flag constants
+# These still have to be created on each environment to be True.
+
+# POST OIDC's token introspect route to see if a token is actually active.
+WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST = 'auth-introspect-token-per-request'
+
+# Allow auth middleware to try and refresh an inactive access token with an active refresh token during non-get requests
+WAFFLE_FLAG_ALLOW_POST_REAUTH = 'auth-allow-post-reauth'


### PR DESCRIPTION
Fixes #380 (Add middleware to introspect current access token)
Fixes #1053 (Allow refresh token to be used if the request is not GET)

* `auth-introspect-token-per-request` forces the middleware to introspect the token every request
* `auth-allow-post-reauth` allows the middleware to attempt to reauth on non-get requests

I've updated the middleware acquired from a mozilla-django-oidc PR to allow refreshing tokens on non-GET requests and making the middleware introspect the access/refresh token. These are both gated behind the above feature flags. 

To test add the feature flags listed above via [django admin panel](http://localhost:8087/admin/waffle/flag/) and set them to true. With a short-lived access token you should hopefully experience a better experience without being bumped to the login screen. Additionally if you invalidate your token (via password reset) it should pick up on it.

An easy way to test this is to remove the active session for the currently logged in user on keycloak's admin panel. (http://keycloak:8999/admin/master/console/#/tbpro/users/). On a refresh that user should be punted to the login screen with a "refresh token is not active" debug log entry listed in the console.

This code is kinda too complex imo, suggestions for streamlining while keeping it secure are welcome. I wanted to let us roll these changes back easily if needed, so that's why they're waffled.