### PR TITLE
Fix email aliases form SelectInput component + CSS padding fix in LoginView

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
+++ b/keycloak/themes/tbpro/assets/vue/BaseTemplate.vue
@@ -95,15 +95,11 @@ section {
       flex-direction: column;
       padding: 6rem 2rem;
 
-      .message-bar {
-        margin-block-end: 1.5rem;
-      }
-
       .logo-link {
         display: block;
         text-decoration: none;
         width: min-content;
-        margin-block-end: 2rem;
+        margin-block-end: 1.5rem;
 
         .logo {
           height: 36px;

--- a/keycloak/themes/tbpro/assets/vue/components/MessageBar.vue
+++ b/keycloak/themes/tbpro/assets/vue/components/MessageBar.vue
@@ -15,3 +15,9 @@ const messageType = computed(() => {
 <template>
   <notice-bar data-testid="notice-bar" class="notice-bar" :type="messageType" v-if="message?.type">{{ message?.summary }}</notice-bar>
 </template>
+
+<style scoped>
+.notice-bar {
+  margin-block-end: 1.5rem;
+}
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@paddle/paddle-js": "^1.6.2",
         "@phosphor-icons/vue": "^2.2.1",
-        "@thunderbirdops/services-ui": "^1.6.3",
+        "@thunderbirdops/services-ui": "^1.6.7",
         "@vueuse/core": "^14.2.1",
         "pinia": "^3.0.4",
         "qr": "^0.5.5",
@@ -852,9 +852,9 @@
       "license": "MIT"
     },
     "node_modules/@thunderbirdops/services-ui": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@thunderbirdops/services-ui/-/services-ui-1.6.3.tgz",
-      "integrity": "sha512-+Us2f0itOTr2eNPfHBE2RIUeMuPcZN8WIKOCiUvS5Tjso3bzhvhwf4vGiQo8ufsxJW20MZB1aDJHU1nAWTTeYQ==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@thunderbirdops/services-ui/-/services-ui-1.6.7.tgz",
+      "integrity": "sha512-OolgR1ioMrS+25zqlDdRQwbqy5hNsBnY3nh8oZ+bZwaEyuf83GvcFZCVGgyZg9pMchWq7yXBQ+dc7w4xoD9IHw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@vue/test-utils": "2.4.10",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@paddle/paddle-js": "^1.6.2",
     "@phosphor-icons/vue": "^2.2.1",
-    "@thunderbirdops/services-ui": "^1.6.3",
+    "@thunderbirdops/services-ui": "^1.6.7",
     "@vueuse/core": "^14.2.1",
     "pinia": "^3.0.4",
     "qr": "^0.5.5",


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Updated services-ui to v1.6.7
- Small CSS fix for the message bar taking space even if its not there

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- services-ui includes the fix for SelectInput component (https://github.com/thunderbird/services-ui/pull/305)

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/819

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

Login before (check the super big margin below the logo):
<img width="1354" height="869" alt="image" src="https://github.com/user-attachments/assets/fa70315a-e438-4270-b4da-f77d5a3dadf6" />


Login after (no longer weird margin below the logo):
<img width="1369" height="856" alt="image" src="https://github.com/user-attachments/assets/2d7bb9eb-be18-45bc-97a7-3d6d914e30e4" />


Email Aliases' SelectInput fix:


https://github.com/user-attachments/assets/bf0ad4f8-e660-4df8-b903-b5a25bafbccc


