### PR TITLE
Add polling time when verifying test has proceeded to the next sign-up step

### DIFF
--- a/test/e2e/pages/tb-accts-signup-page.ts
+++ b/test/e2e/pages/tb-accts-signup-page.ts
@@ -1,5 +1,5 @@
 import { type Page, type Locator, expect } from '@playwright/test';
-import { ACCTS_HUB_URL, ACCTS_SIGN_UP_URL } from '../const/constants';
+import { ACCTS_HUB_URL, ACCTS_SIGN_UP_URL, TIMEOUT_10_SECONDS } from '../const/constants';
 
 export class TbAcctsSignUpPage {
   readonly page: Page;
@@ -105,9 +105,15 @@ export class TbAcctsSignUpPage {
 
     await this.submitForm();
 
-    await expect.poll(async () => {
-      return await this.stepId.inputValue();
-    }).toBe('step-username');
+    await expect.poll(
+      async () => {
+        return await this.stepId.inputValue();
+      },
+      {
+        timeout: TIMEOUT_10_SECONDS,
+        message: 'waiting for the next step (username) to appear',
+      }
+    ).toBe('step-username');
   }
 
   /**
@@ -130,9 +136,15 @@ export class TbAcctsSignUpPage {
     }
     
     // we expect to be on the next step; need time for the next page/step to load (will timeout if fails)
-    await expect.poll(async () => {
-      return await this.stepId.inputValue();
-    }).toBe('step-password');
+    await expect.poll(
+      async () => {
+        return await this.stepId.inputValue();
+      },
+      {
+        timeout: TIMEOUT_10_SECONDS,
+        message: 'waiting for the next step (password) to appear',
+      }
+    ).toBe('step-password');
 
     await this.passwordInput?.fill(password);
     await this.passwordConfirmInput?.fill(passwordConfirm);
@@ -140,7 +152,9 @@ export class TbAcctsSignUpPage {
 
   async submitForm() { 
     // when clicking on android it won't click it unless we force it; but force doesn't work on ios
-    if (this.testPlatform.includes('android')) { 
+    console.log(`clicking '${await this.submitButton.innerText()}' button`);
+
+    if (this.testPlatform.includes('android')) {
       await this.submitButton.click({ force: true, clickCount: 1 });
     } else {
       await this.submitButton.click();


### PR DESCRIPTION
## What changed?
The new sign-up test was intermittently failing when running on Android Chrome. After investigating I noticed that the test is moving forward to the next sign-up step but not giving enough time for the next step to actually appear.

## Why?
When submitting the current sign-up step's form (i.e. clicking the 'setup account' or 'next' button to proceed to the next step) the test was immediately checking that the next step was active, but intermittently this wasn't giving enough time and the screen for the same step was still displayed / the next step's screen wasn't displayed yet, causing the test to fail.

The fix is to add a timeout in the polling that verifies we are on the next sign-up step, so it gives it a chance to proceed. Also adding some logging so we can see in the logs what button is actually being pressed when the test moves on to the next sign-up step, makes debugging easier.

## Applicable Issues
Fixes #1055.

## QA Log
Ran the sign-up test in BrowserStack on [Firefox desktop](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Tests+Firefox+Desktop/239?testListView=spec) and several times on [Android Chrome](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Tests+Android+Chrome/31?tab=sessions&testListView=spec) and didn't see the failure anymore.