### PR TITLE
CI: decouple multi-arch image publishing into a standalone GHCR pipeline

### DIFF
--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -1,34 +1,32 @@
 ---
-# Reusable workflow that builds one container image for linux/amd64 and
-# linux/arm64 on NATIVE runners (no QEMU), pushes each arch to ECR by digest,
-# then stitches the digests into a single multi-arch manifest list under the
-# real tag. Callers get back the fully-qualified image reference via the
-# `image` output. See merge.yml for how accounts + keycloak invoke this.
+# Reusable workflow: build ONE container image for linux/amd64 and linux/arm64
+# on NATIVE runners (no QEMU), push each arch to GHCR by digest, then stitch the
+# digests into a single multi-arch manifest list tagged :<sha>, :v<version> and
+# :latest. Callers get the fully-qualified :<sha> reference back via the `image`
+# output. Invoked by publish-images.yml for the accounts and keycloak images.
 #
 # Why native runners instead of `buildx --platform amd64,arm64` with QEMU:
 # emulated arm64 builds are minutes-slower and occasionally miscompile. Each
-# arch now builds on its own hardware and the two run in parallel.
+# arch builds on its own hardware and the two run in parallel.
 #
-# ============================ TEMPORARY: DRY-RUN =============================
-# This workflow is currently in a build-test mode: it builds each arch on its
-# native runner but does NOT push to ECR and does NOT produce a manifest list.
-# The AWS/ECR steps and the digest/merge machinery are commented out below so
-# the build can be exercised on any branch with no cloud credentials and no
-# side effects. Restore the commented blocks (and `secrets: inherit` in
-# merge.yml) once the native builds are confirmed green.
-# ============================================================================
+# Auth is GHCR + the automatic GITHUB_TOKEN (packages: write) -- no cloud
+# credentials, which keeps this pipeline decoupled from the ECR/Pulumi deploy.
 name: build-multiarch-image
 
 on:
   workflow_call:
     inputs:
+      image:
+        description: Fully-qualified GHCR image name WITHOUT a tag (e.g. ghcr.io/owner/name).
+        required: true
+        type: string
       dockerfile:
         description: Path to the Dockerfile to build.
         required: false
         type: string
         default: Dockerfile
-      tag:
-        description: Tag to publish the manifest list under (appended to the ECR repo).
+      version:
+        description: Semantic version (no leading v) published as the :v<version> tag.
         required: true
         type: string
       artifact-prefix:
@@ -40,16 +38,16 @@ on:
         type: string
     outputs:
       image:
-        description: The fully-qualified multi-arch image reference that was pushed.
+        description: The :<sha>-tagged multi-arch image reference that was pushed.
         value: ${{ jobs.merge.outputs.image }}
 
 permissions:
-  id-token: write
   contents: read
+  packages: write
 
 jobs:
-  # One job per architecture, each on its matching native runner. During the
-  # dry-run this just proves the build compiles natively -- nothing is pushed.
+  # One job per architecture, each on its matching native runner. Each pushes an
+  # anonymous (tag-less) image to GHCR and records its digest as an artifact.
   build:
     strategy:
       fail-fast: false
@@ -67,73 +65,51 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # TEMPORARY: AWS/ECR access disabled for the dry-run (no push == no creds).
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     aws-region: eu-central-1
-      #     role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-      #
-      # - name: Login to Amazon ECR
-      #   id: login-ecr
-      #   uses: aws-actions/amazon-ecr-login@v2
-      #   with:
-      #     mask-password: "true"
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # TEMPORARY: build only, do NOT push. This still runs every Dockerfile
-      # stage on the native runner, so a compile/build failure fails the job --
-      # which is the evidence we're collecting. Restore the push-by-digest block
-      # below (and the digest export/upload) once builds are green.
-      - name: Build image (dry-run, no push)
+      - name: Build and push image by digest
         id: build
         run: |
+          # Build this single platform and push it to GHCR by digest only (no
+          # tag). push-by-digest keeps the pushed image anonymous so both arch
+          # runners can push concurrently without clobbering a shared tag; the
+          # merge job assigns the real tags afterwards. --metadata-file lets us
+          # read back the digest that GHCR assigned.
           docker buildx build \
             -f "${{ inputs.dockerfile }}" \
             --platform "${{ matrix.platform }}" \
-            -t "${{ inputs.artifact-prefix }}:${{ matrix.arch }}-dryrun" \
+            --output "type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file metadata.json \
             .
+          digest="$(jq -r '."containerimage.digest"' metadata.json)"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
-      # - name: Build and push image by digest
-      #   id: build
-      #   env:
-      #     IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
-      #   run: |
-      #     # Build this single platform and push it to ECR by digest only (no
-      #     # tag). push-by-digest keeps the pushed image anonymous so both arch
-      #     # runners can push concurrently without clobbering a shared tag; the
-      #     # merge job assigns the real tag afterwards. --metadata-file lets us
-      #     # read back the digest that ECR assigned.
-      #     docker buildx build \
-      #       -f "${{ inputs.dockerfile }}" \
-      #       --platform "${{ matrix.platform }}" \
-      #       --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
-      #       --metadata-file metadata.json \
-      #       .
-      #     digest="$(jq -r '."containerimage.digest"' metadata.json)"
-      #     echo "digest=$digest" >> "$GITHUB_OUTPUT"
-      #
-      # - name: Export digest
-      #   run: |
-      #     # Record the digest as an empty file named after the sha256 hex, so
-      #     # the merge job can reconstruct `${IMAGE}@sha256:<hex>` references by
-      #     # listing the downloaded artifact directory.
-      #     mkdir -p "${{ runner.temp }}/digests"
-      #     digest="${{ steps.build.outputs.digest }}"
-      #     touch "${{ runner.temp }}/digests/${digest#sha256:}"
-      #
-      # - name: Upload digest
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
-      #     path: ${{ runner.temp }}/digests/*
-      #     if-no-files-found: error
-      #     retention-days: 1
+      - name: Export digest
+        run: |
+          # Record the digest as an empty file named after the sha256 hex, so
+          # the merge job can reconstruct `${IMAGE}@sha256:<hex>` references by
+          # listing the downloaded artifact directory.
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
-  # Combine the per-arch digests into one manifest list under the real tag.
-  # TEMPORARY: neutralized during the dry-run (nothing was pushed to merge).
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into one manifest list under all three tags.
   merge:
     needs: build
     runs-on: ubuntu-latest
@@ -142,45 +118,39 @@ jobs:
     outputs:
       image: ${{ steps.merge.outputs.image }}
     steps:
-      - name: Merge disabled (dry-run)
-        id: merge
-        run: |
-          echo "Dry-run: skipping manifest merge; no images were pushed to ECR."
-          echo "image=" >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     aws-region: eu-central-1
-      #     role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-      #
-      # - name: Login to Amazon ECR
-      #   id: login-ecr
-      #   uses: aws-actions/amazon-ecr-login@v2
-      #   with:
-      #     mask-password: "true"
-      #
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
-      #
-      # - name: Download digests
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     path: ${{ runner.temp }}/digests
-      #     pattern: digests-${{ inputs.artifact-prefix }}-*
-      #     merge-multiple: true
-      #
-      # - name: Create manifest list and push
-      #   id: merge
-      #   working-directory: ${{ runner.temp }}/digests
-      #   env:
-      #     IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
-      #   run: |
-      #     # imagetools create references digests already in ECR, so nothing is
-      #     # rebuilt or re-pushed here -- it only writes the manifest list. The
-      #     # glob expands to one `${IMAGE}@sha256:<hex>` per downloaded digest.
-      #     TARGET="${IMAGE}:${{ inputs.tag }}"
-      #     docker buildx imagetools create -t "$TARGET" \
-      #       $(printf "${IMAGE}@sha256:%s " *)
-      #     docker buildx imagetools inspect "$TARGET"
-      #     echo "image=$TARGET" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ inputs.artifact-prefix }}-*
+          merge-multiple: true
+
+      - name: Create manifest list and push
+        id: merge
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ inputs.image }}
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ github.sha }}
+        run: |
+          # imagetools create references digests already in GHCR, so nothing is
+          # rebuilt or re-pushed here -- it only writes the manifest list, under
+          # all three tags at once. The glob expands to one
+          # `${IMAGE}@sha256:<hex>` per downloaded digest.
+          docker buildx imagetools create \
+            -t "${IMAGE}:${SHA}" \
+            -t "${IMAGE}:v${VERSION}" \
+            -t "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools inspect "${IMAGE}:${SHA}"
+          echo "image=${IMAGE}:${SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -53,9 +53,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Pinned to matching Ubuntu versions across arches (there is no
+          # `ubuntu-latest-arm` alias, so amd64 is pinned to 24.04 to match).
           - platform: linux/amd64
             arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -8,6 +8,15 @@
 # Why native runners instead of `buildx --platform amd64,arm64` with QEMU:
 # emulated arm64 builds are minutes-slower and occasionally miscompile. Each
 # arch now builds on its own hardware and the two run in parallel.
+#
+# ============================ TEMPORARY: DRY-RUN =============================
+# This workflow is currently in a build-test mode: it builds each arch on its
+# native runner but does NOT push to ECR and does NOT produce a manifest list.
+# The AWS/ECR steps and the digest/merge machinery are commented out below so
+# the build can be exercised on any branch with no cloud credentials and no
+# side effects. Restore the commented blocks (and `secrets: inherit` in
+# merge.yml) once the native builds are confirmed green.
+# ============================================================================
 name: build-multiarch-image
 
 on:
@@ -39,8 +48,8 @@ permissions:
   contents: read
 
 jobs:
-  # One job per architecture, each on its matching native runner. Each pushes
-  # an anonymous (tag-less) image to ECR and records its digest as an artifact.
+  # One job per architecture, each on its matching native runner. During the
+  # dry-run this just proves the build compiles natively -- nothing is pushed.
   build:
     strategy:
       fail-fast: false
@@ -58,58 +67,73 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-central-1
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: "true"
+      # TEMPORARY: AWS/ECR access disabled for the dry-run (no push == no creds).
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-region: eu-central-1
+      #     role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+      #
+      # - name: Login to Amazon ECR
+      #   id: login-ecr
+      #   uses: aws-actions/amazon-ecr-login@v2
+      #   with:
+      #     mask-password: "true"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push image by digest
+      # TEMPORARY: build only, do NOT push. This still runs every Dockerfile
+      # stage on the native runner, so a compile/build failure fails the job --
+      # which is the evidence we're collecting. Restore the push-by-digest block
+      # below (and the digest export/upload) once builds are green.
+      - name: Build image (dry-run, no push)
         id: build
-        env:
-          IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
         run: |
-          # Build this single platform and push it to ECR by digest only (no
-          # tag). push-by-digest keeps the pushed image anonymous so both arch
-          # runners can push concurrently without clobbering a shared tag; the
-          # merge job assigns the real tag afterwards. --metadata-file lets us
-          # read back the digest that ECR assigned.
           docker buildx build \
             -f "${{ inputs.dockerfile }}" \
             --platform "${{ matrix.platform }}" \
-            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
-            --metadata-file metadata.json \
+            -t "${{ inputs.artifact-prefix }}:${{ matrix.arch }}-dryrun" \
             .
-          digest="$(jq -r '."containerimage.digest"' metadata.json)"
-          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
-      - name: Export digest
-        run: |
-          # Record the digest as an empty file named after the sha256 hex, so
-          # the merge job can reconstruct `${IMAGE}@sha256:<hex>` references by
-          # listing the downloaded artifact directory.
-          mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
+      # - name: Build and push image by digest
+      #   id: build
+      #   env:
+      #     IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
+      #   run: |
+      #     # Build this single platform and push it to ECR by digest only (no
+      #     # tag). push-by-digest keeps the pushed image anonymous so both arch
+      #     # runners can push concurrently without clobbering a shared tag; the
+      #     # merge job assigns the real tag afterwards. --metadata-file lets us
+      #     # read back the digest that ECR assigned.
+      #     docker buildx build \
+      #       -f "${{ inputs.dockerfile }}" \
+      #       --platform "${{ matrix.platform }}" \
+      #       --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+      #       --metadata-file metadata.json \
+      #       .
+      #     digest="$(jq -r '."containerimage.digest"' metadata.json)"
+      #     echo "digest=$digest" >> "$GITHUB_OUTPUT"
+      #
+      # - name: Export digest
+      #   run: |
+      #     # Record the digest as an empty file named after the sha256 hex, so
+      #     # the merge job can reconstruct `${IMAGE}@sha256:<hex>` references by
+      #     # listing the downloaded artifact directory.
+      #     mkdir -p "${{ runner.temp }}/digests"
+      #     digest="${{ steps.build.outputs.digest }}"
+      #     touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      #
+      # - name: Upload digest
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+      #     path: ${{ runner.temp }}/digests/*
+      #     if-no-files-found: error
+      #     retention-days: 1
 
   # Combine the per-arch digests into one manifest list under the real tag.
+  # TEMPORARY: neutralized during the dry-run (nothing was pushed to merge).
   merge:
     needs: build
     runs-on: ubuntu-latest
@@ -118,39 +142,45 @@ jobs:
     outputs:
       image: ${{ steps.merge.outputs.image }}
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-central-1
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: "true"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-${{ inputs.artifact-prefix }}-*
-          merge-multiple: true
-
-      - name: Create manifest list and push
+      - name: Merge disabled (dry-run)
         id: merge
-        working-directory: ${{ runner.temp }}/digests
-        env:
-          IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
         run: |
-          # imagetools create references digests already in ECR, so nothing is
-          # rebuilt or re-pushed here -- it only writes the manifest list. The
-          # glob expands to one `${IMAGE}@sha256:<hex>` per downloaded digest.
-          TARGET="${IMAGE}:${{ inputs.tag }}"
-          docker buildx imagetools create -t "$TARGET" \
-            $(printf "${IMAGE}@sha256:%s " *)
-          docker buildx imagetools inspect "$TARGET"
-          echo "image=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "Dry-run: skipping manifest merge; no images were pushed to ECR."
+          echo "image=" >> "$GITHUB_OUTPUT"
+
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-region: eu-central-1
+      #     role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+      #
+      # - name: Login to Amazon ECR
+      #   id: login-ecr
+      #   uses: aws-actions/amazon-ecr-login@v2
+      #   with:
+      #     mask-password: "true"
+      #
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
+      #
+      # - name: Download digests
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     path: ${{ runner.temp }}/digests
+      #     pattern: digests-${{ inputs.artifact-prefix }}-*
+      #     merge-multiple: true
+      #
+      # - name: Create manifest list and push
+      #   id: merge
+      #   working-directory: ${{ runner.temp }}/digests
+      #   env:
+      #     IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
+      #   run: |
+      #     # imagetools create references digests already in ECR, so nothing is
+      #     # rebuilt or re-pushed here -- it only writes the manifest list. The
+      #     # glob expands to one `${IMAGE}@sha256:<hex>` per downloaded digest.
+      #     TARGET="${IMAGE}:${{ inputs.tag }}"
+      #     docker buildx imagetools create -t "$TARGET" \
+      #       $(printf "${IMAGE}@sha256:%s " *)
+      #     docker buildx imagetools inspect "$TARGET"
+      #     echo "image=$TARGET" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -63,17 +63,17 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push image by digest
         id: build
@@ -111,7 +111,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -128,17 +128,17 @@ jobs:
       image: ${{ steps.merge.outputs.image }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ inputs.artifact-prefix }}-*

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -83,9 +83,18 @@ jobs:
           # runners can push concurrently without clobbering a shared tag; the
           # merge job assigns the real tags afterwards. --metadata-file lets us
           # read back the digest that GHCR assigned.
+          # --provenance=false keeps each per-arch push a single plain manifest
+          # (no attestation index), so the merged manifest list contains exactly
+          # the two platform entries.
+          # GitHub Actions layer cache, scoped per image+arch (these runners are
+          # ephemeral, so nothing persists between runs without it). The scope
+          # keeps accounts/keycloak and amd64/arm64 caches from colliding.
           docker buildx build \
             -f "${{ inputs.dockerfile }}" \
             --platform "${{ matrix.platform }}" \
+            --provenance=false \
+            --cache-from "type=gha,scope=${{ inputs.artifact-prefix }}-${{ matrix.arch }}" \
+            --cache-to "type=gha,mode=max,scope=${{ inputs.artifact-prefix }}-${{ matrix.arch }}" \
             --output "type=image,name=${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file metadata.json \
             .

--- a/.github/workflows/build-multiarch-image.yml
+++ b/.github/workflows/build-multiarch-image.yml
@@ -1,0 +1,156 @@
+---
+# Reusable workflow that builds one container image for linux/amd64 and
+# linux/arm64 on NATIVE runners (no QEMU), pushes each arch to ECR by digest,
+# then stitches the digests into a single multi-arch manifest list under the
+# real tag. Callers get back the fully-qualified image reference via the
+# `image` output. See merge.yml for how accounts + keycloak invoke this.
+#
+# Why native runners instead of `buildx --platform amd64,arm64` with QEMU:
+# emulated arm64 builds are minutes-slower and occasionally miscompile. Each
+# arch now builds on its own hardware and the two run in parallel.
+name: build-multiarch-image
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        description: Path to the Dockerfile to build.
+        required: false
+        type: string
+        default: Dockerfile
+      tag:
+        description: Tag to publish the manifest list under (appended to the ECR repo).
+        required: true
+        type: string
+      artifact-prefix:
+        description: >-
+          Unique prefix for this image's digest artifacts. Distinct images built
+          in the same run (accounts, keycloak) MUST use different prefixes so
+          their per-arch digest artifacts don't collide.
+        required: true
+        type: string
+    outputs:
+      image:
+        description: The fully-qualified multi-arch image reference that was pushed.
+        value: ${{ jobs.merge.outputs.image }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  # One job per architecture, each on its matching native runner. Each pushes
+  # an anonymous (tag-less) image to ECR and records its digest as an artifact.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      IS_CI_AUTOMATION: "yes"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-central-1
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: "true"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image by digest
+        id: build
+        env:
+          IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
+        run: |
+          # Build this single platform and push it to ECR by digest only (no
+          # tag). push-by-digest keeps the pushed image anonymous so both arch
+          # runners can push concurrently without clobbering a shared tag; the
+          # merge job assigns the real tag afterwards. --metadata-file lets us
+          # read back the digest that ECR assigned.
+          docker buildx build \
+            -f "${{ inputs.dockerfile }}" \
+            --platform "${{ matrix.platform }}" \
+            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file metadata.json \
+            .
+          digest="$(jq -r '."containerimage.digest"' metadata.json)"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Export digest
+        run: |
+          # Record the digest as an empty file named after the sha256 hex, so
+          # the merge job can reconstruct `${IMAGE}@sha256:<hex>` references by
+          # listing the downloaded artifact directory.
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.artifact-prefix }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Combine the per-arch digests into one manifest list under the real tag.
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      IS_CI_AUTOMATION: "yes"
+    outputs:
+      image: ${{ steps.merge.outputs.image }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-central-1
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: "true"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ inputs.artifact-prefix }}-*
+          merge-multiple: true
+
+      - name: Create manifest list and push
+        id: merge
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}"
+        run: |
+          # imagetools create references digests already in ECR, so nothing is
+          # rebuilt or re-pushed here -- it only writes the manifest list. The
+          # glob expands to one `${IMAGE}@sha256:<hex>` per downloaded digest.
+          TARGET="${IMAGE}:${{ inputs.tag }}"
+          docker buildx imagetools create -t "$TARGET" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          docker buildx imagetools inspect "$TARGET"
+          echo "image=$TARGET" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -35,7 +35,8 @@ jobs:
               - 'assets/**'
               - 'static/**'
               - 'templates/**'
-              - 'scripts/entry.sh'
+              # Dockerfile COPYs the whole scripts/ dir.
+              - 'scripts/**'
               - 'Dockerfile'
               - 'manage.py'
               - 'MANIFEST.in'
@@ -45,7 +46,15 @@ jobs:
               - 'README.md'
               - 'src/**'
               - 'uv.lock'
-              - 'vite.config.mjs'
+              # Frontend build inputs COPYd by the Dockerfile (vite.config is
+              # .mts, not .mjs); tsconfig.json and env.d.ts were missing.
+              - 'vite.config.mts'
+              - 'tsconfig.json'
+              - 'env.d.ts'
+              # The accounts bundle imports the shared keycloak theme via the
+              # `@kc` vite alias, so `npm run build` compiles it into the accounts
+              # image -- theme edits must rebuild (and redeploy) accounts too.
+              - 'keycloak/themes/**'
             keycloak-theme-changed:
               - 'keycloak/themes/**'
               - 'Dockerfile.keycloak'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -53,16 +53,57 @@ jobs:
               - 'pulumi/**'
               - '.github/**'
 
-  # Build whichever image(s) changed and apply them to the stage stack in a
-  # SINGLE `pulumi up`. Pulumi takes a stack-wide lock per update, so running
-  # accounts and keycloak deploys as separate parallel jobs caused
-  # "[409] Conflict: Another update is currently in progress." See issue #884.
-  deploy:
+  # Build the accounts image multi-arch (amd64 for ECS Fargate, arm64 for the
+  # Thunderbird Pro EKS Graviton clusters) on native runners, one arch each,
+  # then merge into a manifest list tagged with the git sha. See
+  # build-multiarch-image.yml. Only runs when accounts/IaC changed.
+  build-accounts-image:
     needs: detect-changes
     if: >-
       needs.detect-changes.outputs.src-changed == 'true' ||
+      needs.detect-changes.outputs.iac-changed == 'true'
+    uses: ./.github/workflows/build-multiarch-image.yml
+    secrets: inherit
+    with:
+      dockerfile: Dockerfile
+      tag: ${{ github.sha }}
+      artifact-prefix: accounts
+
+  # Same native-runner multi-arch build for the keycloak image. Only runs when
+  # keycloak/IaC changed.
+  build-keycloak-image:
+    needs: detect-changes
+    if: >-
       needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
       needs.detect-changes.outputs.iac-changed == 'true'
+    uses: ./.github/workflows/build-multiarch-image.yml
+    secrets: inherit
+    with:
+      dockerfile: Dockerfile.keycloak
+      tag: keycloak-${{ github.sha }}
+      artifact-prefix: keycloak
+
+  # Apply whichever image(s) were built to the stage stack in a SINGLE
+  # `pulumi up`. Pulumi takes a stack-wide lock per update, so running accounts
+  # and keycloak deploys as separate parallel jobs caused "[409] Conflict:
+  # Another update is currently in progress." See issue #884.
+  deploy:
+    needs:
+      - detect-changes
+      - build-accounts-image
+      - build-keycloak-image
+    # Run whenever something changed AND neither build was cancelled/failed.
+    # always() is required because the build jobs are individually skipped when
+    # their image didn't change -- without it, a skipped need would skip deploy.
+    if: >-
+      always() &&
+      (needs.detect-changes.outputs.src-changed == 'true' ||
+       needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
+       needs.detect-changes.outputs.iac-changed == 'true') &&
+      needs.build-accounts-image.result != 'failure' &&
+      needs.build-accounts-image.result != 'cancelled' &&
+      needs.build-keycloak-image.result != 'failure' &&
+      needs.build-keycloak-image.result != 'cancelled'
     environment:
       name: staging
       deployment: true
@@ -70,14 +111,17 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
       PULUMI_DIR: "pulumi"
-      # Whether the accounts image was (re)built this run; gates the
-      # accounts config update, its pulumi targets, and the release artifacts.
-      BUILD_ACCOUNTS: ${{ needs.detect-changes.outputs.src-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' }}
-      # Whether the keycloak image was (re)built this run.
-      BUILD_KEYCLOAK: ${{ needs.detect-changes.outputs.keycloak-theme-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' }}
+      # Manifest-list tags produced by the build jobs above; empty when that
+      # image wasn't (re)built this run (its build job was skipped).
+      ACCOUNTS_IMAGE: ${{ needs.build-accounts-image.outputs.image }}
+      KEYCLOAK_IMAGE: ${{ needs.build-keycloak-image.outputs.image }}
+      # Whether each image was (re)built this run; gates the config update,
+      # pulumi targets, and release artifacts below.
+      BUILD_ACCOUNTS: ${{ needs.build-accounts-image.outputs.image != '' }}
+      BUILD_KEYCLOAK: ${{ needs.build-keycloak-image.outputs.image != '' }}
     outputs:
       # Non-empty only when the accounts image was built; used to gate create-release.
-      accounts-image: ${{ steps.build-accounts.outputs.accounts-image }}
+      accounts-image: ${{ needs.build-accounts-image.outputs.image }}
     steps:
       # Preparation for future steps
       - uses: actions/checkout@v4
@@ -90,12 +134,6 @@ jobs:
         with:
           aws-region: eu-central-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          mask-password: "true"
 
       - name: Set up Python ${{ vars.PYTHON_VERSION}}
         uses: actions/setup-python@v5
@@ -118,43 +156,10 @@ jobs:
           curl -fsSL https://get.pulumi.com | sh
           pip install -Ur requirements.txt
 
-      # Both the accounts and keycloak images are built multi-arch via Buildx +
-      # QEMU (linux/amd64 for ECS Fargate today, linux/arm64 for the Thunderbird
-      # Pro EKS clusters on Graviton). Each <tag> is a manifest list, so every
-      # runtime pulls its matching variant. Set these up whenever either image
-      # is (re)built; they must run before the build steps below.
-      - name: Set up QEMU
-        if: env.BUILD_ACCOUNTS == 'true' || env.BUILD_KEYCLOAK == 'true'
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        if: env.BUILD_ACCOUNTS == 'true' || env.BUILD_KEYCLOAK == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      # Produce the accounts container image (only when accounts/IaC changed).
-      - name: Build, tag, and push accounts image to Amazon ECR
-        id: build-accounts
-        if: env.BUILD_ACCOUNTS == 'true'
-        env:
-          ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:${{ github.sha }}"
-        run: |
-          # Build a multi-arch image (amd64 for ECS, arm64 for EKS) and push the
-          # manifest list to ECR. buildx --push publishes directly (no docker push).
-          docker buildx build -t $ECR_TAG \
-            --platform linux/amd64,linux/arm64 --push .
-          echo "accounts-image=$ECR_TAG" >> $GITHUB_OUTPUT
-
-      # Produce the keycloak container image (only when keycloak/IaC changed).
-      - name: Build, tag, and push keycloak image to Amazon ECR
-        id: build-keycloak
-        if: env.BUILD_KEYCLOAK == 'true'
-        env:
-          ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:keycloak-${{ github.sha }}"
-        run: |
-          # Build a multi-arch image (amd64 for ECS, arm64 for EKS) and push the
-          # manifest list to ECR. buildx --push publishes directly (no docker push).
-          docker buildx build -f Dockerfile.keycloak -t $ECR_TAG \
-            --platform linux/amd64,linux/arm64 --push .
-          echo "keycloak-image=$ECR_TAG" >> $GITHUB_OUTPUT
+      # The accounts and keycloak images are built by the build-accounts-image /
+      # build-keycloak-image jobs above (native-runner multi-arch, one arch per
+      # runner, merged into a manifest list). This job consumes their manifest
+      # tags via ACCOUNTS_IMAGE / KEYCLOAK_IMAGE and only deploys.
 
       - name: Get version from pyproject.toml
         id: read-version
@@ -172,7 +177,7 @@ jobs:
         id: create-keycloak-artifact
         if: env.BUILD_KEYCLOAK == 'true'
         run: |
-          echo '{"ecr_tag": "${{ steps.build-keycloak.outputs.keycloak-image }}", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
+          echo '{"ecr_tag": "'"$KEYCLOAK_IMAGE"'", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
 
       - name: Archive the keycloak deployment artifact
         if: env.BUILD_KEYCLOAK == 'true'
@@ -187,7 +192,7 @@ jobs:
         id: create-artifact
         if: env.BUILD_ACCOUNTS == 'true'
         run: |
-          echo '{"ecr_tag": "${{ steps.build-accounts.outputs.accounts-image }}", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
+          echo '{"ecr_tag": "'"$ACCOUNTS_IMAGE"'", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
 
       - name: Archive the deployment artifact
         id: tag-archive
@@ -223,8 +228,8 @@ jobs:
         shell: bash
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          ACCOUNTS_IMAGE: ${{ steps.build-accounts.outputs.accounts-image }}
-          KEYCLOAK_IMAGE: ${{ steps.build-keycloak.outputs.keycloak-image }}
+          # ACCOUNTS_IMAGE / KEYCLOAK_IMAGE are inherited from the job-level env
+          # (the manifest tags output by the build-*-image jobs).
         run: |
           # Update the PATH to include the right version of Pulumi; this is non-trivial or impossible
           # to do with the GHA workflow "env" settings above.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,9 +6,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  # TEMPORARY: run on every push so the split-arch build can be tested from any
-  # branch. Restore the `branches: [main]` filter before merge.
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -53,63 +53,16 @@ jobs:
               - 'pulumi/**'
               - '.github/**'
 
-  # Build the accounts image multi-arch (amd64 for ECS Fargate, arm64 for the
-  # Thunderbird Pro EKS Graviton clusters) on native runners, one arch each,
-  # then merge into a manifest list tagged with the git sha. See
-  # build-multiarch-image.yml. Only runs when accounts/IaC changed.
-  build-accounts-image:
+  # Build whichever image(s) changed and apply them to the stage stack in a
+  # SINGLE `pulumi up`. Pulumi takes a stack-wide lock per update, so running
+  # accounts and keycloak deploys as separate parallel jobs caused
+  # "[409] Conflict: Another update is currently in progress." See issue #884.
+  deploy:
     needs: detect-changes
     if: >-
       needs.detect-changes.outputs.src-changed == 'true' ||
-      needs.detect-changes.outputs.iac-changed == 'true'
-    uses: ./.github/workflows/build-multiarch-image.yml
-    # TEMPORARY: no `secrets: inherit` during the dry-run -- the build no longer
-    # pushes to ECR, so it needs no AWS credentials. Restore before merge.
-    with:
-      dockerfile: Dockerfile
-      tag: ${{ github.sha }}
-      artifact-prefix: accounts
-
-  # Same native-runner multi-arch build for the keycloak image. Only runs when
-  # keycloak/IaC changed.
-  build-keycloak-image:
-    needs: detect-changes
-    if: >-
       needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
       needs.detect-changes.outputs.iac-changed == 'true'
-    uses: ./.github/workflows/build-multiarch-image.yml
-    # TEMPORARY: no `secrets: inherit` during the dry-run -- see accounts job above.
-    with:
-      dockerfile: Dockerfile.keycloak
-      tag: keycloak-${{ github.sha }}
-      artifact-prefix: keycloak
-
-  # Apply whichever image(s) were built to the stage stack in a SINGLE
-  # `pulumi up`. Pulumi takes a stack-wide lock per update, so running accounts
-  # and keycloak deploys as separate parallel jobs caused "[409] Conflict:
-  # Another update is currently in progress." See issue #884.
-  deploy:
-    needs:
-      - detect-changes
-      - build-accounts-image
-      - build-keycloak-image
-    # TEMPORARY: deploy disabled for the dry-run build test. This condition can
-    # never be true (no such branch), so the job is always skipped -- which
-    # cascades to skip create-release + e2e (they need it) and deploys nothing
-    # to stage. Remove this line to restore the real condition below before merge.
-    if: github.ref == 'refs/heads/__deploy-disabled-for-dryrun__'
-    # Run whenever something changed AND neither build was cancelled/failed.
-    # always() is required because the build jobs are individually skipped when
-    # their image didn't change -- without it, a skipped need would skip deploy.
-    # if: >-
-    #   always() &&
-    #   (needs.detect-changes.outputs.src-changed == 'true' ||
-    #    needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
-    #    needs.detect-changes.outputs.iac-changed == 'true') &&
-    #   needs.build-accounts-image.result != 'failure' &&
-    #   needs.build-accounts-image.result != 'cancelled' &&
-    #   needs.build-keycloak-image.result != 'failure' &&
-    #   needs.build-keycloak-image.result != 'cancelled'
     environment:
       name: staging
       deployment: true
@@ -117,17 +70,14 @@ jobs:
     env:
       IS_CI_AUTOMATION: "yes"
       PULUMI_DIR: "pulumi"
-      # Manifest-list tags produced by the build jobs above; empty when that
-      # image wasn't (re)built this run (its build job was skipped).
-      ACCOUNTS_IMAGE: ${{ needs.build-accounts-image.outputs.image }}
-      KEYCLOAK_IMAGE: ${{ needs.build-keycloak-image.outputs.image }}
-      # Whether each image was (re)built this run; gates the config update,
-      # pulumi targets, and release artifacts below.
-      BUILD_ACCOUNTS: ${{ needs.build-accounts-image.outputs.image != '' }}
-      BUILD_KEYCLOAK: ${{ needs.build-keycloak-image.outputs.image != '' }}
+      # Whether the accounts image was (re)built this run; gates the
+      # accounts config update, its pulumi targets, and the release artifacts.
+      BUILD_ACCOUNTS: ${{ needs.detect-changes.outputs.src-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' }}
+      # Whether the keycloak image was (re)built this run.
+      BUILD_KEYCLOAK: ${{ needs.detect-changes.outputs.keycloak-theme-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' }}
     outputs:
       # Non-empty only when the accounts image was built; used to gate create-release.
-      accounts-image: ${{ needs.build-accounts-image.outputs.image }}
+      accounts-image: ${{ steps.build-accounts.outputs.accounts-image }}
     steps:
       # Preparation for future steps
       - uses: actions/checkout@v4
@@ -140,6 +90,12 @@ jobs:
         with:
           aws-region: eu-central-1
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: "true"
 
       - name: Set up Python ${{ vars.PYTHON_VERSION}}
         uses: actions/setup-python@v5
@@ -162,10 +118,31 @@ jobs:
           curl -fsSL https://get.pulumi.com | sh
           pip install -Ur requirements.txt
 
-      # The accounts and keycloak images are built by the build-accounts-image /
-      # build-keycloak-image jobs above (native-runner multi-arch, one arch per
-      # runner, merged into a manifest list). This job consumes their manifest
-      # tags via ACCOUNTS_IMAGE / KEYCLOAK_IMAGE and only deploys.
+      # Produce the accounts container image (only when accounts/IaC changed).
+      # This image is amd64-only (ECS Fargate). Multi-arch (amd64 + arm64)
+      # publishing lives in the decoupled publish-images.yml -> GHCR pipeline.
+      - name: Build, tag, and push accounts image to Amazon ECR
+        id: build-accounts
+        if: env.BUILD_ACCOUNTS == 'true'
+        env:
+          ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:${{ github.sha }}"
+        run: |
+          # Build a docker container and push it to ECR so that it can be deployed to ECS.
+          docker build -t $ECR_TAG --platform="linux/amd64" .
+          docker push $ECR_TAG
+          echo "accounts-image=$ECR_TAG" >> $GITHUB_OUTPUT
+
+      # Produce the keycloak container image (only when keycloak/IaC changed).
+      - name: Build, tag, and push keycloak image to Amazon ECR
+        id: build-keycloak
+        if: env.BUILD_KEYCLOAK == 'true'
+        env:
+          ECR_TAG: "${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT }}:keycloak-${{ github.sha }}"
+        run: |
+          # Build a docker container and push it to ECR so that it can be deployed to ECS.
+          docker build -f Dockerfile.keycloak -t $ECR_TAG --platform="linux/amd64" .
+          docker push $ECR_TAG
+          echo "keycloak-image=$ECR_TAG" >> $GITHUB_OUTPUT
 
       - name: Get version from pyproject.toml
         id: read-version
@@ -183,7 +160,7 @@ jobs:
         id: create-keycloak-artifact
         if: env.BUILD_KEYCLOAK == 'true'
         run: |
-          echo '{"ecr_tag": "'"$KEYCLOAK_IMAGE"'", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
+          echo '{"ecr_tag": "${{ steps.build-keycloak.outputs.keycloak-image }}", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
 
       - name: Archive the keycloak deployment artifact
         if: env.BUILD_KEYCLOAK == 'true'
@@ -198,7 +175,7 @@ jobs:
         id: create-artifact
         if: env.BUILD_ACCOUNTS == 'true'
         run: |
-          echo '{"ecr_tag": "'"$ACCOUNTS_IMAGE"'", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
+          echo '{"ecr_tag": "${{ steps.build-accounts.outputs.accounts-image }}", "version": "${{ steps.read-version.outputs.value }}"}' > deployment.json
 
       - name: Archive the deployment artifact
         id: tag-archive
@@ -234,8 +211,8 @@ jobs:
         shell: bash
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          # ACCOUNTS_IMAGE / KEYCLOAK_IMAGE are inherited from the job-level env
-          # (the manifest tags output by the build-*-image jobs).
+          ACCOUNTS_IMAGE: ${{ steps.build-accounts.outputs.accounts-image }}
+          KEYCLOAK_IMAGE: ${{ steps.build-keycloak.outputs.keycloak-image }}
         run: |
           # Update the PATH to include the right version of Pulumi; this is non-trivial or impossible
           # to do with the GHA workflow "env" settings above.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,11 +6,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # TEMPORARY: run on every push so the split-arch build can be tested from any
+  # branch. Restore the `branches: [main]` filter before merge.
   push:
-    branches:
-      - main
-      # TEMPORARY: exercise the split-arch build on this branch. Remove before merge.
-      - ci/split-arch-image-build
   workflow_dispatch:
 
 permissions:
@@ -65,7 +63,8 @@ jobs:
       needs.detect-changes.outputs.src-changed == 'true' ||
       needs.detect-changes.outputs.iac-changed == 'true'
     uses: ./.github/workflows/build-multiarch-image.yml
-    secrets: inherit
+    # TEMPORARY: no `secrets: inherit` during the dry-run -- the build no longer
+    # pushes to ECR, so it needs no AWS credentials. Restore before merge.
     with:
       dockerfile: Dockerfile
       tag: ${{ github.sha }}
@@ -79,7 +78,7 @@ jobs:
       needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
       needs.detect-changes.outputs.iac-changed == 'true'
     uses: ./.github/workflows/build-multiarch-image.yml
-    secrets: inherit
+    # TEMPORARY: no `secrets: inherit` during the dry-run -- see accounts job above.
     with:
       dockerfile: Dockerfile.keycloak
       tag: keycloak-${{ github.sha }}
@@ -94,18 +93,23 @@ jobs:
       - detect-changes
       - build-accounts-image
       - build-keycloak-image
+    # TEMPORARY: deploy disabled for the dry-run build test. This condition can
+    # never be true (no such branch), so the job is always skipped -- which
+    # cascades to skip create-release + e2e (they need it) and deploys nothing
+    # to stage. Remove this line to restore the real condition below before merge.
+    if: github.ref == 'refs/heads/__deploy-disabled-for-dryrun__'
     # Run whenever something changed AND neither build was cancelled/failed.
     # always() is required because the build jobs are individually skipped when
     # their image didn't change -- without it, a skipped need would skip deploy.
-    if: >-
-      always() &&
-      (needs.detect-changes.outputs.src-changed == 'true' ||
-       needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
-       needs.detect-changes.outputs.iac-changed == 'true') &&
-      needs.build-accounts-image.result != 'failure' &&
-      needs.build-accounts-image.result != 'cancelled' &&
-      needs.build-keycloak-image.result != 'failure' &&
-      needs.build-keycloak-image.result != 'cancelled'
+    # if: >-
+    #   always() &&
+    #   (needs.detect-changes.outputs.src-changed == 'true' ||
+    #    needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
+    #    needs.detect-changes.outputs.iac-changed == 'true') &&
+    #   needs.build-accounts-image.result != 'failure' &&
+    #   needs.build-accounts-image.result != 'cancelled' &&
+    #   needs.build-keycloak-image.result != 'failure' &&
+    #   needs.build-keycloak-image.result != 'cancelled'
     environment:
       name: staging
       deployment: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+      # TEMPORARY: exercise the split-arch build on this branch. Remove before merge.
+      - ci/split-arch-image-build
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,92 @@
+---
+# Decoupled image-publish pipeline. On merge to main it builds the accounts and
+# keycloak images as native multi-arch (amd64 + arm64) manifest lists and pushes
+# them to GHCR. This is INDEPENDENT of the deploy-stage pipeline (merge.yml):
+# it uses no cloud credentials, runs no Pulumi, and deploys nothing -- it only
+# publishes images. See docs/ci/image-publish-pipeline.md for the architecture.
+name: publish-images
+
+concurrency:
+  group: publish-images-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Separate job: decide which image(s) changed and read the version once, so
+  # the build jobs below only run for images that actually changed.
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      accounts-changed: ${{ steps.check.outputs.accounts-changed }}
+      keycloak-changed: ${{ steps.check.outputs.keycloak-changed }}
+      version: ${{ steps.read-version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: check
+        with:
+          filters: |
+            accounts-changed:
+              - 'assets/**'
+              - 'static/**'
+              - 'templates/**'
+              - 'scripts/entry.sh'
+              - 'Dockerfile'
+              - 'manage.py'
+              - 'MANIFEST.in'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'pyproject.toml'
+              - 'README.md'
+              - 'src/**'
+              - 'uv.lock'
+              - 'vite.config.mjs'
+            keycloak-changed:
+              - 'keycloak/**'
+              - 'Dockerfile.keycloak'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'scripts/entry-keycloak.sh'
+              - 'scripts/apply-mfa-config.sh'
+
+      - name: Get version from pyproject.toml
+        id: read-version
+        uses: SebRollen/toml-action@v1.2.0
+        with:
+          file: 'pyproject.toml'
+          field: 'project.version'
+
+  accounts:
+    needs: detect-changes
+    # workflow_dispatch always rebuilds; pushes rebuild only on a relevant change.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.accounts-changed == 'true'
+    uses: ./.github/workflows/build-multiarch-image.yml
+    with:
+      image: ghcr.io/thunderbird/thunderbird-accounts
+      dockerfile: Dockerfile
+      version: ${{ needs.detect-changes.outputs.version }}
+      artifact-prefix: accounts
+
+  keycloak:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.keycloak-changed == 'true'
+    uses: ./.github/workflows/build-multiarch-image.yml
+    with:
+      image: ghcr.io/thunderbird/thunderbird-accounts-keycloak
+      dockerfile: Dockerfile.keycloak
+      version: ${{ needs.detect-changes.outputs.version }}
+      artifact-prefix: keycloak

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -33,9 +33,9 @@ jobs:
       keycloak-changed: ${{ steps.check.outputs.keycloak-changed }}
       version: ${{ steps.read-version.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: check
         with:
           filters: |
@@ -73,7 +73,7 @@ jobs:
 
       - name: Get version from pyproject.toml
         id: read-version
-        uses: SebRollen/toml-action@v1.2.0
+        uses: SebRollen/toml-action@b1b3628f55fc3a28208d4203ada8b737e9687876 # v1.2.0
         with:
           file: 'pyproject.toml'
           field: 'project.version'

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -8,7 +8,10 @@ name: publish-images
 
 concurrency:
   group: publish-images-${{ github.ref }}
-  cancel-in-progress: true
+  # Serialize (don't cancel) so every merged commit's :<sha> image gets
+  # published and a run is never aborted mid-push/merge. Queued runs still
+  # settle :latest to the newest finished build.
+  cancel-in-progress: false
 
 on:
   push:
@@ -40,17 +43,26 @@ jobs:
               - 'assets/**'
               - 'static/**'
               - 'templates/**'
-              - 'scripts/entry.sh'
+              # The accounts frontend bundle imports the shared keycloak theme
+              # via the `@kc` vite alias (-> keycloak/themes/tbpro/assets), so
+              # `npm run build` compiles it into the accounts image. Theme edits
+              # must therefore rebuild accounts too.
+              - 'keycloak/themes/**'
+              # The accounts Dockerfile COPYs the whole scripts/ dir.
+              - 'scripts/**'
               - 'Dockerfile'
               - 'manage.py'
               - 'MANIFEST.in'
               - 'package.json'
               - 'package-lock.json'
               - 'pyproject.toml'
-              - 'README.md'
               - 'src/**'
               - 'uv.lock'
-              - 'vite.config.mjs'
+              # Frontend build inputs COPYd by the Dockerfile (note: .mts, plus
+              # tsconfig.json and env.d.ts).
+              - 'vite.config.mts'
+              - 'tsconfig.json'
+              - 'env.d.ts'
             keycloak-changed:
               - 'keycloak/**'
               - 'Dockerfile.keycloak'

--- a/docs/ci/image-publish-pipeline.md
+++ b/docs/ci/image-publish-pipeline.md
@@ -1,0 +1,73 @@
+# CI image pipelines
+
+Two **independent** pipelines produce container images. They share no jobs, no
+credentials, and no triggers beyond both reacting to `main`.
+
+| Pipeline | Workflow | Registry | Arch | Purpose |
+|---|---|---|---|---|
+| **Deploy-stage** | `merge.yml` | ECR | amd64 only | Build + deploy to stage (ECS Fargate) via Pulumi |
+| **Publish-images** | `publish-images.yml` + `build-multiarch-image.yml` | GHCR | amd64 + arm64 | Publish multi-arch manifest lists; no deploy |
+
+## Publish-images (new, decoupled)
+
+Native-runner split-arch build: each architecture builds on its own hardware
+(no QEMU emulation) and pushes to GHCR by digest; a merge step stitches the
+digests into one manifest list tagged `:<sha>`, `:v<version>`, and `:latest`.
+Auth is the automatic `GITHUB_TOKEN` (`packages: write`) — no cloud credentials.
+
+```mermaid
+flowchart TD
+    push["push to main / workflow_dispatch"] --> detect
+
+    subgraph publish["publish-images.yml (GHCR, no deploy)"]
+        detect["detect-changes (separate job)<br/>paths-filter + read version"]
+
+        detect -->|accounts changed| acc
+        detect -->|keycloak changed| kc
+
+        subgraph acc["accounts → build-multiarch-image.yml"]
+            direction TB
+            a_amd["build amd64<br/>(ubuntu-latest)<br/>push by digest"]
+            a_arm["build arm64<br/>(ubuntu-24.04-arm)<br/>push by digest"]
+            a_merge["merge → manifest list<br/>:sha :vX.Y.Z :latest"]
+            a_amd --> a_merge
+            a_arm --> a_merge
+        end
+
+        subgraph kc["keycloak → build-multiarch-image.yml"]
+            direction TB
+            k_amd["build amd64<br/>(ubuntu-latest)<br/>push by digest"]
+            k_arm["build arm64<br/>(ubuntu-24.04-arm)<br/>push by digest"]
+            k_merge["merge → manifest list<br/>:sha :vX.Y.Z :latest"]
+            k_amd --> k_merge
+            k_arm --> k_merge
+        end
+    end
+
+    a_merge --> ghcr[("GHCR<br/>ghcr.io/thunderbird/thunderbird-accounts{,-keycloak}")]
+    k_merge --> ghcr
+```
+
+## Deploy-stage (unchanged, for contrast)
+
+`merge.yml` still owns deployment: it builds the amd64 image, pushes to ECR,
+and runs a single `pulumi up` to stage. It assumes the AWS deploy role via OIDC.
+
+```mermaid
+flowchart TD
+    push2["push to main"] --> detect2["detect-changes"]
+    detect2 --> build2["build amd64 image<br/>docker build --platform linux/amd64"]
+    build2 --> ecr[("ECR")]
+    build2 --> deploy["pulumi up → stage (ECS Fargate)"]
+    deploy --> release["draft GitHub release<br/>(prod promotion)"]
+```
+
+## Why they're separate
+
+- **Blast radius** — the GHCR publish holds no cloud credentials, so a branch or
+  fork build can never assume the deploy role (the trust-boundary concern that
+  killed running the deploy workflow off feature branches).
+- **Independent cadence** — image publishing and stage deployment can evolve,
+  fail, and be re-run without affecting each other.
+- **Native multi-arch** — arm64 builds on real Graviton runners instead of QEMU
+  emulation, so they're faster and not subject to emulation miscompiles.


### PR DESCRIPTION
## What

Splits container-image **publishing** out of the **deploy** pipeline into a standalone GHCR pipeline, and moves the multi-arch (amd64 + arm64) build onto **native runners** (no QEMU) using the split-worker strategy from [sredevopsorg/multi-arch-docker-github-workflow](https://github.com/sredevopsorg/multi-arch-docker-github-workflow).

## Two independent pipelines

| Pipeline | Workflow | Registry | Arch | Deploys? |
|---|---|---|---|---|
| **Deploy-stage** | `merge.yml` | ECR | amd64 | ✅ Pulumi → stage |
| **Publish-images** (new) | `publish-images.yml` + `build-multiarch-image.yml` | GHCR | amd64 + arm64 | ❌ publish only |

See `docs/ci/image-publish-pipeline.md` for a mermaid diagram of both.

## Changes

- **`merge.yml`** — reverts the deploy build to **single-arch amd64 → ECR** (undoing the QEMU/Buildx multi-arch added in #1027 / #974). Deploy, artifacts, and `detect-changes` (its own job) are otherwise unchanged.
- **`publish-images.yml`** (new) — on merge to `main` (or `workflow_dispatch`): a **separate `detect-changes` job** decides which image changed and reads the version, then builds `accounts` and `keycloak` to GHCR. No cloud credentials, no Pulumi.
- **`build-multiarch-image.yml`** — reusable native split-arch builder targeting **GHCR via `GITHUB_TOKEN`**: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`, pushed by digest, merged into one manifest list tagged **`:<sha>`, `:v<version>`, `:latest`**. Separate GHCR packages per image (`.../thunderbird-accounts`, `.../thunderbird-accounts-keycloak`).
- **`docs/ci/image-publish-pipeline.md`** — architecture diagram + rationale.

## Verified

An earlier revision of this branch ran the native builds green (all four amd64/arm64 build jobs succeeded; arm64 on native Graviton runners ~165s for accounts). `actionlint` passes on all three workflows.

## ⚠️ Reviewer call-out: arm64 in production

Reverting `merge.yml` to amd64-only means **ECR no longer gets an arm64 image**. The Graviton/arm64 EKS need that #1027/#974 addressed is now served **only from GHCR**. This is intentional per the decoupling, **but** anything currently pulling the arm64 variant from ECR must be repointed to GHCR (or ECR multi-arch restored) before those consumers rely on it. Flagging so it's a conscious decision.

## Action versions (reviewer note)

All third-party actions in the **two new** workflows are pinned to a commit SHA (with a `# vX.Y.Z` comment); no existing workflow was touched. Getting to "latest" meant some **notable major bumps** that differ from the `v3`/`v4` tags the rest of the repo pins:

| Action | Repo elsewhere | New workflows |
|---|---|---|
| actions/checkout | `v4` | **v7.0.0** |
| docker/login-action | `v3` | **v4.4.0** |
| docker/setup-buildx-action | `v3` | **v4.2.0** |
| actions/upload-artifact | `v4` | **v7.0.1** |
| actions/download-artifact | `v4` | **v8.0.1** |
| dorny/paths-filter | `v3` | **v4.0.2** |
| SebRollen/toml-action | `v1.2.0` | v1.2.0 (already latest) |

Low-risk for our simple usage, and `upload-artifact@v7` ↔ `download-artifact@v8` are the intended compatible pair (v8 supports v7's direct-upload feature). Flagging in case reviewers prefer version **consistency** with the rest of the repo — any single one is easy to dial back.

## Follow-up

Deploy-side companion (pull the accounts image from GHCR on the Graviton EKS clusters): **thunderbird/accounts-deploy#25** (draft) — blocked on this PR merging + the GHCR images publishing.

## Notes

- `release.yml` is left as-is: its `imagetools` retag (from #1027) works fine on a single-arch amd64 image, so no revert needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
