### PR TITLE
Fix blank SPF host in local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,7 @@ IMAP_TLS=False
 SMTP_HOST=localhost
 SMTP_PORT=25
 SMTP_TLS=False
+SPF_HOST=spf.localhost
 
 JMAP_HOST=localhost
 JMAP_PORT=443

--- a/.env.test
+++ b/.env.test
@@ -46,6 +46,7 @@ IMAP_TLS=True
 SMTP_HOST=localhost
 SMTP_PORT=465
 SMTP_TLS=True
+SPF_HOST=spf.localhost
 
 JMAP_HOST=localhost
 JMAP_PORT=443

--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -56,6 +56,7 @@
 .smtp_host: &VAR_SMTP_HOST {name: "SMTP_HOST", value: "mail.thundermail.com"}
 .smtp_port: &VAR_SMTP_PORT {name: "SMTP_PORT", value: "465"}
 .smtp_tls: &VAR_SMTP_TLS {name: "SMTP_TLS", value: "True"}
+.spf_host: &VAR_SPF_HOST {name: "SPF_HOST", value: "spf.thundermail.com"}
 .stalwart_base_api_url: &VAR_STALWART_BASE_API_URL {name: "STALWART_BASE_API_URL", value: "https://mailstrom-prod-management-i.thundermail.com:8080"}
 .stalwart_base_jmap_url: &VAR_STALWART_BASE_JMAP_URL {name: "STALWART_BASE_JMAP_URL", value: "https://mail.thundermail.com"}
 .support_contact: &VAR_SUPPORT_CONTACT {name: "SUPPORT_CONTACT", value: "dummy@example.org"}
@@ -414,6 +415,7 @@ resources:
                 - *VAR_SMTP_HOST
                 - *VAR_SMTP_PORT
                 - *VAR_SMTP_TLS
+                - *VAR_SPF_HOST
                 - *VAR_STALWART_BASE_API_URL
                 - *VAR_STALWART_BASE_JMAP_URL
                 - *VAR_STALWART_DKIM_STAGE_MANAGEMENT_ENABLED
@@ -508,6 +510,7 @@ resources:
                 - *VAR_SMTP_HOST
                 - *VAR_SMTP_PORT
                 - *VAR_SMTP_TLS
+                - *VAR_SPF_HOST
                 - *VAR_STALWART_BASE_API_URL
                 - *VAR_STALWART_BASE_JMAP_URL
                 - *VAR_STALWART_DKIM_STAGE_MANAGEMENT_ENABLED
@@ -923,6 +926,8 @@ resources:
                 value: '465'
               - name: SMTP_TLS
                 value: 'True'
+              - name: SPF_HOST
+                value: 'spf.thundermail.com'
               - name: SUPPORT_CONTACT
                 value: dummy@example.org
               - name: OIDC_URL_AUTH

--- a/pulumi/config.stage.yaml
+++ b/pulumi/config.stage.yaml
@@ -54,6 +54,7 @@
 .smtp_host: &VAR_SMTP_HOST {name: "SMTP_HOST", value: "mail.stage-thundermail.com"}
 .smtp_port: &VAR_SMTP_PORT {name: "SMTP_PORT", value: "465"}
 .smtp_tls: &VAR_SMTP_TLS {name: "SMTP_TLS", value: "True"}
+.spf_host: &VAR_SPF_HOST {name: "SPF_HOST", value: "spf.stage-thundermail.com"}
 .stalwart_base_api_url: &VAR_STALWART_BASE_API_URL {name: "STALWART_BASE_API_URL", value: "https://mailstrom-stage-management-i.stage-thundermail.com:8080"}
 .stalwart_base_jmap_url: &VAR_STALWART_BASE_JMAP_URL {name: "STALWART_BASE_JMAP_URL", value: "https://mail.stage-thundermail.com"}
 .support_contact: &VAR_SUPPORT_CONTACT {name: "SUPPORT_CONTACT", value: "dummy@example.org"}
@@ -410,6 +411,7 @@ resources:
                 - *VAR_SMTP_HOST
                 - *VAR_SMTP_PORT
                 - *VAR_SMTP_TLS
+                - *VAR_SPF_HOST
                 - *VAR_STALWART_BASE_API_URL
                 - *VAR_STALWART_BASE_JMAP_URL
                 - *VAR_STALWART_DKIM_STAGE_MANAGEMENT_ENABLED
@@ -498,6 +500,7 @@ resources:
                 - *VAR_SMTP_HOST
                 - *VAR_SMTP_PORT
                 - *VAR_SMTP_TLS
+                - *VAR_SPF_HOST
                 - *VAR_STALWART_BASE_API_URL
                 - *VAR_STALWART_BASE_JMAP_URL
                 - *VAR_STALWART_DKIM_STAGE_MANAGEMENT_ENABLED
@@ -906,6 +909,8 @@ resources:
                 value: '465'
               - name: SMTP_TLS
                 value: 'True'
+              - name: SPF_HOST
+                value: 'spf.stage-thundermail.com'
               - name: SUPPORT_CONTACT
                 value: dummy@example.org
               - name: OIDC_URL_AUTH

--- a/src/thunderbird_accounts/mail/clients.py
+++ b/src/thunderbird_accounts/mail/clients.py
@@ -705,7 +705,7 @@ class MailClient:
 
         target_domain = settings.CONNECTION_INFO['SMTP']['HOST'].rstrip('.')
         target_domain_fqdn = f'{target_domain}.'
-        target_top_domain = '.'.join(target_domain.split('.')[1:])
+        spf_host = settings.SPF_HOST.rstrip('.')
         normalized_cust_domain = cust_domain.rstrip('.')
         mx_name = '@' if len(normalized_cust_domain.split('.')) == 2 else f'{normalized_cust_domain}.'
 
@@ -744,7 +744,7 @@ class MailClient:
             {
                 'type': 'TXT',
                 'name': f'{normalized_cust_domain}.',
-                'content': f'v=spf1 include:spf.{target_top_domain} -all',
+                'content': f'v=spf1 include:{spf_host} -all',
                 'priority': '-',
             },
             {

--- a/src/thunderbird_accounts/mail/tests/test_clients.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients.py
@@ -12,6 +12,7 @@ from thunderbird_accounts.mail.exceptions import FailedToCreateDKIM, FailedToRel
     STALWART_API_AUTH_STRING='secret',
     STALWART_API_AUTH_METHOD='bearer',
     CONNECTION_INFO={'SMTP': {'HOST': 'mail.test.com'}},
+    SPF_HOST='spf.test.com',
     HOSTED_DKIM_DOMAIN='dkim.test.net',
     HOSTED_DKIM_SELECTORS=['tm1', 'tm2'],
 )
@@ -561,6 +562,7 @@ class TestMailClientDeleteDkim(TestCase):
     STALWART_API_AUTH_STRING='secret',
     STALWART_API_AUTH_METHOD='bearer',
     CONNECTION_INFO={'SMTP': {'HOST': 'mail.test.com'}},
+    SPF_HOST='spf.example.net',
     HOSTED_DKIM_DOMAIN='dkim.test.net',
     HOSTED_DKIM_SELECTORS=['tm1', 'tm2'],
 )
@@ -612,11 +614,18 @@ class TestMailClientBuildExpectedDNSRecords(SimpleTestCase):
             {
                 'type': 'TXT',
                 'name': 'tb.stosberg.com.',
-                'content': 'v=spf1 include:spf.test.com -all',
+                'content': 'v=spf1 include:spf.example.net -all',
                 'priority': '-',
             },
             records,
         )
+
+    @override_settings(CONNECTION_INFO={'SMTP': {'HOST': 'localhost'}}, SPF_HOST='spf.localhost')
+    def test_build_expected_dns_records_with_localhost(self):
+        records = self.mail_client.build_expected_dns_records(self.domain)
+
+        spf_record = next(record for record in records if record['content'].startswith('v=spf1'))
+        self.assertEqual(spf_record['content'], 'v=spf1 include:spf.localhost -all')
 
     def test_build_expected_dns_records_normalizes_customer_domain(self):
         records = self.mail_client.build_expected_dns_records('tb.stosberg.com.')

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -526,6 +526,7 @@ CONNECTION_INFO = {
     'JMAP': {'HOST': os.getenv('JMAP_HOST'), 'PORT': os.getenv('JMAP_PORT'), 'TLS': os.getenv('JMAP_TLS') == 'True'},
     'SMTP': {'HOST': os.getenv('SMTP_HOST'), 'PORT': os.getenv('SMTP_PORT'), 'TLS': os.getenv('SMTP_TLS') == 'True'},
 }
+SPF_HOST = os.getenv('SPF_HOST')
 
 ALLOWED_EMAIL_DOMAINS: list[str] = (
     [domain.strip() for domain in os.getenv('ALLOWED_EMAIL_DOMAINS', '').split(',')]


### PR DESCRIPTION
## What changed?

SPF include records now use an explicit `SPF_HOST` setting instead of deriving the host from `SMTP_HOST`. Local development uses `spf.localhost`, while stage and production retain their existing effective values (`spf.stage-thundermail.com` and `spf.thundermail.com`). The variable is included in both Pulumi task definitions and their rendered environment lists.

Regression coverage verifies that the SPF host can differ from the SMTP domain and that `SMTP_HOST=localhost` produces `include:spf.localhost` rather than `include:spf.`.

AI disclosure: this contribution and PR text were produced by OpenAI Codex with Kkkakania's authorization. Codex inspected the current implementation, wrote the focused tests and change, and ran the validation listed below.

Validation:

- `uv run ruff check .`
- `uv run python manage.py test thunderbird_accounts.mail.tests --verbosity 0` (170 tests passed)
- `uv run python manage.py test thunderbird_accounts --verbosity 0` after the CI-equivalent Vite build (501 tests passed)
- both Pulumi config files parsed with PyYAML

## Why?

When `SMTP_HOST=localhost`, removing the first hostname label leaves an empty string and generates the invalid SPF include `spf.`. A dedicated setting represents the actual deployment contract and removes the assumption that the SPF host is always a sibling of the SMTP host.

## Limitations and Notes

No fallback derivation is retained: every checked-in environment now declares `SPF_HOST` explicitly.

## Applicable Issues

Closes #887

## Screenshots

Not applicable; this is a configuration and DNS-record generation change.