### PR TITLE
Add domain validation (#605)

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -230,6 +230,7 @@
           "enterCustomDomain": "Enter custom domain",
           "domainPlaceholder": "example.com",
           "domainHelp": "Enter your existing domain from registrars like GoDaddy, Namecheap, Squarespace Domains or another registrar.",
+          "invalidDomain": "Enter a valid domain name.",
           "continue": "Continue",
           "verifyStepTitle": "Next Step: Add your Thundermail DNS records",
           "verifyStepOneTitle": "1. Open your domain DNS settings",

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -230,7 +230,6 @@
           "enterCustomDomain": "Enter custom domain",
           "domainPlaceholder": "example.com",
           "domainHelp": "Enter your existing domain from registrars like GoDaddy, Namecheap, Squarespace Domains or another registrar.",
-          "invalidDomain": "Enter a valid domain name.",
           "continue": "Continue",
           "verifyStepTitle": "Next Step: Add your Thundermail DNS records",
           "verifyStepOneTitle": "1. Open your domain DNS settings",

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/api.ts
@@ -1,4 +1,11 @@
-export const addCustomDomain = async (domainName: string) => {
+type AddCustomDomainResponse = {
+  success: boolean;
+  domain_name?: string;
+  error?: string;
+  code?: string;
+};
+
+export const addCustomDomain = async (domainName: string): Promise<AddCustomDomainResponse> => {
   const response = await fetch(`/custom-domains/add`, {
     method: 'POST',
     headers: {

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -75,49 +75,6 @@ const spfIncludeValue = (record: DNSRecord): string =>
 const normalizeDomainName = (domainName?: string | null): string =>
   (domainName ?? '').trim().replace(/\.$/, '').toLowerCase();
 
-const normalizeCustomDomainInput = (domainName?: string | null): string =>
-  (domainName ?? '').replace(/\s+/g, '').toLowerCase();
-
-const domainLabelPattern = /^[a-z0-9\u00a1-\uffff](?:[a-z0-9\u00a1-\uffff-]{0,61}[a-z0-9\u00a1-\uffff])?$/i;
-const domainTldPattern = /^(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})$/i;
-
-const hasValidDomainTld = (label: string): boolean =>
-  label.length > 0
-  && label[0] !== '-'
-  && label[label.length - 1] !== '-'
-  && domainTldPattern.test(label);
-
-const isValidCustomDomainName = (domainName: string): boolean => {
-  if (!domainName.includes('.') || domainName.endsWith('.') || domainName.length > 255) {
-    return false;
-  }
-
-  const labels = domainName.split('.');
-  const tld = labels.pop();
-
-  return Boolean(tld && hasValidDomainTld(tld) && labels.every((label) => domainLabelPattern.test(label)));
-};
-
-const normalizedCustomDomain = computed(() => normalizeCustomDomainInput(customDomain.value));
-
-const isCustomDomainValid = computed(() => isValidCustomDomainName(normalizedCustomDomain.value));
-
-const customDomainInputError = computed(() => {
-  if (customDomainError.value) {
-    return customDomainError.value;
-  }
-
-  if (customDomain.value && !isCustomDomainValid.value) {
-    return t('views.mail.sections.customDomains.invalidDomain');
-  }
-
-  return null;
-});
-
-const canSubmitCustomDomain = computed(() =>
-  Boolean(customDomain.value) && isCustomDomainValid.value && !isAddingCustomDomain.value
-);
-
 const dkimRecordDomain = (record: DNSRecord): string | null => {
   if (record.type !== 'CNAME') {
     return null;
@@ -460,44 +417,34 @@ const handleDNSRecords = async (domainName: string) => {
       applyVerificationResult(domainName, validationResult(remoteDNSRecords), { showMissingIssues: false });
     } else {
       console.error(remoteDNSRecords.error);
-      customDomainError.value = remoteDNSRecords.error;    
+      customDomainError.value = remoteDNSRecords.error;
     }
   } catch (error) {
     console.error(error);
-    customDomainError.value = error;
+    customDomainError.value = String(error);
   }
 }
 
 const onCreateCustomDomain = async () => {
-  const domainName = normalizedCustomDomain.value;
-
-  if (!isValidCustomDomainName(domainName)) {
-    customDomainError.value = t('views.mail.sections.customDomains.invalidDomain');
-    return;
-  }
-
-  if (props.customDomains.some((domain) => normalizeDomainName(domain.name) === domainName)) {
-    customDomainError.value = t('views.mail.sections.customDomains.domainAlreadyExists');
-    return;
-  }
-
-  customDomain.value = domainName;
+  const submittedDomain = customDomain.value ?? '';
   customDomainError.value = null;
   domainAlreadyConfigured.value = false;
   isAddingCustomDomain.value = true;
 
   try {
-    const data = await addCustomDomain(domainName);
+    const data = await addCustomDomain(submittedDomain);
 
     if (data.success) {
+      const domainName = data.domain_name ?? submittedDomain;
+      customDomain.value = domainName;
       emit('custom-domain-added', domainName);
       await handleDNSRecords(domainName);
     } else if (data.code === 'domain_already_configured') {
       console.error(data.error);
-      domainAlreadyConfigured.value = true
+      domainAlreadyConfigured.value = true;
     } else {
       console.error(data.error);
-      customDomainError.value = data.error;
+      customDomainError.value = data.error ?? '';
     }
   } catch (error) {
     console.error(error);
@@ -595,7 +542,7 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
         :placeholder="t('views.mail.sections.customDomains.domainPlaceholder')"
         name="custom-domain"
         :help="t('views.mail.sections.customDomains.domainHelp')"
-        :error="customDomainInputError"
+        :error="customDomainError"
         class="custom-domain-text-input"
         v-model="customDomain"
       >
@@ -610,7 +557,7 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
         </i18n-t>
       </notice-bar>
 
-      <primary-button variant="outline" @click="onCreateCustomDomain" :disabled="!canSubmitCustomDomain">
+      <primary-button variant="outline" @click="onCreateCustomDomain" :disabled="isAddingCustomDomain">
         {{ t('views.mail.sections.customDomains.continue') }}
       </primary-button>
     </form>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -75,6 +75,49 @@ const spfIncludeValue = (record: DNSRecord): string =>
 const normalizeDomainName = (domainName?: string | null): string =>
   (domainName ?? '').trim().replace(/\.$/, '').toLowerCase();
 
+const normalizeCustomDomainInput = (domainName?: string | null): string =>
+  (domainName ?? '').replace(/\s+/g, '').toLowerCase();
+
+const domainLabelPattern = /^[a-z0-9\u00a1-\uffff](?:[a-z0-9\u00a1-\uffff-]{0,61}[a-z0-9\u00a1-\uffff])?$/i;
+const domainTldPattern = /^(?:[a-z\u00a1-\uffff-]{2,63}|xn--[a-z0-9]{1,59})$/i;
+
+const hasValidDomainTld = (label: string): boolean =>
+  label.length > 0
+  && label[0] !== '-'
+  && label[label.length - 1] !== '-'
+  && domainTldPattern.test(label);
+
+const isValidCustomDomainName = (domainName: string): boolean => {
+  if (!domainName.includes('.') || domainName.endsWith('.') || domainName.length > 255) {
+    return false;
+  }
+
+  const labels = domainName.split('.');
+  const tld = labels.pop();
+
+  return Boolean(tld && hasValidDomainTld(tld) && labels.every((label) => domainLabelPattern.test(label)));
+};
+
+const normalizedCustomDomain = computed(() => normalizeCustomDomainInput(customDomain.value));
+
+const isCustomDomainValid = computed(() => isValidCustomDomainName(normalizedCustomDomain.value));
+
+const customDomainInputError = computed(() => {
+  if (customDomainError.value) {
+    return customDomainError.value;
+  }
+
+  if (customDomain.value && !isCustomDomainValid.value) {
+    return t('views.mail.sections.customDomains.invalidDomain');
+  }
+
+  return null;
+});
+
+const canSubmitCustomDomain = computed(() =>
+  Boolean(customDomain.value) && isCustomDomainValid.value && !isAddingCustomDomain.value
+);
+
 const dkimRecordDomain = (record: DNSRecord): string | null => {
   if (record.type !== 'CNAME') {
     return null;
@@ -426,19 +469,29 @@ const handleDNSRecords = async (domainName: string) => {
 }
 
 const onCreateCustomDomain = async () => {
-  if (props.customDomains.some((domain) => domain.name === customDomain.value)) {
+  const domainName = normalizedCustomDomain.value;
+
+  if (!isValidCustomDomainName(domainName)) {
+    customDomainError.value = t('views.mail.sections.customDomains.invalidDomain');
+    return;
+  }
+
+  if (props.customDomains.some((domain) => normalizeDomainName(domain.name) === domainName)) {
     customDomainError.value = t('views.mail.sections.customDomains.domainAlreadyExists');
     return;
   }
 
+  customDomain.value = domainName;
+  customDomainError.value = null;
+  domainAlreadyConfigured.value = false;
   isAddingCustomDomain.value = true;
 
   try {
-    const data = await addCustomDomain(customDomain.value);
+    const data = await addCustomDomain(domainName);
 
     if (data.success) {
-      emit('custom-domain-added', customDomain.value);
-      await handleDNSRecords(customDomain.value);
+      emit('custom-domain-added', domainName);
+      await handleDNSRecords(domainName);
     } else if (data.code === 'domain_already_configured') {
       console.error(data.error);
       domainAlreadyConfigured.value = true
@@ -448,7 +501,7 @@ const onCreateCustomDomain = async () => {
     }
   } catch (error) {
     console.error(error);
-    customDomainError.value = error;
+    customDomainError.value = String(error);
   } finally {
     isAddingCustomDomain.value = false;
   }
@@ -504,6 +557,11 @@ watch(step, (newStep) => {
   emit('step-change', newStep);
 }, { immediate: true });
 
+watch(customDomain, () => {
+  customDomainError.value = null;
+  domainAlreadyConfigured.value = false;
+});
+
 watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
   // If we just removed the domain we were adding, reset the step to initial
   if (newLastDomainRemoved === customDomain.value) {
@@ -537,7 +595,7 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
         :placeholder="t('views.mail.sections.customDomains.domainPlaceholder')"
         name="custom-domain"
         :help="t('views.mail.sections.customDomains.domainHelp')"
-        :error="customDomainError"
+        :error="customDomainInputError"
         class="custom-domain-text-input"
         v-model="customDomain"
       >
@@ -552,7 +610,7 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
         </i18n-t>
       </notice-bar>
 
-      <primary-button variant="outline" @click="onCreateCustomDomain" :disabled="isAddingCustomDomain">
+      <primary-button variant="outline" @click="onCreateCustomDomain" :disabled="!canSubmitCustomDomain">
         {{ t('views.mail.sections.customDomains.continue') }}
       </primary-button>
     </form>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -427,8 +427,6 @@ const handleDNSRecords = async (domainName: string) => {
 
 const onCreateCustomDomain = async () => {
   const submittedDomain = customDomain.value ?? '';
-  customDomainError.value = null;
-  domainAlreadyConfigured.value = false;
   isAddingCustomDomain.value = true;
 
   try {
@@ -437,17 +435,22 @@ const onCreateCustomDomain = async () => {
     if (data.success) {
       const domainName = data.domain_name ?? submittedDomain;
       customDomain.value = domainName;
+      customDomainError.value = null;
+      domainAlreadyConfigured.value = false;
       emit('custom-domain-added', domainName);
       await handleDNSRecords(domainName);
     } else if (data.code === 'domain_already_configured') {
       console.error(data.error);
+      customDomainError.value = null;
       domainAlreadyConfigured.value = true;
     } else {
       console.error(data.error);
+      domainAlreadyConfigured.value = false;
       customDomainError.value = data.error ?? '';
     }
   } catch (error) {
     console.error(error);
+    domainAlreadyConfigured.value = false;
     customDomainError.value = String(error);
   } finally {
     isAddingCustomDomain.value = false;
@@ -503,11 +506,6 @@ defineExpose({
 watch(step, (newStep) => {
   emit('step-change', newStep);
 }, { immediate: true });
-
-watch(customDomain, () => {
-  customDomainError.value = null;
-  domainAlreadyConfigured.value = false;
-});
 
 watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
   // If we just removed the domain we were adding, reset the step to initial

--- a/src/thunderbird_accounts/core/tests/test_validators.py
+++ b/src/thunderbird_accounts/core/tests/test_validators.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+
+from thunderbird_accounts.core.validators import normalize_custom_domain
+
+
+class CustomDomainValidationTestCase(SimpleTestCase):
+    def test_normalizes_domain_before_validation(self):
+        cases = {
+            'Example.COM': 'example.com',
+            ' example . com ': 'example.com',
+            ' BÜCHER.example ': 'bücher.example',
+        }
+
+        for domain_name, expected in cases.items():
+            with self.subTest(domain_name=domain_name):
+                self.assertEqual(expected, normalize_custom_domain(domain_name))
+
+    def test_rejects_missing_and_trailing_dot_values(self):
+        for domain_name in [
+            None,
+            '',
+            'example.',
+        ]:
+            with self.subTest(domain_name=domain_name):
+                self.assertIsNone(normalize_custom_domain(domain_name))

--- a/src/thunderbird_accounts/core/validators.py
+++ b/src/thunderbird_accounts/core/validators.py
@@ -1,0 +1,23 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_domain_name
+
+
+def normalize_custom_domain(domain_name: str | None) -> str | None:
+    """Normalize and validate a custom mail domain."""
+    if not isinstance(domain_name, str):
+        return None
+
+    domain = ''.join(ch.lower() for ch in domain_name if not ch.isspace())
+    if not domain or domain.endswith('.'):
+        return None
+
+    try:
+        validate_domain_name(domain)
+    except ValidationError:
+        return None
+
+    return domain
+
+
+def is_valid_custom_domain(domain_name: str | None) -> bool:
+    return normalize_custom_domain(domain_name) is not None

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -202,6 +202,7 @@ class CreateCustomDomainTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode())
         self.assertTrue(data['success'])
+        self.assertEqual(data['domain_name'], 'example.com')
         self.assertTrue(Domain.objects.filter(name='example.com', user=self.user).exists())
         mock_instance.get_domain.assert_called_once_with('example.com')
         mock_instance.create_dkim.assert_called_once_with('example.com')

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -14,7 +14,7 @@ from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.core.tests.utils import oidc_force_login
 from thunderbird_accounts.mail.clients import DomainVerificationErrors, StaleDNSRecordCode
 from thunderbird_accounts.mail.models import Account, Domain, Email
-from thunderbird_accounts.mail.views import get_dns_records, remove_custom_domain
+from thunderbird_accounts.mail.views import create_custom_domain, get_dns_records, remove_custom_domain
 
 
 class AppPasswordApiTestCase(TestCase):
@@ -154,6 +154,58 @@ class ActiveSubscriptionRequiredMailViewsTestCase(TestCase):
                     response.json(),
                     {'success': False, 'error': 'An active subscription is required.'},
                 )
+
+
+class CreateCustomDomainTestCase(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+        self.plan = Plan.objects.create(name='Test Plan', mail_domain_count=10)
+        self.user = User.objects.create(
+            username=f'test@{settings.PRIMARY_EMAIL_DOMAIN}',
+            oidc_id='1234',
+            plan=self.plan,
+        )
+        Subscription.objects.create(user=self.user, status=Subscription.StatusValues.ACTIVE)
+        self.url = reverse('add_custom_domain')
+
+    def create_request(self, domain_name: str):
+        request = self.request_factory.post(
+            self.url,
+            data=json.dumps({'domain-name': domain_name}),
+            content_type='application/json',
+        )
+        request.user = self.user
+        return request
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.publish_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_rejects_invalid_domain_before_remote_calls(self, mock_mail_client_cls, mock_publish_hosted_dkim):
+        response = create_custom_domain(self.create_request('user@example.com'))
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content.decode())
+        self.assertFalse(data['success'])
+        self.assertEqual('Enter a valid domain name.', data['error'])
+        mock_mail_client_cls.assert_not_called()
+        mock_publish_hosted_dkim.assert_not_called()
+        self.assertFalse(Domain.objects.exists())
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.publish_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_normalizes_domain_before_creating_it(self, mock_mail_client_cls, mock_publish_hosted_dkim):
+        mock_instance = Mock()
+        mock_instance.get_domain.side_effect = DomainNotFoundError('example.com')
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = create_custom_domain(self.create_request(' Example.COM '))
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode())
+        self.assertTrue(data['success'])
+        self.assertTrue(Domain.objects.filter(name='example.com', user=self.user).exists())
+        mock_instance.get_domain.assert_called_once_with('example.com')
+        mock_instance.create_dkim.assert_called_once_with('example.com')
+        mock_publish_hosted_dkim.assert_called_once_with('example.com')
 
 
 @override_settings(HOSTED_DKIM_DOMAIN='dkim.example.net', HOSTED_DKIM_SELECTORS=['tm1', 'tm2', 'tm3'])

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -24,6 +24,7 @@ from thunderbird_accounts.authentication.middleware import AccountsOIDCBackend
 from thunderbird_accounts.authentication.reserved import is_reserved
 from thunderbird_accounts.mail.clients import DomainVerificationErrors, MailClient, StaleDNSRecordCode
 from thunderbird_accounts.mail.dkim import build_customer_dkim_cname_records
+from thunderbird_accounts.core.validators import normalize_custom_domain
 from thunderbird_accounts.mail.exceptions import (
     AccessTokenNotFound,
     AccountNotFoundError,
@@ -147,7 +148,9 @@ def create_custom_domain(request: HttpRequest):
     if not domain_name:
         return JsonResponse({'success': False, 'error': _('Domain name is required')}, status=400)
 
-    domain_name = domain_name.lower()
+    domain_name = normalize_custom_domain(domain_name)
+    if not domain_name:
+        return JsonResponse({'success': False, 'error': _('Enter a valid domain name.')}, status=400)
 
     custom_domain_count = request.user.domains.count()
 

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -198,7 +198,7 @@ def create_custom_domain(request: HttpRequest):
             status=500,
         )
 
-    return JsonResponse({'success': True})
+    return JsonResponse({'success': True, 'domain_name': domain_name})
 
 
 @login_required


### PR DESCRIPTION
## What changed?

Custom Domain name validation was added.

## Why?

This was spurred by #1079 where an invalid domain got into the system and caused problems.

## Limitations and Notes

To choose exactly how to validate the domain, but Stalwart's domain validation code was analyzed along with Django. They turned out to be highly compatible, so Django's built-in domain validation was used for simplicity.

We can expect Stalwart will also find valid domains validated this way.

## Applicable Issues

* Fixes #105, References #1079

## Screenshots

<img width="617" height="290" alt="image" src="https://github.com/user-attachments/assets/e0bfe534-907f-489f-9185-f976e5819243" />

## QA log

 - Compared Django algo to Stalwart
 - Automated test coverage
 - Manually tested positive and negative cases. Seem screenshot.
