### PR TITLE
Add @active_subscription_required decorator and start using it (#347)

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.core.tests.utils import oidc_force_login
 from thunderbird_accounts.mail.clients import DomainVerificationErrors, StaleDNSRecordCode
 from thunderbird_accounts.mail.models import Account, Domain, Email
 from thunderbird_accounts.mail.views import get_dns_records, remove_custom_domain
@@ -83,6 +84,7 @@ class DisplayNameApiTestCase(TestCase):
     def setUp(self):
         self.client = RequestClient()
         self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
         self.primary_email = f'test@{settings.PRIMARY_EMAIL_DOMAIN}'
         self.account = Account.objects.create(name=self.primary_email, user=self.user)
         Email.objects.create(address=self.primary_email, type=Email.EmailType.PRIMARY, account=self.account)
@@ -115,11 +117,51 @@ class DisplayNameApiTestCase(TestCase):
         self.assertFalse(json.loads(response.content.decode())['success'])
 
 
+class ActiveSubscriptionRequiredMailViewsTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+        self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        oidc_force_login(self.client, self.user)
+
+    def test_mail_management_views_require_active_subscription(self):
+        cases = [
+            ('api_display_name_set', 'post', {'display-name': 'New Name'}),
+            ('add_custom_domain', 'post', {'domain-name': 'example.com'}),
+            ('get_dns_records', 'get', {'domain-name': 'example.com'}),
+            ('verify_custom_domain', 'post', {'domain-name': 'example.com'}),
+            ('remove_custom_domain', 'delete', {'domain-name': 'example.com'}),
+            ('add_email_alias', 'post', {'email-alias': 'buddy', 'domain': settings.PRIMARY_EMAIL_DOMAIN}),
+            ('remove_email_alias', 'delete', {'email-alias': f'buddy@{settings.PRIMARY_EMAIL_DOMAIN}'}),
+        ]
+        if settings.AUTH_SCHEME == 'oidc':
+            cases.append(('jmap-test', 'get', {}))
+
+        for url_name, method, data in cases:
+            with self.subTest(url_name=url_name):
+                url = reverse(url_name)
+                if method == 'get':
+                    response = self.client.get(url, data=data, HTTP_ACCEPT='application/json')
+                else:
+                    response = getattr(self.client, method)(
+                        url,
+                        data=json.dumps(data),
+                        content_type='application/json',
+                        HTTP_ACCEPT='application/json',
+                    )
+
+                self.assertEqual(response.status_code, 403)
+                self.assertEqual(
+                    response.json(),
+                    {'success': False, 'error': 'An active subscription is required.'},
+                )
+
+
 @override_settings(HOSTED_DKIM_DOMAIN='dkim.example.net', HOSTED_DKIM_SELECTORS=['tm1', 'tm2', 'tm3'])
 class CustomDomainDNSRecordsTestCase(TestCase):
     def setUp(self):
         self.request_factory = RequestFactory()
         self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
         self.domain = Domain.objects.create(name='example.com', user=self.user)
         self.url = reverse('get_dns_records')
 
@@ -185,6 +227,7 @@ class VerifyCustomDomainTestCase(TestCase):
     def setUp(self):
         self.client = RequestClient()
         self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
         self.domain = Domain.objects.create(name='example.com', user=self.user)
         self.client.force_login(self.user)
         self.url = reverse('verify_custom_domain')
@@ -485,6 +528,7 @@ class RemoveCustomDomainTestCase(TestCase):
     def setUp(self):
         self.request_factory = RequestFactory()
         self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
         self.account = Account.objects.create(name=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', user=self.user)
         self.domain = Domain.objects.create(
             name='example.com',
@@ -569,6 +613,7 @@ class AddEmailAliasTestCase(TestCase):
         self.user = User.objects.create(
             username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234', plan=self.plan
         )
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
         self.account = Account.objects.create(name=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', user=self.user)
         self.client.force_login(self.user)
 

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -113,6 +113,7 @@ def app_password_set(request: HttpRequest):
 
 @login_required
 @require_http_methods(['POST'])
+@active_subscription_required
 @sensitive_post_parameters('display-name')
 def display_name_set(request: HttpRequest):
     """Sets a display name for a remote Stalwart account"""
@@ -137,6 +138,7 @@ def display_name_set(request: HttpRequest):
 
 @login_required
 @require_http_methods(['POST'])
+@active_subscription_required
 def create_custom_domain(request: HttpRequest):
     """Creates a custom domain for the user"""
     data = json.loads(request.body)
@@ -198,6 +200,7 @@ def create_custom_domain(request: HttpRequest):
 
 @login_required
 @require_http_methods(['GET'])
+@active_subscription_required
 def get_dns_records(request: HttpRequest):
     """Gets the DNS records for a custom domain"""
     domain = request.user.domains.get(name=request.GET.get('domain-name'))
@@ -228,6 +231,7 @@ def get_dns_records(request: HttpRequest):
 
 @login_required
 @require_http_methods(['POST'])
+@active_subscription_required
 def verify_custom_domain(request: HttpRequest):
     """Verifies a custom domain"""
     data = json.loads(request.body)
@@ -327,6 +331,7 @@ def verify_custom_domain(request: HttpRequest):
 
 @login_required
 @require_http_methods(['DELETE'])
+@active_subscription_required
 def remove_custom_domain(request: HttpRequest):
     """Removes a custom domain"""
     data = json.loads(request.body)
@@ -400,6 +405,7 @@ def remove_custom_domain(request: HttpRequest):
 
 @login_required
 @require_http_methods(['POST'])
+@active_subscription_required
 def add_email_alias(request: HttpRequest):
     """Adds an email alias"""
     data = json.loads(request.body)
@@ -513,6 +519,7 @@ def add_email_alias(request: HttpRequest):
 
 @login_required
 @require_http_methods(['DELETE'])
+@active_subscription_required
 def remove_email_alias(request: HttpRequest):
     """Removes an email alias"""
     data = json.loads(request.body)
@@ -652,6 +659,7 @@ def appointment_caldav_setup(request: HttpRequest):
 
 
 @login_required
+@active_subscription_required
 def jmap_test_page(request: HttpRequest):
     from thunderbird_accounts.mail.tiny_jmap_client import TinyJMAPClient
 

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -41,6 +41,7 @@ from thunderbird_accounts.mail.utils import (
 from thunderbird_accounts.mail.models import Account, Email, Domain
 from thunderbird_accounts.mail import tasks as mail_tasks
 from thunderbird_accounts.mail import utils
+from thunderbird_accounts.subscription.decorators import active_subscription_required
 
 
 def _critical_errors_from_stale_dns_records(stale_dns_records: list[dict]) -> list[DomainVerificationErrors]:
@@ -69,15 +70,10 @@ def _capture_domain_exception(exception: Exception, domain: Domain, *, phase: st
 
 @login_required
 @require_http_methods(['POST'])
+@active_subscription_required(error_message=_('An active subscription is required to set an app password.'))
 @sensitive_post_parameters('password')
 def app_password_set(request: HttpRequest):
     """Sets an app password for a remote Stalwart account"""
-
-    if not request.user.has_active_subscription:
-        return JsonResponse(
-            {'success': False, 'error': str(_('An active subscription is required to set an app password.'))},
-            status=403,
-        )
 
     try:
         data = json.loads(request.body)

--- a/src/thunderbird_accounts/subscription/decorators.py
+++ b/src/thunderbird_accounts/subscription/decorators.py
@@ -1,7 +1,8 @@
 from functools import wraps
 
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import HttpResponseRedirect, JsonResponse
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 try:
@@ -36,7 +37,7 @@ def inject_paddle(func):
     return _inject_paddle
 
 
-def active_subscription_required(function=None, *, error_message=None, status=403):
+def active_subscription_required(function=None, *, error_message=None, response_data=None, status=403):
     """Require an authenticated user with an active subscription."""
 
     def decorator(view_func):
@@ -45,11 +46,35 @@ def active_subscription_required(function=None, *, error_message=None, status=40
             if getattr(request.user, 'has_active_subscription', False):
                 return view_func(request, *args, **kwargs)
 
-            message = error_message or _('An active subscription is required.')
-            return JsonResponse({'success': False, 'error': str(message)}, status=status)
+            if _wants_json_response(request):
+                message = error_message or _('An active subscription is required.')
+                data = response_data if response_data is not None else {'success': False, 'error': str(message)}
+                return JsonResponse(data, status=status)
+
+            return HttpResponseRedirect(reverse('vue_app'))
 
         return _view_wrapper
 
     if function:
         return decorator(function)
     return decorator
+
+
+def _wants_json_response(request):
+    accept = request.headers.get('Accept', '')
+    content_type = request.headers.get('Content-Type', '')
+
+    if _has_json_media_type(accept) or _has_json_media_type(content_type):
+        return True
+
+    # Existing fetch calls often rely on the browser default Accept: */*,
+    # and RequestFactory tests often omit Accept entirely.
+    return not accept or accept.strip() == '*/*'
+
+
+def _has_json_media_type(header_value):
+    for value in header_value.split(','):
+        media_type = value.split(';', 1)[0].strip().lower()
+        if media_type == 'application/json' or media_type.endswith('+json'):
+            return True
+    return False

--- a/src/thunderbird_accounts/subscription/decorators.py
+++ b/src/thunderbird_accounts/subscription/decorators.py
@@ -1,4 +1,8 @@
+from functools import wraps
+
 from django.conf import settings
+from django.http import JsonResponse
+from django.utils.translation import gettext_lazy as _
 
 try:
     from paddle_billing import Client, Options, Environment
@@ -30,3 +34,22 @@ def inject_paddle(func):
         return func(*args, **kwargs)
 
     return _inject_paddle
+
+
+def active_subscription_required(function=None, *, error_message=None, status=403):
+    """Require an authenticated user with an active subscription."""
+
+    def decorator(view_func):
+        @wraps(view_func)
+        def _view_wrapper(request, *args, **kwargs):
+            if getattr(request.user, 'has_active_subscription', False):
+                return view_func(request, *args, **kwargs)
+
+            message = error_message or _('An active subscription is required.')
+            return JsonResponse({'success': False, 'error': str(message)}, status=status)
+
+        return _view_wrapper
+
+    if function:
+        return decorator(function)
+    return decorator

--- a/src/thunderbird_accounts/subscription/tests/test_views.py
+++ b/src/thunderbird_accounts/subscription/tests/test_views.py
@@ -248,3 +248,22 @@ class PaddleTransactionCompleteCase(TestCase):
         We should also ensure IS_DEV=False does not call Paddle or the fake webhook task."""
 
         self._test_doneish_by_status(Transaction.StatusValues.COMPLETED, True)
+
+
+class ActiveSubscriptionRequiredViewTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+        self.user = User.objects.create(username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='1234')
+        oidc_force_login(self.client, self.user)
+
+    def test_paddle_portal_link_requires_active_subscription(self):
+        response = self.client.post(reverse('paddle_portal'), HTTP_ACCEPT='application/json')
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {})
+
+    def test_subscription_plan_info_requires_active_subscription(self):
+        response = self.client.post(reverse('subscription_plan_info'), HTTP_ACCEPT='application/json')
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {'success': False, 'error': 'No active subscription found'})

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -23,7 +23,7 @@ from thunderbird_accounts.authentication.models import AllowListEntry, User
 from thunderbird_accounts.mail.clients import MailClient
 from thunderbird_accounts.authentication.permissions import IsValidPaddleWebhook
 from thunderbird_accounts.subscription import tasks
-from thunderbird_accounts.subscription.decorators import inject_paddle
+from thunderbird_accounts.subscription.decorators import active_subscription_required, inject_paddle
 from thunderbird_accounts.subscription.models import Plan, Price, Subscription, Transaction
 from thunderbird_accounts.core.exceptions import UnexpectedBehaviour
 
@@ -182,11 +182,9 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
 
 @login_required
 @require_http_methods(['POST'])
+@active_subscription_required(response_data={}, status=401)
 @inject_paddle
 def get_paddle_portal_link(request: Request, paddle: Client):
-    if not request.user.has_active_subscription:
-        return JsonResponse({}, status=401)
-
     subscription = request.user.subscription_set.filter(status=Subscription.StatusValues.ACTIVE).first()
     customer_session = paddle.customer_portal_sessions.create(
         subscription.paddle_customer_id, CreateCustomerPortalSession()
@@ -240,14 +238,11 @@ def handle_paddle_webhook(request: Request):
 
 
 @login_required
-@inject_paddle
 @require_http_methods(['POST'])
+@active_subscription_required(error_message='No active subscription found', status=404)
+@inject_paddle
 def get_subscription_plan_info(request: Request, paddle: Client):
     """Returns the user's current subscription information including plan details, pricing, and features."""
-
-    # Check if user has an active subscription
-    if not request.user.has_active_subscription:
-        return JsonResponse({'success': False, 'error': 'No active subscription found'}, status=404)
 
     # Get the user's active subscription
     subscription: Subscription = request.user.subscription_set.filter(status=Subscription.StatusValues.ACTIVE).first()


### PR DESCRIPTION
Updates one location to use it as example. This commit is not trying
to refactor every potential use of the decorator.

## Why?

This addresses several Sentry exceptions. It's good for DRY and consistency with @login_required.

## Limitations and Notes

- Initial scope does not refactor every potential case that could use it.

## Applicable Issues

 * https://github.com/thunderbird/thunderbird-accounts/issues/347

## QA Log

* Confirmed there was already relevant test coverage for the refactored route, thus the code is already tested by existing test coverage.

## Questions

Should the scope be expanded to refactor more locations in this PR or continue that work in a follow-up PR?

