### PR TITLE
Don't reference the reason attribute which may not exist. (Sentry THUNDERBIRD-ACCOUNTS-8D)

### DIFF
--- a/src/thunderbird_accounts/authentication/tasks.py
+++ b/src/thunderbird_accounts/authentication/tasks.py
@@ -93,7 +93,7 @@ def tag_abandoned_cart_in_mailchimp(self):
             continue
         except Exception as ex:
             errors += 1
-            logger.exception(f'tag_abandoned_cart_in_mailchimp: failed to tag {user.uuid}: {ex.reason}')
+            logger.exception(f'tag_abandoned_cart_in_mailchimp: failed to tag {user.uuid}: {ex}')
             continue
         else:
             tagged += 1


### PR DESCRIPTION
Before, we could get "object has no attribute 'reason'"

Fixes: https://thunderbird.sentry.io/issues/7561475693/

## QA Log

- Reviewed f string syntax and stringification.
