### PR TITLE
Fix contact E2E test when running on dev stack

### DIFF
--- a/test/e2e/tests/desktop/contact.spec.ts
+++ b/test/e2e/tests/desktop/contact.spec.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { ContactPage } from '../../pages/contact-page';
 import { ensureWeAreSignedIn, overridePageData } from '../../utils/utils';
 
@@ -37,6 +37,18 @@ const verifyFormPostData = async (postData: string | null) => {
   expect(postData).toContain(MOCK_TYPE_VALUE);
   expect(postData).toContain('description');
   expect(postData).toContain(TEST_DESC);
+};
+
+const fakeBeingOnAllowList = async (page: Page) => {
+  // fake having our user on the allow list so we can actually submit the contact form
+  // only needed when running on local dev stack as our stage/prod test accounts are on allow list
+  await page.route('*/**/api/v1/contact/check-email-is-on-allow-list/', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ is_on_allow_list: true }),
+    });
+  });
 };
 
 
@@ -183,7 +195,11 @@ test.describe('contact support form on desktop browser', {
   });
 
   test('able to submit contact form successfully', async ({ page }) => {
-    test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack see issue 1058');
+    // we need our user to be on the allow list so we can submit
+    if (ACCTS_TARGET_ENV == 'dev') {
+      await fakeBeingOnAllowList(page);
+    }
+
     // go to the contact / submit an issue form and wait for it to load
     await contactPage.navigateToContactPage();
 
@@ -250,7 +266,11 @@ test.describe('contact support form on desktop browser', {
   });
 
   test('error handling works correctly', async ({ page }) => {
-    test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack see issue 1058');
+    // we need our user to be on the allow list so we can submit
+    if (ACCTS_TARGET_ENV == 'dev') {
+      await fakeBeingOnAllowList(page);
+    }
+
     // go to the contact / submit an issue form and wait for it to load
     await contactPage.navigateToContactPage();
     // capture the POST /contact/submit and mock an error response
@@ -284,7 +304,11 @@ test.describe('contact support form on desktop browser', {
   });
 
   test('able to submit contact form with attachments', async ({ page }) => {
-    test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack see issue 1058');
+    // we need our user to be on the allow list so we can submit
+    if (ACCTS_TARGET_ENV == 'dev') {
+      await fakeBeingOnAllowList(page);
+    }
+
     // go to the contact / submit an issue form and wait for it to load
     await contactPage.navigateToContactPage();
     // capture the POST /contact/submit and mock the response


### PR DESCRIPTION
## What changed?
Fix the contact E2E test so it works when running against a local dev stack (i.e. on PRs).

## Why?
The contact test was failing when running against a local dev stack (on PRs in CI and/or when running on local machine on local stack). The test is passing fine on stage/prod. The problem is the local user (admin@example.org) used by the E2E tests when running against local stack is not on the email allow list which is required in order to submit the contact form. The fix is, when running the test on a local dev stack mock the is-on-allow-list check to return true, so then the test can proceed and actually submit the contact form.

## Applicable Issues
Fixes #1058.

## QA Log

- Ran the updated contact test on my local machine against my local dev stack, test now passes
- Ran the updated contact test against stage, ensuring it still passes there as it always did
- You'll see when the E2E tests run in this PR's checks that the contact test now passes