### PR TITLE
Revert tbProSendUrl to its root url

### DIFF
--- a/assets/app/vue/components/YourServices.vue
+++ b/assets/app/vue/components/YourServices.vue
@@ -1,16 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 
 const tbProAppointmentUrl = window._page?.tbProAppointmentUrl;
-const tbProSendUrl = computed(() => {
-  if (!window._page?.tbProSendUrl) return undefined;
-  const url = new URL('profile', window._page.tbProSendUrl);
-  url.searchParams.set('showDashboard', 'true');
-  return url.href;
-});
+const tbProSendUrl = window._page?.tbProSendUrl;
 </script>
 
 <template>


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Essentially reverting https://github.com/thunderbird/thunderbird-accounts/pull/1040/changes

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

`https://send.tb.pro/profile?showDashboard=true` gives us a 404.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

Unsure why this change was done but it seemed deliberate? Apparently send has a redirect from `/profile` to `/send/profile` [in this router code](https://github.com/thunderbird/tbpro-add-on/blob/main/packages/send/frontend/src/apps/send/router.ts#L68-L69) so unsure if the fix here is:

a) Revert the change so that the link at least is not broken
b) Keep the change but add `/send/profile` to the URL
c) Investigate + fix it in `tbpro-add-on` code base instead

If this is urgent and needs to be fixed asap, I'd do a).

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Relates to https://github.com/thunderbird/thunderbird-accounts/pull/1040/changes
Also relates to https://github.com/thunderbird/thunderbird-accounts/issues/1039