### PR TITLE
Refresh OIDC access tokens before fixing archive folders (#1106)

### DIFF
--- a/src/thunderbird_accounts/authentication/mfa_management.py
+++ b/src/thunderbird_accounts/authentication/mfa_management.py
@@ -3,7 +3,6 @@ import time
 from dataclasses import dataclass
 from urllib.parse import urlencode, urlparse
 
-import jwt
 import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
@@ -26,7 +25,7 @@ from thunderbird_accounts.authentication.mfa import (
     has_recent_mfa_management_auth,
     make_pending_totp_cache_key,
 )
-from thunderbird_accounts.authentication.middleware import OIDC_ACCESS_TOKEN_KEY, refresh_user_access_token
+from thunderbird_accounts.authentication.tokens import get_user_access_token
 
 
 class MfaManagementError(Exception):
@@ -128,26 +127,6 @@ class MfaMethodsResult:
                 'credentials': serialize_recovery_codes_credentials(self.recovery_codes_credentials),
             },
         }
-
-
-def _access_token_is_expired(access_token: str) -> bool:
-    """True only when the token's exp can be read and has passed (minus a small skew).
-    Unreadable tokens are treated as not-expired so we forward them unchanged."""
-    try:
-        claims = jwt.decode(access_token, options={'verify_signature': False})
-        exp = int(claims['exp'])
-    except (jwt.PyJWTError, KeyError, ValueError, TypeError):
-        return False
-    return time.time() >= exp - settings.MFA_ACCESS_TOKEN_EXPIRY_LEEWAY_SECONDS
-
-
-def get_user_access_token(request: Request) -> str | None:
-    """Return the end user's OIDC access token for the self-service MFA provider."""
-    # Only local expiry is checked here; Keycloak-side revocation surfaces later as a provider 401.
-    access_token = request.session.get(OIDC_ACCESS_TOKEN_KEY)
-    if access_token and not _access_token_is_expired(access_token):
-        return access_token
-    return refresh_user_access_token(request) or access_token
 
 
 def mfa_session_expired_response() -> Response:

--- a/src/thunderbird_accounts/authentication/tests/test_mfa.py
+++ b/src/thunderbird_accounts/authentication/tests/test_mfa.py
@@ -25,7 +25,12 @@ from thunderbird_accounts.authentication.mfa import (
     MFA_REST_ERROR_STEP_UP_REQUIRED,
     MFA_REST_ERROR_TOTP_NOT_CONFIGURED,
 )
-from thunderbird_accounts.authentication.mfa_management import get_user_access_token
+from thunderbird_accounts.authentication.tokens import (
+    AccessTokenExpiry,
+    AccessTokenPolicy,
+    get_access_token_expiry,
+    get_user_access_token,
+)
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.authentication.views import MfaReauthenticationRequestView
 
@@ -55,7 +60,8 @@ class MfaApiTestCase(TestCase):
         session = self.client.session
         session[MFA_MANAGEMENT_AUTH_SESSION_KEY] = int(time.time())
         # The provider is self-service: the view forwards the user's stored OIDC access token.
-        session['oidc_access_token'] = 'test-user-access-token'
+        self.user_access_token = _jwt_with_exp(300)
+        session['oidc_access_token'] = self.user_access_token
         session.save()
         self.mfa_provider_patcher = patch('thunderbird_accounts.authentication.mfa_management.KeycloakMfaClient')
         self.mock_mfa_client = self.mfa_provider_patcher.start()
@@ -220,7 +226,7 @@ class MfaApiTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.mock_mfa_client.return_value.register_totp_credential.assert_called_once_with(
-            user_access_token='test-user-access-token',
+            user_access_token=self.user_access_token,
             secret=pending_secret,
             code='123456',
             user_label='Authenticator app',
@@ -242,7 +248,7 @@ class MfaApiTestCase(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.mock_mfa_client.return_value.logout_other_sessions.assert_called_once_with('test-user-access-token')
+        self.mock_mfa_client.return_value.logout_other_sessions.assert_called_once_with(self.user_access_token)
 
     @patch('thunderbird_accounts.authentication.mfa_management.KeycloakClient')
     def test_confirm_totp_setup_without_logout_flag_skips_account_api(self, mock_keycloak_client: Mock):
@@ -465,7 +471,7 @@ class MfaApiTestCase(TestCase):
         self.assertEqual(body['codes'], codes)
         self.assertTrue(body['credentials'][0]['totalCodes'] == 12)
         self.mock_mfa_client.return_value.regenerate_recovery_codes.assert_called_once_with(
-            'test-user-access-token', user_label='Recovery codes'
+            self.user_access_token, user_label='Recovery codes'
         )
 
     @patch('thunderbird_accounts.authentication.mfa_management.KeycloakClient')
@@ -674,28 +680,43 @@ class GetUserAccessTokenTestCase(TestCase):
     def _request(**session):
         return SimpleNamespace(session=dict(session))
 
-    @patch('thunderbird_accounts.authentication.mfa_management.refresh_user_access_token')
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token')
     def test_returns_unexpired_token_without_refreshing(self, mock_refresh: Mock):
         token = _jwt_with_exp(300)
         self.assertEqual(get_user_access_token(self._request(oidc_access_token=token)), token)
         mock_refresh.assert_not_called()
 
-    @patch('thunderbird_accounts.authentication.mfa_management.refresh_user_access_token', return_value='fresh-token')
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token', return_value='fresh-token')
     def test_refreshes_expired_token(self, mock_refresh: Mock):
         request = self._request(oidc_access_token=_jwt_with_exp(-10))
         self.assertEqual(get_user_access_token(request), 'fresh-token')
         mock_refresh.assert_called_once_with(request)
 
-    @patch('thunderbird_accounts.authentication.mfa_management.refresh_user_access_token', return_value=None)
-    def test_falls_back_to_stored_token_when_refresh_fails(self, _mock_refresh: Mock):
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token', return_value=None)
+    def test_returns_none_for_expired_token_when_refresh_fails(self, _mock_refresh: Mock):
         expired = _jwt_with_exp(-10)
-        self.assertEqual(get_user_access_token(self._request(oidc_access_token=expired)), expired)
+        self.assertIsNone(get_user_access_token(self._request(oidc_access_token=expired)))
 
-    @patch('thunderbird_accounts.authentication.mfa_management.refresh_user_access_token')
-    def test_opaque_token_is_forwarded_unchanged(self, mock_refresh: Mock):
-        self.assertEqual(get_user_access_token(self._request(oidc_access_token='opaque-not-a-jwt')), 'opaque-not-a-jwt')
-        mock_refresh.assert_not_called()
+    def test_opaque_token_has_unknown_expiry(self):
+        self.assertEqual(get_access_token_expiry('opaque-not-a-jwt'), AccessTokenExpiry.UNKNOWN)
 
-    @patch('thunderbird_accounts.authentication.mfa_management.refresh_user_access_token', return_value=None)
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token', return_value='fresh-token')
+    def test_refreshes_unknown_expiry_token(self, mock_refresh: Mock):
+        request = self._request(oidc_access_token='opaque-not-a-jwt')
+        self.assertEqual(get_user_access_token(request), 'fresh-token')
+        mock_refresh.assert_called_once_with(request)
+
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token', return_value=None)
+    def test_returns_none_for_unknown_expiry_when_refresh_fails(self, _mock_refresh: Mock):
+        self.assertIsNone(get_user_access_token(self._request(oidc_access_token='opaque-not-a-jwt')))
+
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token', return_value='fresh-token')
+    def test_force_refresh_ignores_stored_token(self, mock_refresh: Mock):
+        stored_token = _jwt_with_exp(300)
+        request = self._request(oidc_access_token=stored_token)
+        self.assertEqual(get_user_access_token(request, policy=AccessTokenPolicy.FORCE_REFRESH), 'fresh-token')
+        mock_refresh.assert_called_once_with(request)
+
+    @patch('thunderbird_accounts.authentication.tokens.refresh_user_access_token', return_value=None)
     def test_returns_none_when_no_token_stored(self, _mock_refresh: Mock):
         self.assertIsNone(get_user_access_token(self._request()))

--- a/src/thunderbird_accounts/authentication/tokens.py
+++ b/src/thunderbird_accounts/authentication/tokens.py
@@ -1,0 +1,52 @@
+from enum import Enum
+import time
+
+import jwt
+from django.conf import settings
+
+from thunderbird_accounts.authentication.middleware import OIDC_ACCESS_TOKEN_KEY, refresh_user_access_token
+
+
+class AccessTokenExpiry(Enum):
+    EXPIRED = 'expired'
+    NOT_EXPIRED = 'not_expired'
+    UNKNOWN = 'unknown'
+
+
+class AccessTokenPolicy(Enum):
+    REQUIRE_KNOWN_FRESH = 'require_known_fresh'
+    FORCE_REFRESH = 'force_refresh'
+
+
+def get_access_token_expiry(access_token: str) -> AccessTokenExpiry:
+    try:
+        claims = jwt.decode(access_token, options={'verify_signature': False})
+        exp = int(claims['exp'])
+    except (jwt.PyJWTError, KeyError, ValueError, TypeError):
+        return AccessTokenExpiry.UNKNOWN
+    if time.time() >= exp - settings.MFA_ACCESS_TOKEN_EXPIRY_LEEWAY_SECONDS:
+        return AccessTokenExpiry.EXPIRED
+    return AccessTokenExpiry.NOT_EXPIRED
+
+
+def get_user_access_token(
+    request,
+    *,
+    policy: AccessTokenPolicy = AccessTokenPolicy.REQUIRE_KNOWN_FRESH,
+) -> str | None:
+    """Return the end user's OIDC access token, refreshing if needed."""
+    access_token = request.session.get(OIDC_ACCESS_TOKEN_KEY)
+    if policy == AccessTokenPolicy.FORCE_REFRESH:
+        return refresh_user_access_token(request)
+
+    expiry = get_access_token_expiry(access_token) if access_token else None
+
+    if access_token:
+        if expiry == AccessTokenExpiry.NOT_EXPIRED:
+            return access_token
+
+    refreshed_access_token = refresh_user_access_token(request)
+    if refreshed_access_token:
+        return refreshed_access_token
+
+    return None

--- a/src/thunderbird_accounts/mail/middleware.py
+++ b/src/thunderbird_accounts/mail/middleware.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest
+from thunderbird_accounts.authentication.tokens import AccessTokenPolicy, get_user_access_token
 from thunderbird_accounts.mail.utils import fix_archives_folder
 
 
@@ -15,15 +16,22 @@ class FixMissingArchivesFolderMiddleware:
         return self.get_response(request)
 
     def check_if_we_need_to_fix_archives_folder(self, request: HttpRequest):
-        oidc_access_token = request.session.get('oidc_access_token')
-        if not oidc_access_token:
-            return
-
         user = request.user
 
         # If the user exists, has a stalwart account reference and an oidc access token
         # Check if we need to fix their archives folder, and do it if we need to.
-        if user and user.account_set.count() > 0 and oidc_access_token:
+        if user and user.account_set.count() > 0:
             archive_folders_to_check = user.account_set.filter(verified_archive_folder=False)
             for account in archive_folders_to_check:
-                fix_archives_folder(oidc_access_token, account)
+                oidc_access_token = get_user_access_token(
+                    request,
+                    policy=AccessTokenPolicy.REQUIRE_KNOWN_FRESH,
+                )
+                if not oidc_access_token:
+                    return
+
+                fix_archives_folder(
+                    oidc_access_token,
+                    account,
+                    refresh_access_token=lambda: get_user_access_token(request, policy=AccessTokenPolicy.FORCE_REFRESH),
+                )

--- a/src/thunderbird_accounts/mail/tests/test_middleware.py
+++ b/src/thunderbird_accounts/mail/tests/test_middleware.py
@@ -1,15 +1,21 @@
 from django.contrib.auth.models import AnonymousUser
-from thunderbird_accounts.subscription.models import Subscription
-from thunderbird_accounts.mail.models import Account
-from django.conf import settings
+import time
 from importlib import import_module
 from typing import Optional
-from django.http.request import HttpRequest
 from unittest.mock import MagicMock
-from thunderbird_accounts.mail.middleware import FixMissingArchivesFolderMiddleware
-from thunderbird_accounts.authentication.models import User
-from django.test.testcases import TestCase
 from unittest.mock import patch
+
+import jwt
+import requests
+from django.conf import settings
+from django.http.request import HttpRequest
+from django.test.testcases import TestCase
+from requests.exceptions import HTTPError
+
+from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.mail.middleware import FixMissingArchivesFolderMiddleware
+from thunderbird_accounts.mail.models import Account
+from thunderbird_accounts.subscription.models import Subscription
 
 
 @patch('thunderbird_accounts.mail.tiny_jmap_client.TinyJMAPClient')
@@ -57,13 +63,20 @@ class FixMissingArchivesFolderMiddlewareTestCase(TestCase):
             'sessionState': '3e25b2a0',
         }
 
-    def build_request(self, user: Optional[User] = None, access_token: Optional[str] = None):
+    def build_request(
+        self,
+        user: Optional[User] = None,
+        access_token: Optional[str] = None,
+        refresh_token: Optional[str] = None,
+    ):
         fake_request = HttpRequest()
         engine = import_module(settings.SESSION_ENGINE)
         fake_request.session = engine.SessionStore()
 
         if access_token:
             fake_request.session['oidc_access_token'] = access_token
+        if refresh_token:
+            fake_request.session['oidc_refresh_token'] = refresh_token
 
         if user:
             fake_request.user = user
@@ -73,10 +86,22 @@ class FixMissingArchivesFolderMiddlewareTestCase(TestCase):
         fake_request.session.save()
         return fake_request
 
+    def build_access_token(self, exp_offset_seconds: int) -> str:
+        return jwt.encode(
+            {'exp': int(time.time()) + exp_offset_seconds},
+            'test-signing-key-not-verified-0123456789',
+            algorithm='HS256',
+        )
+
+    def build_unauthorized_error(self) -> HTTPError:
+        response = requests.Response()
+        response.status_code = 401
+        return HTTPError('401 Client Error: Unauthorized', response=response)
+
     def test_freshly_subscribed_user(self, tiny_jmap_mock: MagicMock):
         """A fresh user who has a subscription and a stalwart account should have their archive folder checked
         and successfully created"""
-        oidc_access_token = 'abc123'
+        oidc_access_token = self.build_access_token(300)
 
         user = User(username='test@example.org', email='test@example.com')
         user.save()
@@ -115,9 +140,101 @@ class FixMissingArchivesFolderMiddlewareTestCase(TestCase):
         account.refresh_from_db()
         self.assertTrue(account.verified_archive_folder)
 
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    def test_expired_access_token_refreshes_before_checking_archives_folder(
+        self, mock_post: MagicMock, tiny_jmap_mock: MagicMock
+    ):
+        user = User(username='test@example.org', email='test@example.com')
+        user.save()
+        account = Account(name=user.username, user=user)
+        account.save()
+        Subscription.objects.create(
+            paddle_id='foo', paddle_customer_id='bar', status=Subscription.StatusValues.ACTIVE, user=user
+        )
+
+        mock_post.return_value = MagicMock(
+            json=MagicMock(return_value={'access_token': 'fresh-access', 'refresh_token': 'fresh-refresh'})
+        )
+        tiny_jmap_mock.return_value.make_jmap_call.side_effect = [
+            self.build_mailbox_query_response(),
+            self.build_mailbox_set_response(),
+        ]
+
+        fake_request = self.build_request(
+            user,
+            self.build_access_token(-10),
+            refresh_token='old-refresh',
+        )
+
+        with patch('uuid.uuid4') as uuid_mock:
+            uuid_mock.return_value = self.DEFAULT_TEMP_ID
+            self.middleware(fake_request)
+
+        tiny_jmap_mock.assert_called_once_with(
+            hostname=settings.STALWART_BASE_JMAP_URL,
+            username=account.name,
+            token='fresh-access',
+        )
+        account.refresh_from_db()
+        self.assertTrue(account.verified_archive_folder)
+
+    def test_expired_access_token_without_refresh_token_skips_archives_folder(self, tiny_jmap_mock: MagicMock):
+        user = User(username='test@example.org', email='test@example.com')
+        user.save()
+        account = Account(name=user.username, user=user)
+        account.save()
+        Subscription.objects.create(
+            paddle_id='foo', paddle_customer_id='bar', status=Subscription.StatusValues.ACTIVE, user=user
+        )
+
+        fake_request = self.build_request(user, self.build_access_token(-10))
+
+        self.middleware(fake_request)
+
+        tiny_jmap_mock.assert_not_called()
+        account.refresh_from_db()
+        self.assertFalse(account.verified_archive_folder)
+
+    @patch('thunderbird_accounts.authentication.middleware.requests.post')
+    def test_unauthorized_jmap_session_retries_with_refreshed_token(
+        self, mock_post: MagicMock, tiny_jmap_mock: MagicMock
+    ):
+        user = User(username='test@example.org', email='test@example.com')
+        user.save()
+        account = Account(name=user.username, user=user)
+        account.save()
+        Subscription.objects.create(
+            paddle_id='foo', paddle_customer_id='bar', status=Subscription.StatusValues.ACTIVE, user=user
+        )
+
+        mock_post.return_value = MagicMock(
+            json=MagicMock(return_value={'access_token': 'fresh-access', 'refresh_token': 'fresh-refresh'})
+        )
+        stale_access_token = self.build_access_token(300)
+        stale_client = MagicMock()
+        stale_client.get_account_id.side_effect = self.build_unauthorized_error()
+        fresh_client = MagicMock()
+        fresh_client.get_account_id.return_value = 'd'
+        fresh_client.make_jmap_call.side_effect = [
+            self.build_mailbox_query_response(),
+            self.build_mailbox_set_response(),
+        ]
+        tiny_jmap_mock.side_effect = [stale_client, fresh_client]
+
+        fake_request = self.build_request(user, stale_access_token, refresh_token='old-refresh')
+
+        with patch('uuid.uuid4') as uuid_mock:
+            uuid_mock.return_value = self.DEFAULT_TEMP_ID
+            self.middleware(fake_request)
+
+        self.assertEqual(tiny_jmap_mock.call_args_list[0].kwargs['token'], stale_access_token)
+        self.assertEqual(tiny_jmap_mock.call_args_list[1].kwargs['token'], 'fresh-access')
+        account.refresh_from_db()
+        self.assertTrue(account.verified_archive_folder)
+
     def test_already_verified_account_isnt_checked_again(self, tiny_jmap_mock: MagicMock):
         """A user with a verified archive folder shouldn't have any jmap calls sent"""
-        oidc_access_token = 'abc123'
+        oidc_access_token = self.build_access_token(300)
 
         user = User(username='test@example.org', email='test@example.com')
         user.save()
@@ -204,7 +321,7 @@ class FixMissingArchivesFolderMiddlewareTestCase(TestCase):
         self, tiny_jmap_mock: MagicMock, fix_archives_folder_mock: MagicMock
     ):
         """An authenticated but non-subscribed user shouldn't ahve fix archives folder called"""
-        oidc_access_token = 'abc123'
+        oidc_access_token = self.build_access_token(300)
 
         user = User(username='test@example.org', email='test@example.com')
         user.save()
@@ -260,7 +377,7 @@ class FixMissingArchivesFolderMiddlewareTestCase(TestCase):
 
     def test_malformed_jmap_response_shouldnt_crash_the_request(self, tiny_jmap_mock: MagicMock):
         """An authenticated user with a non-active subscription shouldn't ahve fix archives folder called"""
-        oidc_access_token = 'abc123'
+        oidc_access_token = self.build_access_token(300)
 
         user = User(username='test@example.org', email='test@example.com')
         user.save()

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -96,7 +96,12 @@ def create_stalwart_account(user, app_password: Optional[str] = None) -> bool:
     return True
 
 
-def fix_archives_folder(access_token, account: Account) -> bool:
+def _is_unauthorized_http_error(exception: HTTPError) -> bool:
+    response = getattr(exception, 'response', None)
+    return response is not None and response.status_code == 401
+
+
+def fix_archives_folder(access_token, account: Account, *, refresh_access_token=None) -> bool:
     """Check if the archive folder exists, if it doesn't create it!
     This fixes a bug with our stalwart instance where it doesn't give us an archives folder...
 
@@ -211,7 +216,14 @@ def fix_archives_folder(access_token, account: Account) -> bool:
 
         return True
     except (HTTPError, RuntimeError, KeyError) as ex:
-        logging.error('fix_archive_folder failed!')
+        if isinstance(ex, HTTPError) and refresh_access_token and _is_unauthorized_http_error(ex):
+            refreshed_access_token = refresh_access_token()
+            if refreshed_access_token and refreshed_access_token != access_token:
+                # Retry once with a refreshed token. Do not pass refresh_access_token
+                # again, so repeated 401s fail instead of recursing indefinitely.
+                return fix_archives_folder(refreshed_access_token, account)
+
+        logging.warning('fix_archives_folder failed!')
         sentry_sdk.set_context('inbox_response', {'inboxes': inboxes})
         sentry_sdk.capture_exception(ex)
     return False


### PR DESCRIPTION
## What changed and why? 

The MFA management flow already checked the stored Keycloak access token's
expiration and refreshed it.

Here we move that freshness check into a shared helper and use it from
fix_archives_folder() before making JMAP calls.

This avoids forwarding stale access tokens to Stalwart, which was producing
frequent 401s in Sentry from the archive-folder repair path.

## Notes

We also tighten the behavior: If refresh fails, "fail fast" instead
of passing a known-stail token downstream.

If there was a specific reason the MFA code passed along expired tokens rather than
considering them failed, we can restore that behavior. My read that Keycloak was
going to consider them failed on the next hop, so it was clearer to treat them
as failed earlier.

## Applicable Issues

* Fixes #1106

## QA Log

 * Automated testing
 * Manual re-testing locally of MFA onboarding flow for regressions
