### PR TITLE
Restructure routing table to be more secure-by-default (#1070)

### DIFF
--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -1,6 +1,7 @@
 from requests.auth import HTTPBasicAuth
+from enum import StrEnum
 from json import JSONDecodeError
-from urllib.parse import urlencode, quote
+from urllib.parse import urlencode, quote, urlsplit
 from django.utils.crypto import get_random_string
 import requests
 from time import time
@@ -12,9 +13,13 @@ from socket import gethostbyname, gethostname
 from typing import Optional
 
 from django.conf import settings
+from django.contrib import admin
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.views import redirect_to_login
 from django.contrib import messages
-from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.core.exceptions import ImproperlyConfigured, PermissionDenied, SuspiciousOperation
 from django.http import HttpRequest, JsonResponse, HttpResponseRedirect
+from django.shortcuts import resolve_url
 from django.utils.translation import gettext_lazy as _
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from sentry_sdk import capture_exception
@@ -33,6 +38,77 @@ from mozilla_django_oidc.utils import add_state_and_verifier_and_nonce_to_sessio
 OIDC_ACCESS_TOKEN_KEY = 'oidc_access_token'
 OIDC_ID_TOKEN_KEY = 'oidc_id_token'
 OIDC_REFRESH_TOKEN_KEY = 'oidc_refresh_token'
+
+# authorizations supported by authorized_path()
+class RequiredAuth(StrEnum):
+    AUTHENTICATED = 'authenticated'
+    ACTIVE_SUBSCRIPTION = 'active_subscription'
+    ADMIN = 'admin'
+
+
+class AuthorizationMiddleware:
+    """
+    Enforce authorization from included URLconfs for secure-by-default protection of routes in there.
+    Ex:  authorized_path('', mail_urls.admin_urlpatterns, required_auth=Authz.ADMIN),
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        required_auth = view_kwargs.pop('required_auth', None)
+        if required_auth is None:
+            return None
+
+        try:
+            required_auth = RequiredAuth(required_auth)
+        except ValueError as exc:
+            raise ImproperlyConfigured(f'Unsupported required auth value: {required_auth}') from exc
+
+        if required_auth == RequiredAuth.AUTHENTICATED:
+            return self._require_authenticated(request)
+
+        if required_auth == RequiredAuth.ACTIVE_SUBSCRIPTION:
+            response = self._require_authenticated(request)
+            # Fail fast if they are not logged in.
+            if response is not None:
+                return response
+
+            from thunderbird_accounts.subscription.decorators import active_subscription_denial_response
+
+            return active_subscription_denial_response(
+                request,
+                error_message=view_kwargs.pop('active_subscription_error_message', None),
+                response_data=view_kwargs.pop('active_subscription_response_data', None),
+                status=view_kwargs.pop('active_subscription_status', 403),
+            )
+
+        if required_auth == RequiredAuth.ADMIN:
+            if admin.site.has_permission(request):
+                return None
+            return self._redirect_to_login(request, 'admin:login')
+
+        return None
+
+    def _require_authenticated(self, request):
+        if request.user.is_authenticated:
+            return None
+        return self._redirect_to_login(request, settings.LOGIN_URL)
+
+    @staticmethod
+    def _redirect_to_login(request, login_url, redirect_field_name=REDIRECT_FIELD_NAME):
+        path = request.build_absolute_uri()
+        resolved_login_url = resolve_url(login_url)
+        login_scheme, login_netloc = urlsplit(resolved_login_url)[:2]
+        current_scheme, current_netloc = urlsplit(path)[:2]
+        if (not login_scheme or login_scheme == current_scheme) and (
+            not login_netloc or login_netloc == current_netloc
+        ):
+            path = request.get_full_path()
+        return redirect_to_login(path, resolved_login_url, redirect_field_name)
 
 
 def store_tokens(request, access_token, id_token, refresh_token):

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -73,6 +74,45 @@ AUTHORIZATION_TEST_MIDDLEWARE = [
     'thunderbird_accounts.authentication.middleware.AuthorizationMiddleware',
 ]
 
+ADMIN_ROUTE_CASES = [
+    ('allow_list_entry_import', 'get', {}),
+    ('allow_list_entry_import_submit', 'post', {'bulk-entry': 'user@example.com'}),
+    ('admin_stalwart_list', 'get', {}),
+]
+
+AUTHENTICATED_ROUTE_CASES = [
+    ('legal_current', 'get', {}),
+    ('legal_accept', 'post', {}),
+    ('legal_decline', 'post', {}),
+    ('paddle_completed', 'get', {}),
+    ('paddle_info', 'post', {}),
+    ('paddle_txid', 'put', {'txid': 'tx_123'}),
+    ('paddle_is_done', 'post', {}),
+]
+
+ACTIVE_SUBSCRIPTION_ROUTE_CASES = [
+    ('app_password_set', 'post', {'name': 'Primary account', 'password': 'new-password'}),
+    ('display_name_set', 'post', {'display-name': 'New Name'}),
+    ('add_custom_domain', 'post', {'domain-name': 'example.com'}),
+    ('get_dns_records', 'get', {'domain-name': 'example.com'}),
+    ('verify_custom_domain', 'post', {'domain-name': 'example.com'}),
+    ('remove_custom_domain', 'delete', {'domain-name': 'example.com'}),
+    ('add_email_alias', 'post', {'email-alias': 'buddy', 'domain': settings.PRIMARY_EMAIL_DOMAIN}),
+    ('remove_email_alias', 'delete', {'email-alias': f'buddy@{settings.PRIMARY_EMAIL_DOMAIN}'}),
+    ('api_app_password_set', 'post', {'name': 'Primary account', 'password': 'new-password'}),
+    ('api_display_name_set', 'post', {'display-name': 'New Name'}),
+    ('paddle_portal', 'post', {}),
+    ('subscription_plan_info', 'post', {}),
+]
+
+if settings.AUTH_SCHEME == 'oidc':
+    AUTHENTICATED_ROUTE_CASES += [
+        ('mfa_reauth', 'get', {}),
+        ('logout_callback', 'get', {}),
+        ('reset_password', 'get', {}),
+    ]
+    ACTIVE_SUBSCRIPTION_ROUTE_CASES.append(('jmap-test', 'get', {}))
+
 
 @override_settings(
     ROOT_URLCONF='thunderbird_accounts.authentication.tests.test_middleware',
@@ -141,30 +181,93 @@ class AuthorizationMiddlewareTestCase(TestCase):
         self.assertEqual(response.json(), {'kwargs': {}})
 
 
+@override_settings(MIDDLEWARE=AUTHORIZATION_TEST_MIDDLEWARE, LOGIN_URL='/login/')
+class AuthorizationProtectedRouteTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+
+    def _request(self, route_case):
+        url_name, method, data = route_case
+        url = reverse(url_name)
+
+        if method == 'get':
+            return self.client.get(url, data=data, HTTP_ACCEPT='application/json')
+
+        return getattr(self.client, method)(
+            url,
+            data=json.dumps(data),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json',
+        )
+
+    def test_authenticated_routes_redirect_anonymous_users_to_login(self):
+        for route_case in AUTHENTICATED_ROUTE_CASES:
+            with self.subTest(url_name=route_case[0]):
+                response = self._request(route_case)
+
+                self.assertEqual(response.status_code, 302)
+                self.assertIn('next=', response['Location'])
+
+    def test_active_subscription_routes_reject_users_without_active_subscriptions(self):
+        user = User.objects.create(username=f'no-subscription@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='no-sub')
+        oidc_force_login(self.client, user)
+        custom_denials = {
+            'paddle_portal': (401, {}),
+            'subscription_plan_info': (404, {'success': False, 'error': 'No active subscription found'}),
+        }
+
+        for route_case in ACTIVE_SUBSCRIPTION_ROUTE_CASES:
+            url_name = route_case[0]
+            with self.subTest(url_name=url_name):
+                response = self._request(route_case)
+                expected_status, expected_json = custom_denials.get(
+                    url_name,
+                    (403, {'success': False, 'error': 'An active subscription is required.'}),
+                )
+
+                self.assertEqual(response.status_code, expected_status)
+                self.assertEqual(response.json(), expected_json)
+
+    def test_admin_routes_redirect_non_staff_users_to_admin_login(self):
+        user = User.objects.create(username=f'not-staff@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='not-staff')
+        oidc_force_login(self.client, user)
+
+        for route_case in ADMIN_ROUTE_CASES:
+            with self.subTest(url_name=route_case[0]):
+                response = self._request(route_case)
+
+                self.assertEqual(response.status_code, 302)
+                self.assertIn('/admin/login/', response['Location'])
+
+
 class AuthorizationUrlMetadataTestCase(SimpleTestCase):
-    def test_root_urlconf_marks_protected_route_groups(self):
-        self.assertEqual(
-            resolve(reverse('api_display_name_set')).extra_kwargs.get('required_auth'),
-            RequiredAuth.ACTIVE_SUBSCRIPTION,
-        )
-        self.assertEqual(
-            resolve(reverse('legal_current')).extra_kwargs.get('required_auth'),
-            RequiredAuth.AUTHENTICATED,
-        )
-        self.assertEqual(
-            resolve(reverse('admin_stalwart_list')).extra_kwargs.get('required_auth'),
-            RequiredAuth.ADMIN,
-        )
-        self.assertEqual(
-            resolve(reverse('paddle_portal')).extra_kwargs.get('required_auth'),
-            RequiredAuth.ACTIVE_SUBSCRIPTION,
-        )
+    def test_root_urlconf_marks_admin_route_groups(self):
+        for url_name, _, _ in ADMIN_ROUTE_CASES:
+            with self.subTest(url_name=url_name):
+                self.assertEqual(
+                    resolve(reverse(url_name)).extra_kwargs.get('required_auth'),
+                    RequiredAuth.ADMIN,
+                )
+
+    def test_root_urlconf_marks_authenticated_route_groups(self):
+        for url_name, _, _ in AUTHENTICATED_ROUTE_CASES:
+            with self.subTest(url_name=url_name):
+                self.assertEqual(
+                    resolve(reverse(url_name)).extra_kwargs.get('required_auth'),
+                    RequiredAuth.AUTHENTICATED,
+                )
+
+    def test_root_urlconf_marks_active_subscription_route_groups(self):
+        for url_name, _, _ in ACTIVE_SUBSCRIPTION_ROUTE_CASES:
+            with self.subTest(url_name=url_name):
+                self.assertEqual(
+                    resolve(reverse(url_name)).extra_kwargs.get('required_auth'),
+                    RequiredAuth.ACTIVE_SUBSCRIPTION,
+                )
+
+    def test_root_urlconf_marks_active_subscription_custom_denials(self):
         self.assertEqual(resolve(reverse('paddle_portal')).extra_kwargs.get('active_subscription_response_data'), {})
         self.assertEqual(resolve(reverse('paddle_portal')).extra_kwargs.get('active_subscription_status'), 401)
-        self.assertEqual(
-            resolve(reverse('subscription_plan_info')).extra_kwargs.get('required_auth'),
-            RequiredAuth.ACTIVE_SUBSCRIPTION,
-        )
         self.assertEqual(
             resolve(reverse('subscription_plan_info')).extra_kwargs.get('active_subscription_error_message'),
             'No active subscription found',

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -4,16 +4,179 @@ from unittest.mock import MagicMock, patch
 import freezegun
 import requests
 from django.conf import settings
+from django.contrib import admin
 from django.core.exceptions import PermissionDenied
 from django.forms import model_to_dict
-from django.http import HttpRequest
+from django.http import HttpRequest, JsonResponse
 from django.test import override_settings
-from django.test import TestCase
+from django.test import Client as RequestClient, SimpleTestCase, TestCase
+from django.urls import path, resolve, reverse
 
 
-from thunderbird_accounts.authentication.middleware import AccountsOIDCBackend, refresh_user_access_token
+from thunderbird_accounts.authentication.middleware import (
+    AccountsOIDCBackend,
+    RequiredAuth,
+    refresh_user_access_token,
+)
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.authentication.models import AllowListEntry
+from thunderbird_accounts.core.tests.utils import oidc_force_login
+from thunderbird_accounts.subscription.models import Subscription
+from thunderbird_accounts.urls import authorized_path
+
+
+def authorization_test_view(request, **kwargs):
+    return JsonResponse({'kwargs': kwargs})
+
+
+authorization_test_urlpatterns = [
+    path('view/', authorization_test_view, name='authorization_test_view'),
+]
+
+urlpatterns = [
+    authorized_path(
+        'auth/',
+        authorization_test_urlpatterns,
+        required_auth=RequiredAuth.AUTHENTICATED,
+    ),
+    authorized_path(
+        'subscribed/',
+        authorization_test_urlpatterns,
+        required_auth=RequiredAuth.ACTIVE_SUBSCRIPTION,
+    ),
+    authorized_path(
+        'subscribed-empty-response/',
+        authorization_test_urlpatterns,
+        required_auth=RequiredAuth.ACTIVE_SUBSCRIPTION,
+        active_subscription_response_data={},
+        active_subscription_status=401,
+    ),
+    authorized_path(
+        'subscribed-custom-error/',
+        authorization_test_urlpatterns,
+        required_auth=RequiredAuth.ACTIVE_SUBSCRIPTION,
+        active_subscription_error_message='No active subscription found',
+        active_subscription_status=404,
+    ),
+    authorized_path(
+        'admin-only/',
+        authorization_test_urlpatterns,
+        required_auth=RequiredAuth.ADMIN,
+    ),
+    path('django-admin/', admin.site.urls),
+    path('login/', authorization_test_view, name='authorization_test_login'),
+]
+
+AUTHORIZATION_TEST_MIDDLEWARE = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'thunderbird_accounts.authentication.middleware.AuthorizationMiddleware',
+]
+
+
+@override_settings(
+    ROOT_URLCONF='thunderbird_accounts.authentication.tests.test_middleware',
+    MIDDLEWARE=AUTHORIZATION_TEST_MIDDLEWARE,
+    LOGIN_URL='/login/',
+)
+class AuthorizationMiddlewareTestCase(TestCase):
+    def setUp(self):
+        self.client = RequestClient()
+
+    def test_authenticated_include_requires_login_and_strips_metadata(self):
+        response = self.client.get('/auth/view/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/login/?next=/auth/view/')
+
+        user = User.objects.create(username=f'auth@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='auth')
+        oidc_force_login(self.client, user)
+
+        response = self.client.get('/auth/view/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'kwargs': {}})
+
+    def test_active_subscription_include_requires_active_subscription(self):
+        user = User.objects.create(username=f'subscriber@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='subscriber')
+        oidc_force_login(self.client, user)
+
+        response = self.client.get('/subscribed/view/', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json(), {'success': False, 'error': 'An active subscription is required.'})
+
+        Subscription.objects.create(user=user, status=Subscription.StatusValues.ACTIVE)
+
+        response = self.client.get('/subscribed/view/', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'kwargs': {}})
+
+    def test_active_subscription_include_supports_custom_error_response(self):
+        user = User.objects.create(username=f'custom@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='custom')
+        oidc_force_login(self.client, user)
+
+        response = self.client.get('/subscribed-empty-response/view/', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {})
+
+        response = self.client.get('/subscribed-custom-error/view/', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {'success': False, 'error': 'No active subscription found'})
+
+    def test_admin_include_requires_staff(self):
+        user = User.objects.create(username=f'user@{settings.PRIMARY_EMAIL_DOMAIN}', oidc_id='user')
+        oidc_force_login(self.client, user)
+
+        response = self.client.get('/admin-only/view/')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/django-admin/login/?next=/admin-only/view/')
+
+        staff_user = User.objects.create(
+            username=f'staff@{settings.PRIMARY_EMAIL_DOMAIN}',
+            oidc_id='staff',
+            is_staff=True,
+        )
+        oidc_force_login(self.client, staff_user)
+
+        response = self.client.get('/admin-only/view/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'kwargs': {}})
+
+
+class AuthorizationUrlMetadataTestCase(SimpleTestCase):
+    def test_root_urlconf_marks_protected_route_groups(self):
+        self.assertEqual(
+            resolve(reverse('api_display_name_set')).extra_kwargs.get('required_auth'),
+            RequiredAuth.ACTIVE_SUBSCRIPTION,
+        )
+        self.assertEqual(
+            resolve(reverse('legal_current')).extra_kwargs.get('required_auth'),
+            RequiredAuth.AUTHENTICATED,
+        )
+        self.assertEqual(
+            resolve(reverse('admin_stalwart_list')).extra_kwargs.get('required_auth'),
+            RequiredAuth.ADMIN,
+        )
+        self.assertEqual(
+            resolve(reverse('paddle_portal')).extra_kwargs.get('required_auth'),
+            RequiredAuth.ACTIVE_SUBSCRIPTION,
+        )
+        self.assertEqual(resolve(reverse('paddle_portal')).extra_kwargs.get('active_subscription_response_data'), {})
+        self.assertEqual(resolve(reverse('paddle_portal')).extra_kwargs.get('active_subscription_status'), 401)
+        self.assertEqual(
+            resolve(reverse('subscription_plan_info')).extra_kwargs.get('required_auth'),
+            RequiredAuth.ACTIVE_SUBSCRIPTION,
+        )
+        self.assertEqual(
+            resolve(reverse('subscription_plan_info')).extra_kwargs.get('active_subscription_error_message'),
+            'No active subscription found',
+        )
+        self.assertEqual(
+            resolve(reverse('subscription_plan_info')).extra_kwargs.get('active_subscription_status'),
+            404,
+        )
+
+    def test_root_urlconf_leaves_non_session_auth_routes_unmarked(self):
+        self.assertNotIn('required_auth', resolve(reverse('api_support_customer')).extra_kwargs)
+        self.assertNotIn('required_auth', resolve(reverse('appointment_caldav_setup')).extra_kwargs)
 
 
 @override_settings(

--- a/src/thunderbird_accounts/authentication/urls.py
+++ b/src/thunderbird_accounts/authentication/urls.py
@@ -1,0 +1,66 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import include, path
+from rest_framework_simplejwt.views import TokenRefreshView, TokenVerifyView
+
+from thunderbird_accounts.authentication import api, views
+from thunderbird_accounts.authentication.api import (
+    can_i_sign_up,
+    create_test_allow_list_entry,
+    get_user_profile,
+    sign_up,
+)
+
+
+admin_urlpatterns = [
+    path(
+        'admin/authentication/allowlistentry-custom/import/',
+        views.AdminAllowListEntryImport.as_view(),
+        name='allow_list_entry_import',
+    ),
+    path(
+        'admin/authentication/allowlistentry-custom/import/submit/',
+        views.bulk_import_allow_list,
+        name='allow_list_entry_import_submit',
+    ),
+]
+
+middleware_exempt_urlpatterns = [
+    path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+    path('api/v1/auth/get-profile/', get_user_profile, name='api_get_profile'),
+    path('api/v1/auth/sign-up/', sign_up, name='api_sign_up'),
+    path('api/v1/auth/can-i-sign-up/', can_i_sign_up, name='api_can_i_sign_up'),
+    path('api/v1/auth/waffle-flags/', api.get_waffle_flags, name='api_waffle_flags'),
+    path('api/v1/auth/mfa/methods/', api.get_mfa_methods, name='api_get_mfa_methods'),
+    path('api/v1/auth/mfa/totp/setup/start/', api.start_totp_setup, name='api_start_totp_setup'),
+    path('api/v1/auth/mfa/totp/setup/confirm/', api.confirm_totp_setup, name='api_confirm_totp_setup'),
+    path(
+        'api/v1/auth/mfa/totp/credentials/<str:credential_id>/',
+        api.remove_totp_credential,
+        name='api_remove_totp_credential',
+    ),
+    path(
+        'api/v1/auth/mfa/recovery-codes/regenerate/',
+        api.regenerate_recovery_codes,
+        name='api_regenerate_recovery_codes',
+    ),
+    path(
+        'api/v1/auth/mfa/recovery-codes/credentials/<str:credential_id>/',
+        api.remove_recovery_codes_credential,
+        name='api_remove_recovery_codes_credential',
+    ),
+    path('api/v1/testing/allow-list/', create_test_allow_list_entry, name='api_create_test_allow_list_entry'),
+]
+
+oidc_authenticated_urlpatterns = [
+    path('oidc/mfa-reauth/', views.MfaReauthenticationRequestView.as_view(), name='mfa_reauth'),
+    path('logout/callback', views.oidc_logout_callback, name='logout_callback'),
+    path('reset-password/', views.start_reset_password_flow, name='reset_password'),
+]
+
+oidc_public_urlpatterns = [
+    path('oidc/', include('mozilla_django_oidc.urls')),
+    path('logout/', views.start_oidc_logout, name='logout'),
+    path('login/', lambda r: redirect(settings.LOGIN_URL), name='login'),
+]

--- a/src/thunderbird_accounts/authentication/views.py
+++ b/src/thunderbird_accounts/authentication/views.py
@@ -2,9 +2,8 @@ import csv
 import re
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import logout as django_logout
-from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.decorators import permission_required
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
@@ -26,14 +25,12 @@ from thunderbird_accounts.core.utils import get_absolute_url
 DISCOUNT_ID_PATTERN = re.compile(r'^dsc_[a-z0-9]{26}$')
 
 
-@login_required
 def start_reset_password_flow(request: HttpRequest):
     """Generates a url and redirects the user to an app initiated action that will start a flow to
     update their password."""
     return HttpResponseRedirect(create_aia_url(KeycloakRequiredAction.UPDATE_PASSWORD))
 
 
-@method_decorator(login_required, name='dispatch')
 class MfaReauthenticationRequestView(OIDCAuthenticationRequestView):
     """OIDC step-up entry point for sensitive MFA-management actions.
 
@@ -88,7 +85,6 @@ def start_oidc_logout(request: HttpRequest):
     return HttpResponseRedirect(redirect_url)
 
 
-@login_required
 def oidc_logout_callback(request: HttpRequest):
     """Finalize logout locally after the user confirmed the logout."""
     django_logout(request)
@@ -98,7 +94,6 @@ def oidc_logout_callback(request: HttpRequest):
 
 
 @require_http_methods(['POST'])
-@staff_member_required()
 @permission_required('authentication.add_allowlistentry')
 def bulk_import_allow_list(request: HttpRequest):
     """
@@ -176,7 +171,6 @@ def bulk_import_allow_list(request: HttpRequest):
 
 
 @method_decorator(never_cache, name='dispatch')
-@method_decorator(staff_member_required, name='dispatch')
 @method_decorator(permission_required('authentication.add_allowlistentry'), name='dispatch')
 class AdminAllowListEntryImport(TemplateView):
     template_name = 'admin/authentication/allowlistentry/import.html'

--- a/src/thunderbird_accounts/infra/urls.py
+++ b/src/thunderbird_accounts/infra/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from thunderbird_accounts.infra import views
+
+
+public_urlpatterns = [
+    path('health', views.health_check),
+]

--- a/src/thunderbird_accounts/legal/urls.py
+++ b/src/thunderbird_accounts/legal/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from thunderbird_accounts.legal import views
+
+
+authenticated_urlpatterns = [
+    path('api/v1/legal/current/', views.get_current_legal_docs, name='legal_current'),
+    path('api/v1/legal/accept/', views.accept_legal_docs, name='legal_accept'),
+    path('api/v1/legal/decline/', views.decline_legal_docs, name='legal_decline'),
+]

--- a/src/thunderbird_accounts/legal/views.py
+++ b/src/thunderbird_accounts/legal/views.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import logout as django_logout
-from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
@@ -97,7 +96,6 @@ def _record_response(request, action: str) -> JsonResponse:
     return JsonResponse({'responses': created})
 
 
-@login_required
 @require_http_methods(['GET'])
 def get_current_legal_docs(request):
     """Returns current TOS and Privacy documents with their pre-rendered HTML content
@@ -130,13 +128,11 @@ def get_current_legal_docs(request):
     return JsonResponse({'documents': docs_data})
 
 
-@login_required
 @require_http_methods(['POST'])
 def accept_legal_docs(request):
     return _record_response(request, LegalDocumentResponse.Action.ACCEPTED)
 
 
-@login_required
 @require_http_methods(['POST'])
 def decline_legal_docs(request):
     _record_response(request, LegalDocumentResponse.Action.DECLINED)

--- a/src/thunderbird_accounts/mail/urls.py
+++ b/src/thunderbird_accounts/mail/urls.py
@@ -1,0 +1,40 @@
+from django.urls import path
+
+from thunderbird_accounts.mail import api, views
+from thunderbird_accounts.mail.views import jmap_test_page
+
+
+admin_urlpatterns = [
+    path(
+        'mail/admin/stalwart/',
+        views.AdminStalwartList.as_view(),
+        name='admin_stalwart_list',
+    ),
+]
+
+middleware_exempt_urlpatterns = [
+    path('appointment/caldav/setup/', views.appointment_caldav_setup, name='appointment_caldav_setup'),
+    path('api/v1/mail/is-username-available/', api.is_username_available, name='api_is_username_available'),
+    path(
+        'api/v1/contact/check-email-is-on-allow-list/',
+        api.check_email_is_on_allow_list,
+        name='api_check_email_is_on_allow_list',
+    ),
+]
+
+subscribed_urlpatterns = [
+    path('app-passwords/set', views.app_password_set, name='app_password_set'),
+    path('display-name/set', views.display_name_set, name='display_name_set'),
+    path('custom-domains/add', views.create_custom_domain, name='add_custom_domain'),
+    path('custom-domains/verify', views.verify_custom_domain, name='verify_custom_domain'),
+    path('custom-domains/remove', views.remove_custom_domain, name='remove_custom_domain'),
+    path('custom-domains/dns-records', views.get_dns_records, name='get_dns_records'),
+    path('email-aliases/add', views.add_email_alias, name='add_email_alias'),
+    path('email-aliases/remove', views.remove_email_alias, name='remove_email_alias'),
+    path('api/v1/mail/app-passwords/set/', views.app_password_set, name='api_app_password_set'),
+    path('api/v1/mail/display-name/set/', views.display_name_set, name='api_display_name_set'),
+]
+
+oidc_subscribed_urlpatterns = [
+    path('test/jmap/', jmap_test_page, name='jmap-test'),
+]

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -9,8 +9,6 @@ import sentry_sdk
 from django.conf import settings
 from django.contrib import messages
 from django.db import IntegrityError
-from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, JsonResponse, Http404
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
@@ -41,7 +39,6 @@ from thunderbird_accounts.mail.utils import (
 from thunderbird_accounts.mail.models import Account, Email, Domain
 from thunderbird_accounts.mail import tasks as mail_tasks
 from thunderbird_accounts.mail import utils
-from thunderbird_accounts.subscription.decorators import active_subscription_required
 
 
 def _critical_errors_from_stale_dns_records(stale_dns_records: list[dict]) -> list[DomainVerificationErrors]:
@@ -68,9 +65,7 @@ def _capture_domain_exception(exception: Exception, domain: Domain, *, phase: st
     sentry_sdk.capture_exception(exception)
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required(error_message=_('An active subscription is required to set an app password.'))
 @sensitive_post_parameters('password')
 def app_password_set(request: HttpRequest):
     """Sets an app password for a remote Stalwart account"""
@@ -111,9 +106,7 @@ def app_password_set(request: HttpRequest):
         )
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required
 @sensitive_post_parameters('display-name')
 def display_name_set(request: HttpRequest):
     """Sets a display name for a remote Stalwart account"""
@@ -136,9 +129,7 @@ def display_name_set(request: HttpRequest):
     return JsonResponse({'success': True, 'message': str(_('Display name set successfully'))})
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required
 def create_custom_domain(request: HttpRequest):
     """Creates a custom domain for the user"""
     data = json.loads(request.body)
@@ -198,9 +189,7 @@ def create_custom_domain(request: HttpRequest):
     return JsonResponse({'success': True})
 
 
-@login_required
 @require_http_methods(['GET'])
-@active_subscription_required
 def get_dns_records(request: HttpRequest):
     """Gets the DNS records for a custom domain"""
     domain = request.user.domains.get(name=request.GET.get('domain-name'))
@@ -229,9 +218,7 @@ def get_dns_records(request: HttpRequest):
         )
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required
 def verify_custom_domain(request: HttpRequest):
     """Verifies a custom domain"""
     data = json.loads(request.body)
@@ -329,9 +316,7 @@ def verify_custom_domain(request: HttpRequest):
         )
 
 
-@login_required
 @require_http_methods(['DELETE'])
-@active_subscription_required
 def remove_custom_domain(request: HttpRequest):
     """Removes a custom domain"""
     data = json.loads(request.body)
@@ -403,9 +388,7 @@ def remove_custom_domain(request: HttpRequest):
     return JsonResponse({'success': True})
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required
 def add_email_alias(request: HttpRequest):
     """Adds an email alias"""
     data = json.loads(request.body)
@@ -524,9 +507,7 @@ def add_email_alias(request: HttpRequest):
     return JsonResponse({'success': True})
 
 
-@login_required
 @require_http_methods(['DELETE'])
-@active_subscription_required
 def remove_email_alias(request: HttpRequest):
     """Removes an email alias"""
     data = json.loads(request.body)
@@ -677,8 +658,6 @@ def appointment_caldav_setup(request: HttpRequest):
         return error_response
 
 
-@login_required
-@active_subscription_required
 def jmap_test_page(request: HttpRequest):
     from thunderbird_accounts.mail.tiny_jmap_client import TinyJMAPClient
 
@@ -730,7 +709,6 @@ def jmap_test_page(request: HttpRequest):
 
 
 @method_decorator(never_cache, name='dispatch')
-@method_decorator(staff_member_required, name='dispatch')
 class AdminStalwartList(TemplateView):
     template_name = 'admin_stalwart_view.html'
 

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -184,6 +184,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'thunderbird_accounts.authentication.middleware.AuthorizationMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     #'mozilla_django_oidc.middleware.SessionRefresh',
     'thunderbird_accounts.authentication.middleware.OIDCRefreshSession',

--- a/src/thunderbird_accounts/subscription/decorators.py
+++ b/src/thunderbird_accounts/subscription/decorators.py
@@ -1,5 +1,3 @@
-from functools import wraps
-
 from django.conf import settings
 from django.http import HttpResponseRedirect, JsonResponse
 from django.urls import reverse
@@ -37,27 +35,17 @@ def inject_paddle(func):
     return _inject_paddle
 
 
-def active_subscription_required(function=None, *, error_message=None, response_data=None, status=403):
-    """Require an authenticated user with an active subscription."""
+def active_subscription_denial_response(request, *, error_message=None, response_data=None, status=403):
+    """Return a denial response when the user lacks an active subscription."""
+    if getattr(request.user, 'has_active_subscription', False):
+        return None
 
-    def decorator(view_func):
-        @wraps(view_func)
-        def _view_wrapper(request, *args, **kwargs):
-            if getattr(request.user, 'has_active_subscription', False):
-                return view_func(request, *args, **kwargs)
+    if _wants_json_response(request):
+        message = error_message or _('An active subscription is required.')
+        data = response_data if response_data is not None else {'success': False, 'error': str(message)}
+        return JsonResponse(data, status=status)
 
-            if _wants_json_response(request):
-                message = error_message or _('An active subscription is required.')
-                data = response_data if response_data is not None else {'success': False, 'error': str(message)}
-                return JsonResponse(data, status=status)
-
-            return HttpResponseRedirect(reverse('vue_app'))
-
-        return _view_wrapper
-
-    if function:
-        return decorator(function)
-    return decorator
+    return HttpResponseRedirect(reverse('vue_app'))
 
 
 def _wants_json_response(request):

--- a/src/thunderbird_accounts/subscription/urls.py
+++ b/src/thunderbird_accounts/subscription/urls.py
@@ -1,0 +1,23 @@
+from django.urls import path
+
+from thunderbird_accounts.subscription import views
+
+
+authenticated_urlpatterns = [
+    path('subscription/paddle/complete/', views.paddle_transaction_complete, name='paddle_completed'),
+    path('api/v1/subscription/paddle/info/', views.get_paddle_information, name='paddle_info'),
+    path('api/v1/subscription/paddle/tx/set/', views.set_paddle_transaction_id, name='paddle_txid'),
+    path('api/v1/subscription/paddle/tx/is-done/', views.is_paddle_transaction_done, name='paddle_is_done'),
+]
+
+paddle_portal_urlpatterns = [
+    path('api/v1/subscription/paddle/portal/', views.get_paddle_portal_link, name='paddle_portal'),
+]
+
+subscription_plan_info_urlpatterns = [
+    path('api/v1/subscription/plan/info/', views.get_subscription_plan_info, name='subscription_plan_info'),
+]
+
+public_urlpatterns = [
+    path('api/v1/subscription/paddle/webhook/', views.handle_paddle_webhook, name='paddle_webhook'),
+]

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -5,7 +5,6 @@ import sentry_sdk
 
 from django.db import transaction as dj_transaction
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse, HttpRequest, HttpResponseRedirect
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
@@ -23,7 +22,7 @@ from thunderbird_accounts.authentication.models import AllowListEntry, User
 from thunderbird_accounts.mail.clients import MailClient
 from thunderbird_accounts.authentication.permissions import IsValidPaddleWebhook
 from thunderbird_accounts.subscription import tasks
-from thunderbird_accounts.subscription.decorators import active_subscription_required, inject_paddle
+from thunderbird_accounts.subscription.decorators import inject_paddle
 from thunderbird_accounts.subscription.models import Plan, Price, Subscription, Transaction
 from thunderbird_accounts.core.exceptions import UnexpectedBehaviour
 
@@ -42,7 +41,6 @@ def prefilter_paddle_webhook(event_type: str, event_data: dict) -> bool:
     return True
 
 
-@login_required
 @require_http_methods(['POST'])
 def get_paddle_information(request: Request):
     signer = Signer()
@@ -73,7 +71,6 @@ def get_paddle_information(request: Request):
     )
 
 
-@login_required
 @require_http_methods(['PUT'])
 def set_paddle_transaction_id(request: Request):
     """This error is used to work-around the fact we don't get a transaction id from Paddle's successUrl redirect.
@@ -84,7 +81,6 @@ def set_paddle_transaction_id(request: Request):
     return JsonResponse({'success': True})
 
 
-@login_required
 @require_http_methods(['POST'])
 def is_paddle_transaction_done(request: Request):
     """Checks if the Paddle transaction has finished and returns True or False.
@@ -106,7 +102,6 @@ def is_paddle_transaction_done(request: Request):
     return JsonResponse({'status': status})
 
 
-@login_required
 @inject_paddle
 def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     """User is redirected by Paddle via the successUrl. This means we have a transaction that's paid or
@@ -180,9 +175,7 @@ def paddle_transaction_complete(request: HttpRequest, paddle: Client):
     return redirect_response
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required(response_data={}, status=401)
 @inject_paddle
 def get_paddle_portal_link(request: Request, paddle: Client):
     subscription = request.user.subscription_set.filter(status=Subscription.StatusValues.ACTIVE).first()
@@ -237,9 +230,7 @@ def handle_paddle_webhook(request: Request):
     return response
 
 
-@login_required
 @require_http_methods(['POST'])
-@active_subscription_required(error_message='No active subscription found', status=404)
 @inject_paddle
 def get_subscription_plan_info(request: Request, paddle: Client):
     """Returns the user's current subscription information including plan details, pricing, and features."""

--- a/src/thunderbird_accounts/support/urls.py
+++ b/src/thunderbird_accounts/support/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from thunderbird_accounts.support import views
+from thunderbird_accounts.support.customer import support_customer_api
+
+
+middleware_exempt_urlpatterns = [
+    path('api/v1/support/customer/', support_customer_api, name='api_support_customer'),
+    path('contact/fields', views.contact_fields, name='contact_fields'),
+    path('contact/submit', views.contact_submit, name='contact_submit'),
+]

--- a/src/thunderbird_accounts/telemetry/urls.py
+++ b/src/thunderbird_accounts/telemetry/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from thunderbird_accounts.telemetry import api, views
+
+
+public_urlpatterns = [
+    path('api/v1/telemetry/stalwart/webhook/', views.stalwart_webhook, name='stalwart_webhook'),
+    path('api/v1/telemetry/event', api.capture_frontend_event, name='api_capture_frontend_event'),
+]

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -7,140 +7,93 @@ These are the routes and some light admin panel customization are located.
 
 from django.conf import settings
 from django.contrib import admin
-from django.shortcuts import redirect
 from django.urls import path, include, re_path
-from rest_framework_simplejwt.views import TokenRefreshView, TokenVerifyView
 
-from thunderbird_accounts.authentication import api as auth_api, views as auth_views
 from thunderbird_accounts.core import views as core_views
-from thunderbird_accounts.infra import views as infra_views
-from thunderbird_accounts.mail import views as mail_views, api as mail_api
-from thunderbird_accounts.mail.views import jmap_test_page
-from thunderbird_accounts.subscription import views as subscription_views
-from thunderbird_accounts.support import views as support_views
-from thunderbird_accounts.support.customer import support_customer_api
+from thunderbird_accounts.authentication import urls as authentication_urls
+from thunderbird_accounts.authentication.middleware import RequiredAuth as Authz
+from thunderbird_accounts.infra import urls as infra_urls
+from thunderbird_accounts.legal import urls as legal_urls
+from thunderbird_accounts.mail import urls as mail_urls
+from thunderbird_accounts.subscription import urls as subscription_urls
+from thunderbird_accounts.support import urls as support_urls
+from thunderbird_accounts.telemetry import urls as telemetry_urls
 
-from thunderbird_accounts.authentication.api import (
-    get_user_profile,
-    sign_up,
-    can_i_sign_up,
-    create_test_allow_list_entry,
-)
-from thunderbird_accounts.legal import views as legal_views
-from thunderbird_accounts.telemetry import views as telemetry_views, api as telemetry_api
+
+def authorized_path(route, urlconf, *, required_auth: Authz, **auth_options):
+    return path(route, include(urlconf), {'required_auth': required_auth, **auth_options})
 
 # Error handler overrides
 handler500 = 'thunderbird_accounts.core.views.handle_500'
 
-urlpatterns = [
-    # Custom admin routes need to be before admin.site.urls
-    path(
-        'admin/authentication/allowlistentry-custom/import/',
-        auth_views.AdminAllowListEntryImport.as_view(),
-        name='allow_list_entry_import',
-    ),
-    path(
-        'admin/authentication/allowlistentry-custom/import/submit/',
-        auth_views.bulk_import_allow_list,
-        name='allow_list_entry_import_submit',
-    ),
-    path('admin/', admin.site.urls),
-    # Django-specific routes (not handled by Vue)
-    path('contact/fields', support_views.contact_fields, name='contact_fields'),
-    # Post only
-    path('contact/submit', support_views.contact_submit, name='contact_submit'),
-    path('app-passwords/set', mail_views.app_password_set, name='app_password_set'),
-    path('display-name/set', mail_views.display_name_set, name='display_name_set'),
-    path('custom-domains/add', mail_views.create_custom_domain, name='add_custom_domain'),
-    path('custom-domains/verify', mail_views.verify_custom_domain, name='verify_custom_domain'),
-    path('custom-domains/remove', mail_views.remove_custom_domain, name='remove_custom_domain'),
-    path('custom-domains/dns-records', mail_views.get_dns_records, name='get_dns_records'),
-    path('email-aliases/add', mail_views.add_email_alias, name='add_email_alias'),
-    path('email-aliases/remove', mail_views.remove_email_alias, name='remove_email_alias'),
-    # Subscription
-    path('subscription/paddle/complete/', subscription_views.paddle_transaction_complete, name='paddle_completed'),
-    # CalDAV auto-setup for Appointment
-    path('appointment/caldav/setup/', mail_views.appointment_caldav_setup, name='appointment_caldav_setup'),
-    # API
-    path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('api/v1/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
-    path('api/v1/auth/get-profile/', get_user_profile, name='api_get_profile'),
-    path('api/v1/auth/sign-up/', sign_up, name='api_sign_up'),
-    path('api/v1/auth/can-i-sign-up/', can_i_sign_up, name='api_can_i_sign_up'),
-    path('api/v1/auth/waffle-flags/', auth_api.get_waffle_flags, name='api_waffle_flags'),
-    path('api/v1/auth/mfa/methods/', auth_api.get_mfa_methods, name='api_get_mfa_methods'),
-    path('api/v1/auth/mfa/totp/setup/start/', auth_api.start_totp_setup, name='api_start_totp_setup'),
-    path('api/v1/auth/mfa/totp/setup/confirm/', auth_api.confirm_totp_setup, name='api_confirm_totp_setup'),
-    path(
-        'api/v1/auth/mfa/totp/credentials/<str:credential_id>/',
-        auth_api.remove_totp_credential,
-        name='api_remove_totp_credential',
-    ),
-    path(
-        'api/v1/auth/mfa/recovery-codes/regenerate/',
-        auth_api.regenerate_recovery_codes,
-        name='api_regenerate_recovery_codes',
-    ),
-    path(
-        'api/v1/auth/mfa/recovery-codes/credentials/<str:credential_id>/',
-        auth_api.remove_recovery_codes_credential,
-        name='api_remove_recovery_codes_credential',
-    ),
-    path('api/v1/support/customer/', support_customer_api, name='api_support_customer'),
-    path('api/v1/legal/current/', legal_views.get_current_legal_docs, name='legal_current'),
-    path('api/v1/legal/accept/', legal_views.accept_legal_docs, name='legal_accept'),
-    path('api/v1/legal/decline/', legal_views.decline_legal_docs, name='legal_decline'),
-    path('api/v1/subscription/paddle/webhook/', subscription_views.handle_paddle_webhook, name='paddle_webhook'),
-    path('api/v1/subscription/paddle/info/', subscription_views.get_paddle_information, name='paddle_info'),
-    path('api/v1/subscription/paddle/portal/', subscription_views.get_paddle_portal_link, name='paddle_portal'),
-    path('api/v1/subscription/paddle/tx/set/', subscription_views.set_paddle_transaction_id, name='paddle_txid'),
-    path(
-        'api/v1/subscription/paddle/tx/is-done/', subscription_views.is_paddle_transaction_done, name='paddle_is_done'
-    ),
-    path(
-        'api/v1/subscription/plan/info/', subscription_views.get_subscription_plan_info, name='subscription_plan_info'
-    ),
-    path('api/v1/mail/app-passwords/set/', mail_views.app_password_set, name='api_app_password_set'),
-    path('api/v1/mail/display-name/set/', mail_views.display_name_set, name='api_display_name_set'),
-    path('api/v1/mail/is-username-available/', mail_api.is_username_available, name='api_is_username_available'),
-    path(
-        'api/v1/contact/check-email-is-on-allow-list/',
-        mail_api.check_email_is_on_allow_list,
-        name='api_check_email_is_on_allow_list',
-    ),
-    # Waffle
-    re_path(r'^', include('waffle.urls')),
-    # Stalwart telemetry webhook
-    path('api/v1/telemetry/stalwart/webhook/', telemetry_views.stalwart_webhook, name='stalwart_webhook'),
-    path('api/v1/telemetry/event', telemetry_api.capture_frontend_event, name='api_capture_frontend_event'),
-    # Health check
-    path('health', infra_views.health_check),
-    # Test routes
-    path('api/v1/testing/allow-list/', create_test_allow_list_entry, name='api_create_test_allow_list_entry'),
+authentication_urlpatterns = [
+    # This custom admin route needs to be before admin.site.urls.
+    authorized_path('', authentication_urls.admin_urlpatterns, required_auth=Authz.ADMIN),
+    path('', include(authentication_urls.middleware_exempt_urlpatterns)),
 ]
 
+mail_urlpatterns = [
+    authorized_path('', mail_urls.admin_urlpatterns, required_auth=Authz.ADMIN),
+    path('', include(mail_urls.middleware_exempt_urlpatterns)),
+    authorized_path('', mail_urls.subscribed_urlpatterns, required_auth=Authz.ACTIVE_SUBSCRIPTION),
+]
+
+subscription_urlpatterns = [
+    path('', include(subscription_urls.public_urlpatterns)),
+    authorized_path(
+        '',
+        subscription_urls.authenticated_urlpatterns,
+        required_auth=Authz.AUTHENTICATED,
+    ),
+    authorized_path(
+        '',
+        subscription_urls.paddle_portal_urlpatterns,
+        required_auth=Authz.ACTIVE_SUBSCRIPTION,
+        active_subscription_response_data={},
+        active_subscription_status=401,
+    ),
+    authorized_path(
+        '',
+        subscription_urls.subscription_plan_info_urlpatterns,
+        required_auth=Authz.ACTIVE_SUBSCRIPTION,
+        active_subscription_error_message='No active subscription found',
+        active_subscription_status=404,
+    ),
+]
 
 if settings.AUTH_SCHEME == 'oidc':
-    urlpatterns.append(path('oidc/mfa-reauth/', auth_views.MfaReauthenticationRequestView.as_view(), name='mfa_reauth'))
-    urlpatterns.append(path('oidc/', include('mozilla_django_oidc.urls')))
-    urlpatterns.append(path('logout/', auth_views.start_oidc_logout, name='logout'))
-    urlpatterns.append(path('logout/callback', auth_views.oidc_logout_callback, name='logout_callback'))
-    urlpatterns.append(path('login/', lambda r: redirect(settings.LOGIN_URL), name='login'))
-    urlpatterns.append(path('reset-password/', auth_views.start_reset_password_flow, name='reset_password'))
-    # Test url for ensuring jmap connection works
-    urlpatterns.append(path('test/jmap/', jmap_test_page, name='jmap-test'))
+    authentication_urlpatterns += [
+        authorized_path(
+            '',
+            authentication_urls.oidc_authenticated_urlpatterns,
+            required_auth=Authz.AUTHENTICATED,
+        ),
+        path('', include(authentication_urls.oidc_public_urlpatterns)),
+    ]
+    mail_urlpatterns.append(
+        authorized_path('', mail_urls.oidc_subscribed_urlpatterns, required_auth=Authz.ACTIVE_SUBSCRIPTION)
+    )
+
+urlpatterns = [
+    *authentication_urlpatterns,
+    path('admin/', admin.site.urls),
+    path('', include(infra_urls.public_urlpatterns)),
+    authorized_path(
+        '',
+        legal_urls.authenticated_urlpatterns,
+        required_auth=Authz.AUTHENTICATED,
+    ),
+    *mail_urlpatterns,
+    *subscription_urlpatterns,
+    path('', include(support_urls.middleware_exempt_urlpatterns)),
+    path('', include(telemetry_urls.public_urlpatterns)),
+    # Waffle
+    re_path(r'^', include('waffle.urls')),
+]
 
 
 if settings.DEBUG:
     urlpatterns.append(path('docs/', include('rest_framework.urls')))
-
-urlpatterns += [
-    path(
-        'mail/admin/stalwart/',
-        mail_views.AdminStalwartList.as_view(),
-        name='admin_stalwart_list',
-    ),
-]
 
 urlpatterns += [
     # Vue App catch-all: keep this last so all explicit Django routes above take precedence


### PR DESCRIPTION
## What changed?

Refactor URL routing to more secure by default (#1070)
    
`urls.py` was converted to a mapping of authorization contexts to sub-routers that handle these contexts.
    
Authorization rules are moved from distributed decorators to views to a central middleware.
    
Route table entries are now decentralized from a monolithic urls.py to be organized by existing sub-folders.

## What's not changing

 * URLs are not changing. Organizing URLs around authorization rules may provide further clarity about authorization rules, but is not in scope here or planned at this time.

## Why?

This makes it harder to accidentally have missing or wrong authorization on routes.

This centralizes authorization rules, making the security architecture easier to see.

## Limitations and Notes

A drawback to this approach is that the main `urls.py` no long servers as central list of all URLs in the app. But the app is growing and security and privacy are key concerns, reframing urls.py to surface key authorization rules feels like a worthwhile trade-off.

Django has it's own limitations-- as of 6.0  it does not support middleware scoped to sub-routers like FastAPI or Express.js does. If it did, the solution might be even cleaner.

## Applicable Issues

 * [Proposal: re-structure routes to be "secure by default" · Issue #1070 · thunderbird/thunderbird-accounts](https://github.com/thunderbird/thunderbird-accounts/issues/1070)

## QA Log

 * Test suite is used to confirm that all routes continue to work as expected.
 * Analyzed test suite for gaps in authorization checks and added them in a follow-up commit.
