### PR TITLE
🐛 Reload Stalwart after publishing DKIM records (platform-infrastructure#591)

### DIFF
--- a/src/thunderbird_accounts/mail/clients.py
+++ b/src/thunderbird_accounts/mail/clients.py
@@ -11,6 +11,7 @@ from thunderbird_accounts.mail.exceptions import (
     AccountNotFoundError,
     DomainNotFoundError,
     FailedToCreateDKIM,
+    FailedToReloadStalwart,
     StalwartError,
 )
 
@@ -236,6 +237,17 @@ class MailClient:
         self._raise_for_error(response)
         return response
 
+    def _reload(self):
+        response = requests.get(
+            f'{self.api_url}/reload/',
+            headers=self.authorized_headers,
+            verify=settings.VERIFY_PRIVATE_LINK_SSL,
+        )
+        response.raise_for_status()
+        self._raise_for_error(response)
+
+        return response
+
     def get_domain(self, domain):
         response = self._get_principal(domain)
 
@@ -261,6 +273,7 @@ class MailClient:
         dkim_algorithms = settings.STALWART_DKIM_ALGOS if algorithms is None else algorithms
         for algorithm in dkim_algorithms:
             data = {
+                # Stalwart 0.15, creates defaults IDs when ID is None. Ex: `$algo-$domain`
                 'id': None,
                 'algorithm': algorithm,
                 'domain': domain,
@@ -269,16 +282,21 @@ class MailClient:
             if settings.STALWART_DKIM_STAGE_MANAGEMENT_ENABLED:
                 data['stage'] = stage.value
 
-            response = requests.post(
-                f'{self.api_url}/dkim',
-                json=data,
-                headers=self.authorized_headers,
-                verify=settings.VERIFY_PRIVATE_LINK_SSL,
-            )
             try:
+                response = requests.post(
+                    f'{self.api_url}/dkim',
+                    json=data,
+                    headers=self.authorized_headers,
+                    verify=settings.VERIFY_PRIVATE_LINK_SSL,
+                )
                 response.raise_for_status()
             except requests.RequestException as exc:
                 raise FailedToCreateDKIM(algorithm, domain, str(exc)) from exc
+            try:
+                # Stalwart 0.15 requires reloading to sync persisent state with in-memory cache
+                self._reload()
+            except (requests.RequestException, StalwartError) as exc:
+                raise FailedToReloadStalwart(domain, str(exc), algorithm=algorithm) from exc
             response_data.append(response.json().get('data'))
         return response_data
 

--- a/src/thunderbird_accounts/mail/exceptions.py
+++ b/src/thunderbird_accounts/mail/exceptions.py
@@ -76,6 +76,22 @@ class FailedToCreateDKIM(StalwartError):
         return f'FailedToCreateDKIM: {self.algorithm} for {self.domain}'
 
 
+class FailedToReloadStalwart(StalwartError):
+    """Raise when Stalwart fails to reload persisted changes."""
+
+    domain: str
+    algorithm: str | None
+
+    def __init__(self, domain, details=None, algorithm=None, *args, **kwargs):
+        super().__init__(details, *args, **kwargs)
+        self.domain = domain
+        self.algorithm = algorithm
+
+    def __str__(self):
+        context = f' after {self.algorithm} DKIM creation' if self.algorithm else ''
+        return f'FailedToReloadStalwart: {self.domain}{context}'
+
+
 class HostedDkimPublishRetry(Exception):
     """Raise when hosted DKIM publication should be retried."""
 

--- a/src/thunderbird_accounts/mail/tests/test_clients.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients.py
@@ -4,7 +4,7 @@ import dns.resolver as dns_resolver
 from unittest.mock import MagicMock, patch
 from django.test import SimpleTestCase, override_settings, TestCase
 from thunderbird_accounts.mail.clients import DkimSignatureStage, MailClient, DomainVerificationErrors
-from thunderbird_accounts.mail.exceptions import FailedToCreateDKIM
+from thunderbird_accounts.mail.exceptions import FailedToCreateDKIM, FailedToReloadStalwart, StalwartError
 
 
 @override_settings(
@@ -221,18 +221,26 @@ class TestMailClientCreateDkim(TestCase):
         STALWART_DKIM_ALGO_SELECTORS={'Rsa': 'tm1', 'Ed25519': 'tm2'},
         STALWART_DKIM_STAGE_MANAGEMENT_ENABLED=True,
     )
+    @patch('requests.get')
     @patch('requests.post')
-    def test_success(self, requests_mock: MagicMock):
+    def test_success(self, requests_mock: MagicMock, requests_get_mock: MagicMock):
         success_response = requests.Response()
         success_response.status_code = 200
         success_response._content = b'{"data": {}}'
 
         requests_mock.return_value = success_response
 
+        success_reload_response = requests.Response()
+        success_reload_response.status_code = 200
+        success_reload_response._content = b'{"data": {"warnings": {}, "errors": {}}}'
+
+        requests_get_mock.return_value = success_reload_response
+
         response_data = self.mail_client.create_dkim(self.domain)
 
         self.assertIsNotNone(response_data)
         self.assertEqual(2, requests_mock.call_count)
+        self.assertEqual(2, requests_get_mock.call_count)
         self.assertEqual(
             [
                 {
@@ -252,13 +260,17 @@ class TestMailClientCreateDkim(TestCase):
             ],
             [call_args.kwargs['json'] for call_args in requests_mock.call_args_list],
         )
+        for call_args in requests_get_mock.call_args_list:
+            self.assertEqual(f'{self.mail_client.api_url}/reload/', call_args.args[0])
+            self.assertEqual(self.mail_client.authorized_headers, call_args.kwargs['headers'])
 
     @override_settings(
         STALWART_DKIM_ALGOS=['Ed25519'],
         STALWART_DKIM_ALGO_SELECTORS={'Ed25519': 'tm2'},
     )
+    @patch('requests.get')
     @patch('requests.post')
-    def test_failure_raises_failed_to_create_dkim(self, requests_mock: MagicMock):
+    def test_failure_raises_failed_to_create_dkim(self, requests_mock: MagicMock, requests_get_mock: MagicMock):
         failure_response = requests.Response()
         failure_response.status_code = 500
         failure_response.reason = 'Internal Server Error'
@@ -271,6 +283,82 @@ class TestMailClientCreateDkim(TestCase):
         self.assertEqual('Ed25519', cm.exception.algorithm)
         self.assertEqual(self.domain, cm.exception.domain)
         self.assertIsInstance(cm.exception.__cause__, requests.RequestException)
+        requests_get_mock.assert_not_called()
+
+    @override_settings(
+        STALWART_DKIM_ALGOS=['Ed25519'],
+        STALWART_DKIM_ALGO_SELECTORS={'Ed25519': 'tm2'},
+    )
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_request_failure_raises_failed_to_create_dkim(
+        self, requests_mock: MagicMock, requests_get_mock: MagicMock
+    ):
+        requests_mock.side_effect = requests.ConnectionError('Connection refused')
+
+        with self.assertRaises(FailedToCreateDKIM) as cm:
+            self.mail_client.create_dkim(self.domain)
+
+        self.assertEqual('Ed25519', cm.exception.algorithm)
+        self.assertEqual(self.domain, cm.exception.domain)
+        self.assertIsInstance(cm.exception.__cause__, requests.ConnectionError)
+        requests_get_mock.assert_not_called()
+
+    @override_settings(
+        STALWART_DKIM_ALGOS=['Ed25519'],
+        STALWART_DKIM_ALGO_SELECTORS={'Ed25519': 'tm2'},
+    )
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_reload_failure_raises_request_exception(
+        self, requests_mock: MagicMock, requests_get_mock: MagicMock
+    ):
+        success_response = requests.Response()
+        success_response.status_code = 200
+        success_response._content = b'{"data": {}}'
+
+        requests_mock.return_value = success_response
+
+        failure_reload_response = requests.Response()
+        failure_reload_response.status_code = 500
+        failure_reload_response.reason = 'Internal Server Error'
+
+        requests_get_mock.return_value = failure_reload_response
+
+        with self.assertRaises(FailedToReloadStalwart) as cm:
+            self.mail_client.create_dkim(self.domain)
+
+        self.assertEqual('Ed25519', cm.exception.algorithm)
+        self.assertEqual(self.domain, cm.exception.domain)
+        self.assertIsInstance(cm.exception.__cause__, requests.RequestException)
+
+    @override_settings(
+        STALWART_DKIM_ALGOS=['Ed25519'],
+        STALWART_DKIM_ALGO_SELECTORS={'Ed25519': 'tm2'},
+    )
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_reload_application_error_raises_failed_to_reload_stalwart(
+        self, requests_mock: MagicMock, requests_get_mock: MagicMock
+    ):
+        success_response = requests.Response()
+        success_response.status_code = 200
+        success_response._content = b'{"data": {}}'
+
+        requests_mock.return_value = success_response
+
+        failure_reload_response = requests.Response()
+        failure_reload_response.status_code = 200
+        failure_reload_response._content = b'{"error": "other", "details": "reload", "reason": "failed"}'
+
+        requests_get_mock.return_value = failure_reload_response
+
+        with self.assertRaises(FailedToReloadStalwart) as cm:
+            self.mail_client.create_dkim(self.domain)
+
+        self.assertEqual('Ed25519', cm.exception.algorithm)
+        self.assertEqual(self.domain, cm.exception.domain)
+        self.assertIsInstance(cm.exception.__cause__, StalwartError)
 
 
 @override_settings(


### PR DESCRIPTION
With Stalwart 0.15, after publishing a DKIM record the persistent store is updatedbut the in-memory cache is not, and it is the in-memory cache that's used for signing emails.

So until Stalwart is reloaded, emails for the domain may not be DKIM signed.

Here we had the extra reload call in it's own `try` block with exception handling for clear identification of the error.

Also, exception handling of the DKIM post is improved by moving the DKIM POST call into the pre-existin try block.

## Applicable Issues

 * https://github.com/thunderbird/platform-infrastructure/issues/591

## QA Log

* Reviewed Stalwart 0.15 docs for DKIM POST and Reload:
 * https://stalw.art/docs/0.15/api/management/endpoints/#create-dkim-signature
 * https://stalw.art/docs/0.15/api/management/endpoints/#reload-settings
* Analyzed 0.15 code base
* Manual testing adding a DKIM record, testing sending, reloading Stalwart, re-testing sending.
  Local testing confirmed that DKIM signing only started after Stalwart was reloaded.


