### PR TITLE
Refactor notice-bar positioning in Keycloak Vue app

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
+++ b/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
@@ -97,10 +97,6 @@ section {
 
       .message-bar {
         margin-block-end: 1.5rem;
-
-        &:not(:has(:deep(.notice-bar))) {
-          display: none;
-        }
       }
 
       .logo-link {
@@ -112,7 +108,6 @@ section {
         .logo {
           height: 36px;
           width: auto;
-          transition: opacity 0.2s ease;
         }
       }
     }

--- a/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
+++ b/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 import ThundermailLogo from '@kc/svg/thundermail-logo-blue.svg';
+import MessageBar from '@kc/vue/components/MessageBar.vue';
 
 const clientUrl = window._page.currentView?.clientUrl;
-
 </script>
 
 <template>
@@ -18,6 +17,11 @@ const clientUrl = window._page.currentView?.clientUrl;
           <a :href="clientUrl" class="logo-link">
             <img :src="ThundermailLogo" alt="Thundermail" class="base-template__logo" />
           </a>
+
+          <div id="message-bar" class="message-bar">
+            <message-bar />
+          </div>
+
           <div class="panel-contents">
             <slot />
           </div>
@@ -66,7 +70,6 @@ section {
     width: 100%;
     height: auto;
     min-height: 100vh;
-    max-height: var(--max-card-height);
     display: flex;
     align-items: stretch;
     justify-content: center;
@@ -90,11 +93,25 @@ section {
       height: 100%;
       display: flex;
       flex-direction: column;
-      gap: 3rem;
+      gap: 2rem;
       padding: 6rem 2rem;
 
-      &:has(.notice-bar) {
-        padding: 6rem 2rem;
+      .message-bar {
+        &:not(:has(:deep(.notice-bar))) {
+          display: none;
+        }
+      }
+
+      .logo-link {
+        display: block;
+        text-decoration: none;
+        width: min-content;
+
+        .logo {
+          height: 36px;
+          width: auto;
+          transition: opacity 0.2s ease;
+        }
       }
     }
   }
@@ -146,13 +163,7 @@ section {
         min-height: auto;
 
         .panel {
-
-
-          padding: 6rem 10rem 5.625rem 6rem;
-
-          &:has(.notice-bar) {
-            padding: 6rem 10rem 5.625rem 6rem;
-          }
+          padding: 6rem 6rem 5.625rem 6rem;
         }
 
         .panel-contents {

--- a/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
+++ b/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
@@ -93,10 +93,11 @@ section {
       height: 100%;
       display: flex;
       flex-direction: column;
-      gap: 2rem;
       padding: 6rem 2rem;
 
       .message-bar {
+        margin-block-end: 1.5rem;
+
         &:not(:has(:deep(.notice-bar))) {
           display: none;
         }
@@ -106,6 +107,7 @@ section {
         display: block;
         text-decoration: none;
         width: min-content;
+        margin-block-end: 2rem;
 
         .logo {
           height: 36px;

--- a/keycloak/themes/tbpro/assets/vue/components/MessageBar.vue
+++ b/keycloak/themes/tbpro/assets/vue/components/MessageBar.vue
@@ -15,9 +15,3 @@ const messageType = computed(() => {
 <template>
   <notice-bar data-testid="notice-bar" class="notice-bar" :type="messageType" v-if="message?.type">{{ message?.summary }}</notice-bar>
 </template>
-
-<style scoped>
-.notice-bar {
-  margin-bottom: var(--space-12);
-}
-</style>

--- a/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
@@ -9,8 +9,6 @@ import {
 import { computed, ref, useTemplateRef } from "vue";
 import { i18n } from '@kc/composables/i18n.js';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
-import MessageBar from "@kc/vue/components/MessageBar.vue";
-
 const isManualMode = ref(false);
 const formAction = window._page.currentView?.formAction;
 const settingsForm = useTemplateRef('settings-form');
@@ -117,8 +115,6 @@ export default {
 
 
 <template>
-  <message-bar/>
-
   <h2>{{ $t('loginTotpTitle') }}</h2>
   <cancel-form ref="cancel-form" :action="formAction" cancelId="cancelTOTPBtn" cancelValue="true"
                 cancelName="cancel-aia"/>

--- a/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
@@ -197,18 +197,6 @@ export default {
 </template>
 
 <style scoped>
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-  }
-}
-
 h2 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/DeleteCredentialView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/DeleteCredentialView/index.vue
@@ -2,8 +2,6 @@
 import { DangerButton, PrimaryButton } from '@thunderbirdops/services-ui';
 import { useTemplateRef } from 'vue';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
-import MessageBar from '@kc/vue/components/MessageBar.vue';
-
 const formAction = window._page.currentView?.formAction;
 const loginForm = useTemplateRef('login-form');
 const cancelForm = useTemplateRef('cancel-form');
@@ -27,7 +25,6 @@ export default {
 </script>
 
 <template>
-  <message-bar/>
   <h2>{{ deleteCredentialTitle }}</h2>
   <cancel-form ref="cancel-form" :action="formAction" cancelId="kc-decline" cancelValue="$t('doCancel')"
                 cancelName="cancel-aia"/>

--- a/keycloak/themes/tbpro/assets/vue/views/DeleteCredentialView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/DeleteCredentialView/index.vue
@@ -40,18 +40,6 @@ export default {
 </template>
 
 <style scoped>
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-  }
-}
-
 h2 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/ErrorView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ErrorView/index.vue
@@ -38,20 +38,4 @@ h2 {
 .button-container {
   width: fit-content;
 }
-
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
 </style>

--- a/keycloak/themes/tbpro/assets/vue/views/ErrorView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ErrorView/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 import { BrandButton } from '@thunderbirdops/services-ui';
 import { PhArrowLeft } from '@phosphor-icons/vue';
 
@@ -14,8 +13,6 @@ export default {
 </script>
 
 <template>
-  <message-bar/>
-
   <h2>{{ $t('errorTitle') }}</h2>
   <template v-if="actionUrl">
     <div class="button-container">
@@ -29,14 +26,6 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 h2 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -74,22 +74,6 @@ h2 {
   margin: 0 0 1.5rem 0;
 }
 
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
-
 .form-elements {
   display: flex;
   flex-direction: column;

--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { TextInput, PrimaryButton, NoticeBar, NoticeBarTypes } from "@thunderbirdops/services-ui";
 import { ref, computed, useTemplateRef } from 'vue';
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 
 const errors = window._page.currentView?.errors;
 const formAction = window._page.currentView?.formAction;
@@ -30,7 +29,6 @@ export default {
 
 <template>
   <notice-bar :type="NoticeBarTypes.Critical" v-if="usernameError">{{ $t('forgotPasswordError') }}</notice-bar>
-  <message-bar v-else/>
 
   <h2>{{ $t('emailForgotTitle') }}</h2>
   <form
@@ -67,14 +65,6 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 h2 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/InfoView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/InfoView/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 import { BrandButton } from '@thunderbirdops/services-ui';
 import { PhArrowRight } from '@phosphor-icons/vue';
 import { computed } from 'vue';
@@ -39,7 +38,6 @@ export default {
     </h1>
     <p class="text" v-if="isVerifyEmailAction">{{ $t('infoVerifyEmailText') }}</p>
     <p class="text" v-else-if="isAccountUpdated">{{ $t('infoAccountUpdatedText') }}</p>
-    <message-bar v-if="messageHeader && messageHeader !== message?.summary" />
   </header>
   <main>
     <ul class="required-actions" v-if="!isSingleAction">
@@ -57,14 +55,6 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 .required-actions {
   margin: 0;
   margin-bottom: 1.5rem;

--- a/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { TextInput, PrimaryButton, LinkButton } from "@thunderbirdops/services-ui";
 import { computed, useTemplateRef } from "vue";
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
 
 const formAction = window._page.currentView?.formAction;
@@ -36,7 +35,6 @@ export default {
     <h2>{{ $t('authRecoveryCodeHeader') }}</h2>
     <form id="kc-recovery-code-login-form" ref="login-form" method="POST" :action="formAction" @submit.prevent="onSubmit"
           @keyup.enter="onSubmit">
-      <message-bar/>
       <div class="form-elements">
         <text-input data-testid="recovery-code-input" id="recoveryCodeInput" name="recoveryCodeInput"
                     autocomplete="off" required autofocus :error="recoveryError">

--- a/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { TextInput, PrimaryButton, SelectInput, LinkButton } from "@thunderbirdops/services-ui";
 import { computed, ref, useTemplateRef } from "vue";
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
 
 const errors = window._page.currentView?.errors;
@@ -38,7 +37,6 @@ export default {
     <h2>{{ $t('doLogIn') }}</h2>
     <form id="kc-form-login" ref="login-form" method="POST" :action="formAction" @submit.prevent="onSubmit"
           @keyup.enter="onSubmit">
-      <message-bar/>
       <div class="form-elements">
         <!-- #1011: with a single credential there's nothing to choose, so hide the
              selector (matches stock Keycloak's `userOtpCredentials?size gt 1` guard). -->

--- a/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
@@ -2,16 +2,13 @@
 import { ref, computed, useTemplateRef } from 'vue';
 import { TextInput, BrandButton, CheckboxInput, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import { PhArrowRight } from '@phosphor-icons/vue';
-import ThunderbirdLogoLight from '@kc/svg/thunderbird-pro-light.svg';
 import { TBPRO_WAIT_LIST } from '@kc/defines';
 
 const firstError = window._page.currentView?.firstError;
 const formAction = window._page.currentView?.formAction;
 const rememberMe = window._page.currentView?.rememberMe;
 const forgotPasswordUrl = window._page.currentView?.forgotPasswordUrl;
-const registerUrl = window._page.currentView?.registerUrl;
 const supportUrl = window._page.currentView?.supportUrl;
-const clientUrl = window._page.currentView?.clientUrl;
 const loginForm = useTemplateRef('login-form');
 const message = window._page?.message;
 const tbProPrimaryDomain = window._page.currentView?.tbProPrimaryDomain;

--- a/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
@@ -157,22 +157,6 @@ export default {
   margin-bottom: 1.5rem;
 }
 
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
-
 h2 {
   font-size: 2.25rem;
   font-family: metropolis;
@@ -188,7 +172,7 @@ form {
 }
 
 .forgot-password-link {
-  display: block;
+  display: inline-block;
   font-size: 0.6875rem;
   color: var(--colour-ti-muted);
   margin-block-end: 2rem;

--- a/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
@@ -2,7 +2,6 @@
 import { ref, computed, useTemplateRef } from 'vue';
 import { TextInput, BrandButton, CheckboxInput, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import { PhArrowRight } from '@phosphor-icons/vue';
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 import ThunderbirdLogoLight from '@kc/svg/thunderbird-pro-light.svg';
 import { TBPRO_WAIT_LIST } from '@kc/defines';
 
@@ -63,9 +62,8 @@ export default {
 </script>
 
 <template>
-  <notice-bar :type="NoticeBarTypes.Critical" v-if="firstError">{{ firstError }}</notice-bar>
-  <message-bar v-else-if="message?.type" />
-  <notice-bar :type="NoticeBarTypes.Info" v-else>
+  <notice-bar :type="NoticeBarTypes.Critical" v-if="firstError" class="notice-bar-login">{{ firstError }}</notice-bar>
+  <notice-bar :type="NoticeBarTypes.Info" v-else-if="!message?.type" class="notice-bar-login">
     <i18n-t keypath="inviteOnly" tag="span">
       <a :href="TBPRO_WAIT_LIST" data-testid="go-to-invite-only-url" target="_blank">{{ $t('inviteOnlyAction') }}</a>
     </i18n-t>
@@ -158,12 +156,8 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
+.notice-bar-login {
+  margin-bottom: 1.5rem;
 }
 
 .logo-link {

--- a/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
@@ -37,22 +37,6 @@ export default {
 </template>
 
 <style scoped>
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
-
 h2 {
   font-size: 2.25rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
@@ -1,8 +1,6 @@
 <script setup>
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import { useTemplateRef } from 'vue';
-import MessageBar from '@kc/vue/components/MessageBar.vue';
-
 const formAction = window._page.currentView?.formAction;
 const logoutForm = useTemplateRef('logout-form');
 
@@ -20,8 +18,6 @@ export default {
 </script>
 
 <template>
-  <message-bar />
-
   <h2>{{ $t('logoutConfirmTitle') }}</h2>
   <form id="kc-logout-confirm" ref="logout-form" method="POST" :action="formAction" @submit.prevent="onSubmit"
         @keyup.enter="onSubmit">
@@ -41,14 +37,6 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 .logo-link {
   display: block;
   text-decoration: none;

--- a/keycloak/themes/tbpro/assets/vue/views/PageExpiredView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/PageExpiredView/index.vue
@@ -1,6 +1,4 @@
 <script setup>
-import MessageBar from '@kc/vue/components/MessageBar.vue';
-
 const restartFlowUrl = window._page.currentView?.restartFlowUrl;
 const loginUrl = window._page.currentView?.loginUrl;
 </script>
@@ -12,8 +10,6 @@ export default {
 </script>
 
 <template>
-  <message-bar/>
-
   <h2>{{ $t('pageExpiredTitle') }}</h2>
   <div class="buttons">
     <p>{{ $t('pageExpiredMsg1') }} <a data-testid="restart-flow-url" :href="restartFlowUrl">{{ $t('doClickHere') }}</a></p>
@@ -22,14 +18,6 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 h2 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/PageExpiredView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/PageExpiredView/index.vue
@@ -27,22 +27,6 @@ h2 {
   margin: 0 0 1.5rem 0;
 }
 
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
-
 .buttons {
   margin-top: var(--space-24);
   width: 100%;

--- a/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
@@ -3,7 +3,6 @@ import { TextInput, BrandButton, NoticeBar, NoticeBarTypes } from '@thunderbirdo
 import { computed, ref, useTemplateRef } from 'vue';
 import { useRoute } from 'vue-router';
 import { PhArrowRight } from '@phosphor-icons/vue';
-import MessageBar from '@kc/vue/components/MessageBar.vue';
 
 const route = useRoute();
 
@@ -73,12 +72,9 @@ export default {
 
   <h2 data-testid="title">{{ $t('registerTitle') }}</h2>
 
-  <slot name="notice-bars">
-    <notice-bar data-testid="error-notice-bar" :type="NoticeBarTypes.Critical" v-if="usernameError || passwordError || passwordConfirmError || recoveryEmailError">
-      {{ $t('registerError') }}
-    </notice-bar>
-    <message-bar v-else/>
-  </slot>
+  <notice-bar data-testid="error-notice-bar" :type="NoticeBarTypes.Critical" v-if="usernameError || passwordError || passwordConfirmError || recoveryEmailError">
+    {{ $t('registerError') }}
+  </notice-bar>
 
   <form id="kc-register-form" ref="register-form" method="POST" :action="formAction" @submit.prevent="onSubmit"
         @keyup.enter="onSubmit">
@@ -158,14 +154,6 @@ export default {
 
 .hidden {
   display: none;
-}
-
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
 }
 
 .logo-link {

--- a/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
@@ -10,6 +10,7 @@ const errors = window._page.currentView?.errors;
 const formAction = window._page.currentView?.formAction;
 const tbProPrimaryDomain = `@${window._page.currentView?.tbProPrimaryDomain}`;
 const attributeValues = window._page.currentView?.attributes;
+const message = window._page?.message;
 
 // Fixed values
 const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
@@ -72,7 +73,11 @@ export default {
 
   <h2 data-testid="title">{{ $t('registerTitle') }}</h2>
 
-  <notice-bar data-testid="error-notice-bar" :type="NoticeBarTypes.Critical" v-if="usernameError || passwordError || passwordConfirmError || recoveryEmailError">
+  <notice-bar
+    data-testid="error-notice-bar"
+    :type="NoticeBarTypes.Critical"
+    v-if="!message?.type && (usernameError || passwordError || passwordConfirmError || recoveryEmailError)"
+  >
     {{ $t('registerError') }}
   </notice-bar>
 

--- a/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
@@ -156,22 +156,6 @@ export default {
   display: none;
 }
 
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
-
 h2 {
   font-size: 2.25rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/RouteNotImplementedView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RouteNotImplementedView/index.vue
@@ -1,6 +1,4 @@
 <script setup>
-import MessageBar from '@kc/vue/components/MessageBar.vue';
-
 console.error('Route not implemented', {
   pageId: window?._page?.pageId,
   page: window?._page,
@@ -16,22 +14,12 @@ export default {
 </script>
 
 <template>
-  <message-bar />
-
   <h1>{{ $t('routeNotImplementedTitle') }}</h1>
   <p>{{ $t('routeNotImplementedText1') }}</p>
   <p>{{ $t('routeNotImplementedText2') }}</p>
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 h1 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/RouteNotImplementedView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RouteNotImplementedView/index.vue
@@ -28,16 +28,4 @@ h1 {
   color: var(--colour-primary-default);
   margin: 0 0 1.5rem 0;
 }
-
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-  }
-}
 </style>

--- a/keycloak/themes/tbpro/assets/vue/views/SelectAuthenticatorView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/SelectAuthenticatorView/index.vue
@@ -1,6 +1,4 @@
 <script setup>
-import MessageBar from '@kc/vue/components/MessageBar.vue';
-
 const formAction = window._page.currentView?.formAction;
 
 // Surface the authenticator app first; recovery codes are a fallback. Falls back to
@@ -23,7 +21,6 @@ export default {
 <template>
   <div class="panel">
     <h2>{{ $t('loginChooseAuthenticator') }}</h2>
-    <message-bar/>
     <form method="POST" :action="formAction" class="select-auth-form">
       <button
         v-for="selection in authenticationSelections"

--- a/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
@@ -41,22 +41,6 @@ export default {
 </template>
 
 <style scoped>
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-
-    &:hover {
-      opacity: 0.8;
-    }
-  }
-}
-
 h2 {
   font-size: 1.5rem;
   font-family: metropolis;

--- a/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
@@ -1,8 +1,6 @@
 <script setup>
 import { TextInput, PrimaryButton, CheckboxInput } from "@thunderbirdops/services-ui";
 import { computed, useTemplateRef } from 'vue';
-import MessageBar from '@kc/vue/components/MessageBar.vue';
-
 const formAction = window._page.currentView?.formAction;
 const updatePasswordForm = useTemplateRef('update-password-form');
 const errors = window._page.currentView?.errors;
@@ -26,8 +24,6 @@ export default {
 
 
 <template>
-  <message-bar/>
-
   <h2>{{ $t('updatePasswordTitle') }}</h2>
   <form id="kc-passwd-update-form" ref="update-password-form" method="POST" :action="formAction" @submit.prevent="onSubmit" @keyup.enter="onSubmit">
     <div class="form-elements">
@@ -45,14 +41,6 @@ export default {
 </template>
 
 <style scoped>
-.notice-bar {
-  position: absolute;
-  top: 1rem;
-  left: 1.5rem;
-  right: 1.5rem;
-  z-index: 1;
-}
-
 .logo-link {
   display: block;
   text-decoration: none;

--- a/keycloak/themes/tbpro/assets/vue/views/VerifyEmailView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/VerifyEmailView/index.vue
@@ -57,18 +57,6 @@ h2 {
   margin: 0 0 1.5rem 0;
 }
 
-.logo-link {
-  display: block;
-  text-decoration: none;
-  margin-block-end: 2.8125rem;
-
-  .logo {
-    height: 36px;
-    width: auto;
-    transition: opacity 0.2s ease;
-  }
-}
-
 .buttons {
   margin-top: var(--space-24);
   width: 100%;


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Added `message-bar` component to the `BaseTemplate` and removed all the duplicated message-bars from all the views in the Keycloak vue app
- Updated the padding of the `panel-contents` section to be horizontally even (6rem). Approved by the design team!
- Fixed the logo spanning the whole width as a container causing potentially misclicks
- Fixed the "Forgot Password" link spanning the whole width as a container causing potentially misclicks
- Removed duplicated styles for `.notice-bar` and `.logo-link`
- Removed the `max-height` in the panel so that it can grow according to its content instead of overflowing. This is perhaps a bit controversial as the left side orb graphic grows a bit when a layout shift happens (I know @MelissaAutumn changed this purposely before). IMHO it is less jarring to have it grow rather than overflowing but can put it back if there's a counter argument for it.

> [!NOTE]
> Since this updates _all_ the Keycloak app notices, please peruse the app to help test. I did trigger some of them and they look fine for me though! 

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- To better approximate the Zeplin designs: https://zpl.io/6JQPMYy. Please note that there's some deviation from the input itself but that's on purpose as we still allow folks to sign up with their recovery email at this moment.
- Reduce duplicated code

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/1036
Fixes https://github.com/thunderbird/thunderbird-accounts/issues/1021

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

<img width="2926" height="1876" alt="image" src="https://github.com/user-attachments/assets/b4420e4f-7948-443d-95fe-9a2b4d37dcd2" />
