### PR TITLE
ci(deploy-stage): force keycloak/accounts builds + stop concurrency dropping deploys

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -3,13 +3,31 @@ name: deploy-stage
 
 concurrency:
   group: deploy-stage
-  cancel-in-progress: true
+  # Serialize (don't cancel) deploys. A single global group keeps only one
+  # `pulumi up` in flight at a time (Pulumi holds a stack-wide lock -- see the
+  # deploy job comment / issue #884), and cancel-in-progress: false ensures a
+  # later run can't abort an in-flight deploy. Previously cancel-in-progress:
+  # true let a Dependabot merge cancel an in-flight keycloak-aware run, whose
+  # replacement then change-detection-skipped -- so that commit never deployed
+  # to stage (observed on #1087). Narrowing the group per-ref instead would let
+  # deploys run in parallel and collide on the Pulumi stack lock, so we keep the
+  # single group and queue runs.
+  cancel-in-progress: false
 
 on:
   push:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      force_accounts:
+        description: "Force building & deploying the accounts image, regardless of change detection"
+        type: boolean
+        default: false
+      force_keycloak:
+        description: "Force building & deploying the keycloak image, regardless of change detection"
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -75,7 +93,9 @@ jobs:
     if: >-
       needs.detect-changes.outputs.src-changed == 'true' ||
       needs.detect-changes.outputs.keycloak-theme-changed == 'true' ||
-      needs.detect-changes.outputs.iac-changed == 'true'
+      needs.detect-changes.outputs.iac-changed == 'true' ||
+      github.event.inputs.force_accounts == 'true' ||
+      github.event.inputs.force_keycloak == 'true'
     environment:
       name: staging
       deployment: true
@@ -85,9 +105,11 @@ jobs:
       PULUMI_DIR: "pulumi"
       # Whether the accounts image was (re)built this run; gates the
       # accounts config update, its pulumi targets, and the release artifacts.
-      BUILD_ACCOUNTS: ${{ needs.detect-changes.outputs.src-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' }}
-      # Whether the keycloak image was (re)built this run.
-      BUILD_KEYCLOAK: ${{ needs.detect-changes.outputs.keycloak-theme-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' }}
+      # The force_accounts workflow_dispatch input overrides change detection.
+      BUILD_ACCOUNTS: ${{ needs.detect-changes.outputs.src-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' || github.event.inputs.force_accounts == 'true' }}
+      # Whether the keycloak image was (re)built this run; the force_keycloak
+      # workflow_dispatch input overrides change detection.
+      BUILD_KEYCLOAK: ${{ needs.detect-changes.outputs.keycloak-theme-changed == 'true' || needs.detect-changes.outputs.iac-changed == 'true' || github.event.inputs.force_keycloak == 'true' }}
     outputs:
       # Non-empty only when the accounts image was built; used to gate create-release.
       accounts-image: ${{ steps.build-accounts.outputs.accounts-image }}


### PR DESCRIPTION
## What

Addresses both gaps in `merge.yml` (deploy-stage) called out in the #1087 review.

### 1. Force builds via `workflow_dispatch`

Adds two boolean inputs, mirroring the force behavior already in `publish-images.yml`:

- `force_accounts` — force building & deploying the accounts image
- `force_keycloak` — force building & deploying the keycloak image

They are wired into:

- the `deploy` job `if:` gate (so the job runs even when change-detection finds nothing), and
- the `BUILD_ACCOUNTS` / `BUILD_KEYCLOAK` env expressions (so the corresponding image build step, config merge, pulumi `--target`s, and artifacts all fire).

Each input independently forces only its own image, so a manual run can rebuild keycloak alone without touching accounts. Comparisons use `github.event.inputs.<name> == 'true'`, which is empty (falsey) on `push`, so normal merge-to-main behavior is unchanged.

### 2. Concurrency: stop silently dropping deploys

Changed the `deploy-stage` group from `cancel-in-progress: true` to `cancel-in-progress: false`.

**Decision + tradeoff:** the group is kept as a single global `deploy-stage` group (not narrowed per-ref). The deploy job runs a single `pulumi up` and Pulumi holds a stack-wide lock (see the deploy-job comment / #884), so narrowing the scope to allow parallel deploys would just make concurrent runs collide on that lock (`[409] Conflict`). Keeping one global group with `cancel-in-progress: false` therefore serializes deploys: every merged commit's run is queued and allowed to finish rather than being cancelled. This fixes the observed #1087 edge case where a Dependabot merge cancelled an in-flight keycloak-aware run, and the replacement run then change-detection-skipped the deploy — so that commit never reached stage. Tradeoff: deploys now queue (slightly slower to converge under rapid merges) instead of cancelling, in exchange for never dropping a deploy. This matches the `cancel-in-progress: false` already used by `publish-images.yml`.

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` — valid
- `actionlint .github/workflows/merge.yml` — clean

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)