### PR TITLE
Enforce f-string interpolation with Ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ These can be installed be appending `--extra <optional dependency>` like so:
 uv sync --extra cli --extra docs --extra subscription
 ```
 
+## Python linting
+
+Ruff is the source of truth for Python linting. Read `pyproject.toml` and `pulumi/ruff.toml` for the active rules.
+
 ## Re-bootstrapping the project
 
 If you find your environment in a troubled state (it happens) you can add the option `--from-scratch` to bootstrap like

--- a/pulumi/ruff.toml
+++ b/pulumi/ruff.toml
@@ -20,7 +20,9 @@ quote-style = "single"
 
 [lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
+# Require f-strings for interpolation instead of printf-style formatting (UP031)
+# or `.format` calls (UP032).
+select = ["E", "F", "UP031", "UP032"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,9 @@ quote-style = "single"
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # Enable flagging print (T201)
-select = ["E", "F", "T201"]
+# Require f-strings for interpolation instead of printf-style formatting (UP031)
+# or `.format` calls (UP032).
+select = ["E", "F", "T201", "UP031", "UP032"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -441,7 +441,7 @@ class OIDCRefreshSession(SessionRefresh):
         request.session['oidc_login_next'] = request.get_full_path()
 
         query = urlencode(params, quote_via=quote)
-        return '{auth_url}?{query}'.format(auth_url=auth_url, query=query)
+        return f'{auth_url}?{query}'
 
 
 class SetHostIPInAllowedHostsMiddleware:


### PR DESCRIPTION
## What changed?

Adds rule to express that we prefer f-strings, enforcing it with pre-commit hook and CI.

## Why?

Saves time in the peer-review process from accidentally not using them and then
having them flagged by a human and fixed.

## Limitations and Notes

Devs need to each install the pre-commit hook:

```
uv tool install pre-commit
pre-commit install
```
## Applicable Issues

Inspired by PR #1075, where I used non-f-strings in a few places, a mistake
which which likely to be completed by myself or other new contributors without
automation.
