### PR TITLE
Expose waffle flags through an API route

### DIFF
--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -7,10 +7,12 @@ from enum import StrEnum
 from urllib.parse import quote
 
 from django.conf import settings
+from mozilla_django_oidc.contrib.drf import OIDCAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.throttling import UserRateThrottle
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 import sentry_sdk
+from waffle import get_waffle_flag_model
 
 from thunderbird_accounts.authentication.exceptions import (
     InvalidDomainError,
@@ -64,6 +66,28 @@ def get_user_profile(request: Request):
     if not request.user:
         raise NotAuthenticated()
     return Response(UserProfileSerializer(request.user).data)
+
+
+@api_view(['GET'])
+@authentication_classes([OIDCAuthentication])
+@permission_classes([IsAuthenticated])
+def get_waffle_flags(request: Request):
+    """Return the caller's active waffle flags.
+
+    Callers authenticate with `Authorization: Bearer <keycloak-access-token>`
+    and we resolve that to the matching local user via OIDCAuthentication.
+    """
+    flags = get_waffle_flag_model().get_all()
+
+    # read_only=True: this is a machine-to-machine request, not a browser session, so
+    # there's no waffle cookie to make percent-rollout sticky across calls.
+    # In other words, percentage-based flags will NOT be sticky unless another rule
+    # (e.g. everyone/staff/superuser/authenticated/users/groups) also qualifies the user.
+    return Response(
+        {
+            'flags': {flag.name: flag.is_active(request, read_only=True) for flag in flags},
+        }
+    )
 
 
 @api_view(['GET'])

--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -12,7 +12,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.permissions import AllowAny, IsAuthenticated
 import sentry_sdk
-from waffle import get_waffle_flag_model
+from waffle.views import waffle_json
 
 from thunderbird_accounts.authentication.exceptions import (
     InvalidDomainError,
@@ -72,22 +72,13 @@ def get_user_profile(request: Request):
 @authentication_classes([OIDCAuthentication])
 @permission_classes([IsAuthenticated])
 def get_waffle_flags(request: Request):
-    """Return the caller's active waffle flags.
+    """Return the caller's active waffle flags, switches, and samples.
 
     Callers authenticate with `Authorization: Bearer <keycloak-access-token>`
     and we resolve that to the matching local user via OIDCAuthentication.
+    This is just waffle's own `waffle_json` view wrapped with our token auth.
     """
-    flags = get_waffle_flag_model().get_all()
-
-    # read_only=True: this is a machine-to-machine request, not a browser session, so
-    # there's no waffle cookie to make percent-rollout sticky across calls.
-    # In other words, percentage-based flags will NOT be sticky unless another rule
-    # (e.g. everyone/staff/superuser/authenticated/users/groups) also qualifies the user.
-    return Response(
-        {
-            'flags': {flag.name: flag.is_active(request, read_only=True) for flag in flags},
-        }
-    )
+    return waffle_json(request)
 
 
 @api_view(['GET'])

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -361,17 +361,34 @@ class WaffleFlagsTestcase(APITestCase):
         self.client = APIClient()
         self.url = reverse('api_waffle_flags')
         self.user = User.objects.create(
-            recovery_email=f'{uuid.uuid4()}@example.com', username=f'{uuid.uuid4()}@example.org'
+            oidc_id=str(uuid.uuid4()),
+            recovery_email=f'{uuid.uuid4()}@example.com',
+            username=f'{uuid.uuid4()}@example.org',
         )
 
         Flag.objects.create(name='flag-on-for-everyone', everyone=True)
         Flag.objects.create(name='flag-off-for-everyone', everyone=False)
         Flag.objects.create(name='flag-on-for-authenticated', authenticated=True)
 
-    def test_returns_active_flags_for_authenticated_user(self):
-        self.client.force_authenticate(self.user)
+        # Due to the endpoint being gated by OIDCAuthentication
+        patcher = patch(
+            'thunderbird_accounts.authentication.middleware.AccountsOIDCBackend.get_userinfo',
+            side_effect=self._fake_userinfo,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
-        response = self.client.get(self.url)
+    @staticmethod
+    def _fake_userinfo(access_token, id_token, payload):
+        return {
+            'sub': access_token,
+            'email': f'{access_token}@example.org',
+            'email_verified': True,
+            'preferred_username': f'{access_token}@example.org',
+        }
+
+    def test_returns_active_flags_for_authenticated_user(self):
+        response = self.client.get(self.url, headers={'authorization': f'Bearer {self.user.oidc_id}'})
         self.assertEqual(200, response.status_code, response.content)
 
         flags = response.json().get('flags')
@@ -389,21 +406,21 @@ class WaffleFlagsTestcase(APITestCase):
 
     def test_returns_active_flag_for_specific_user_only(self):
         other_user = User.objects.create(
-            recovery_email=f'{uuid.uuid4()}@example.com', username=f'{uuid.uuid4()}@example.org'
+            oidc_id=str(uuid.uuid4()),
+            recovery_email=f'{uuid.uuid4()}@example.com',
+            username=f'{uuid.uuid4()}@example.org',
         )
 
         flag = Flag.objects.create(name='flag-on-for-specific-user')
         flag.users.add(self.user)
 
-        # Login in as the user created in the setup step and check that the flag is active
-        self.client.force_authenticate(self.user)
-        response = self.client.get(self.url)
+        # Authenticate as the user created in the setup step and check that the flag is active
+        response = self.client.get(self.url, headers={'authorization': f'Bearer {self.user.oidc_id}'})
         self.assertEqual(200, response.status_code, response.content)
         self.assertTrue(response.json()['flags']['flag-on-for-specific-user']['is_active'])
 
-        # Login in as the other user and check that the flag is not active
-        self.client.force_authenticate(other_user)
-        response = self.client.get(self.url)
+        # Authenticate as the other user and check that the flag is not active
+        response = self.client.get(self.url, headers={'authorization': f'Bearer {other_user.oidc_id}'})
         self.assertEqual(200, response.status_code, response.content)
         self.assertFalse(response.json()['flags']['flag-on-for-specific-user']['is_active'])
 

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -377,12 +377,15 @@ class WaffleFlagsTestcase(APITestCase):
         flags = response.json().get('flags')
         self.assertEqual(
             {
-                'flag-on-for-everyone': True,
-                'flag-off-for-everyone': False,
-                'flag-on-for-authenticated': True,
+                'flag-on-for-everyone',
+                'flag-off-for-everyone',
+                'flag-on-for-authenticated',
             },
-            flags,
+            flags.keys(),
         )
+        self.assertTrue(flags['flag-on-for-everyone']['is_active'])
+        self.assertFalse(flags['flag-off-for-everyone']['is_active'])
+        self.assertTrue(flags['flag-on-for-authenticated']['is_active'])
 
     def test_returns_active_flag_for_specific_user_only(self):
         other_user = User.objects.create(
@@ -396,13 +399,13 @@ class WaffleFlagsTestcase(APITestCase):
         self.client.force_authenticate(self.user)
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code, response.content)
-        self.assertTrue(response.json()['flags']['flag-on-for-specific-user'])
+        self.assertTrue(response.json()['flags']['flag-on-for-specific-user']['is_active'])
 
         # Login in as the other user and check that the flag is not active
         self.client.force_authenticate(other_user)
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code, response.content)
-        self.assertFalse(response.json()['flags']['flag-on-for-specific-user'])
+        self.assertFalse(response.json()['flags']['flag-on-for-specific-user']['is_active'])
 
     def test_requires_authentication(self):
         response = self.client.get(self.url)

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -4,6 +4,7 @@ from thunderbird_accounts.authentication.api import CanISignUpResponses
 from django.urls import reverse
 from json import JSONDecodeError
 from unittest.mock import MagicMock, patch
+from waffle.models import Flag
 import uuid
 
 from django.conf import settings
@@ -353,3 +354,56 @@ class CreateTestAllowListEntryTestCase(APITestCase):
         self.assertEqual('no-email', resp_data.get('type'))
         test_entry = AllowListEntry.objects.filter(email=email).first()
         self.assertIsNone(test_entry)
+
+
+class WaffleFlagsTestcase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse('api_waffle_flags')
+        self.user = User.objects.create(
+            recovery_email=f'{uuid.uuid4()}@example.com', username=f'{uuid.uuid4()}@example.org'
+        )
+
+        Flag.objects.create(name='flag-on-for-everyone', everyone=True)
+        Flag.objects.create(name='flag-off-for-everyone', everyone=False)
+        Flag.objects.create(name='flag-on-for-authenticated', authenticated=True)
+
+    def test_returns_active_flags_for_authenticated_user(self):
+        self.client.force_authenticate(self.user)
+
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code, response.content)
+
+        flags = response.json().get('flags')
+        self.assertEqual(
+            {
+                'flag-on-for-everyone': True,
+                'flag-off-for-everyone': False,
+                'flag-on-for-authenticated': True,
+            },
+            flags,
+        )
+
+    def test_returns_active_flag_for_specific_user_only(self):
+        other_user = User.objects.create(
+            recovery_email=f'{uuid.uuid4()}@example.com', username=f'{uuid.uuid4()}@example.org'
+        )
+
+        flag = Flag.objects.create(name='flag-on-for-specific-user')
+        flag.users.add(self.user)
+
+        # Login in as the user created in the setup step and check that the flag is active
+        self.client.force_authenticate(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertTrue(response.json()['flags']['flag-on-for-specific-user'])
+
+        # Login in as the other user and check that the flag is not active
+        self.client.force_authenticate(other_user)
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertFalse(response.json()['flags']['flag-on-for-specific-user'])
+
+    def test_requires_authentication(self):
+        response = self.client.get(self.url)
+        self.assertEqual(401, response.status_code)

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -8,6 +8,7 @@ from waffle.models import Flag
 import uuid
 
 from django.conf import settings
+from django.core.exceptions import SuspiciousOperation
 from urllib.parse import quote
 from django.test import Client as RequestClient, override_settings
 from rest_framework.test import APITestCase, APIClient
@@ -380,6 +381,11 @@ class WaffleFlagsTestcase(APITestCase):
 
     @staticmethod
     def _fake_userinfo(access_token, id_token, payload):
+        # Mimic a real OIDC provider, which would reject unrecognized/invalid
+        # access tokens rather than happily returning userinfo for anything.
+        if not User.objects.filter(oidc_id=access_token).exists():
+            raise SuspiciousOperation('invalid access token')
+
         return {
             'sub': access_token,
             'email': f'{access_token}@example.org',
@@ -426,4 +432,8 @@ class WaffleFlagsTestcase(APITestCase):
 
     def test_requires_authentication(self):
         response = self.client.get(self.url)
+        self.assertEqual(401, response.status_code)
+
+    def test_returns_401_for_invalid_token(self):
+        response = self.client.get(self.url, headers={'authorization': 'Bearer invalid-token'})
         self.assertEqual(401, response.status_code)

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -67,6 +67,7 @@ urlpatterns = [
     path('api/v1/auth/get-profile/', get_user_profile, name='api_get_profile'),
     path('api/v1/auth/sign-up/', sign_up, name='api_sign_up'),
     path('api/v1/auth/can-i-sign-up/', can_i_sign_up, name='api_can_i_sign_up'),
+    path('api/v1/auth/waffle-flags/', auth_api.get_waffle_flags, name='api_waffle_flags'),
     path('api/v1/auth/mfa/methods/', auth_api.get_mfa_methods, name='api_get_mfa_methods'),
     path('api/v1/auth/mfa/totp/setup/start/', auth_api.start_totp_setup, name='api_start_totp_setup'),
     path('api/v1/auth/mfa/totp/setup/confirm/', auth_api.confirm_totp_setup, name='api_confirm_totp_setup'),


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Added a GET `api/v1/auth/waffle-flags/` route that gets the feature flags available for the logged in user.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

A centralized place to control feature flags across services would be great and since we already have django-waffle set up here we can simply make a request from other services instead of having service-specific env var-based flags.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

Since this is machine-to-machine, we lose the ability to rely on Waffle cookies for percent-rollout sticky-ness across calls unless another rule also qualifies the user.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/1064

