### PR TITLE
Handle pending mail account provisioning case (#1081)

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -1128,6 +1128,25 @@ class AppointmentCalDAVSetupTestCase(TestCase):
         self.assertEqual(payload['error'], _('An error has occurred while setting up the Appointment CalDAV.'))
 
     @override_settings(APPOINTMENT_CALDAV_SECRET='test-secret-123')
+    @patch('thunderbird_accounts.mail.views.AccountsOIDCBackend')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_mail_account_not_ready(self, mock_mail_client_cls, mock_backend_cls):
+        Email.objects.filter(type=Email.EmailType.PRIMARY, account=self.account).delete()
+        mock_backend = Mock()
+        mock_backend.get_user_from_access_token.return_value = self.user
+        mock_backend_cls.return_value = mock_backend
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'appointment-secret': 'test-secret-123', 'oidc-access-token': self.access_token}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(json.loads(response.content.decode())['code'], 'mail_account_not_ready')
+        mock_mail_client_cls.assert_not_called()
+
+    @override_settings(APPOINTMENT_CALDAV_SECRET='test-secret-123')
     @patch('thunderbird_accounts.mail.views.secrets.token_urlsafe')
     @patch('thunderbird_accounts.mail.views.AccountsOIDCBackend')
     @patch('thunderbird_accounts.mail.views.utils.save_app_password')

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -627,25 +627,37 @@ def appointment_caldav_setup(request: HttpRequest):
         error_response.status_code = 400
         return error_response
 
+    primary_email = user.stalwart_primary_email
+    if not primary_email:
+        logging.info(f'Primary Stalwart email not found during Appointment CalDAV setup for user {user.uuid}')
+        return JsonResponse(
+            {
+                'success': False,
+                'error': _('Thundermail account setup is still in progress. Please try again shortly.'),
+                'code': 'mail_account_not_ready',
+            },
+            status=409,
+        )
+
     # Use a special label for the App Password to be used in Appointment's CalDAV auto-setup
-    label = f'{settings.APPOINTMENT_APP_PASSWORD_PREFIX}{user.stalwart_primary_email}'
+    label = f'{settings.APPOINTMENT_APP_PASSWORD_PREFIX}{primary_email}'
 
     try:
         stalwart_client = MailClient()
-        email_user = stalwart_client.get_account(user.stalwart_primary_email)
+        email_user = stalwart_client.get_account(primary_email)
 
         # Remove any existing app password for this label so we can
         # replace it with a fresh one.
         expected_prefix = f'$app${label}$'
         for secret in email_user.get('secrets', []):
             if secret.startswith(expected_prefix):
-                stalwart_client.delete_app_password(user.stalwart_primary_email, secret)
+                stalwart_client.delete_app_password(primary_email, secret)
 
         # Generate a random base64 password, hash it for Stalwart
         # storage, and return the base64 password to the caller for CalDAV auth.
         base64_password = secrets.token_urlsafe(64)
         app_password_hash = utils.save_app_password(label, base64_password)
-        stalwart_client.save_app_password(user.stalwart_primary_email, app_password_hash)
+        stalwart_client.save_app_password(primary_email, app_password_hash)
 
         return JsonResponse({'success': True, 'app_password': base64_password})
 


### PR DESCRIPTION
Appointment can call the CalDAV setup endpoint after subscription has marked a user active, but before the async Stalwart account provisioning task has completed. In that window the user has no local primary Stalwart email yet, so the old flow could throw AccountNotFoundError.

Return a machine-readable 409 `mail_account_not_ready` response for that transient state where user.stalwart_primary_email is not set.

We will continue to throw on other Stalwart lookup failures, as those remain unexpected.

## Applicable Issues

 * Fixes #1081 
 * Issue for Appointment's side:  https://github.com/thunderbird/thunderbird-accounts/pull/1082
 
## QA Log

* Confirmed we have test coverage for this route.
  * ( src/thunderbird_accounts/mail/tests/test_views.py:999, AppointmentCalDAVSetupTestCase.)
