### PR TITLE
Check for required fields before calling Zendesk (#1117)

### DIFF
--- a/src/thunderbird_accounts/support/tests/test_views.py
+++ b/src/thunderbird_accounts/support/tests/test_views.py
@@ -205,6 +205,37 @@ class ZendeskContactSubmitTestCase(TestCase):
         mock_client_cls.assert_not_called()
 
     @patch('thunderbird_accounts.support.views.ZendeskClient')
+    def test_contact_submit_rejects_missing_required_zendesk_fields_before_upload(self, mock_client_cls):
+        url = reverse('contact_submit')
+        payload = {
+            'email': 'user@example.org',
+            'name': 'User',
+            'fields': [],
+        }
+        uploaded = SimpleUploadedFile('test.txt', b'hi', content_type='text/plain')
+        response = self.client.post(url, data={'data': json.dumps(payload), 'attachments': uploaded})
+
+        self.assertEqual(response.status_code, 400)
+        body = json.loads(response.content.decode())
+        self.assertFalse(body['success'])
+        self.assertIn('Subject is required', body['error'])
+        self.assertIn('Description is required', body['error'])
+        mock_client_cls.assert_not_called()
+
+    @patch('thunderbird_accounts.support.views.ZendeskClient')
+    def test_contact_submit_rejects_missing_data_payload(self, mock_client_cls):
+        url = reverse('contact_submit')
+        response = self.client.post(url, data={})
+
+        self.assertEqual(response.status_code, 400)
+        body = json.loads(response.content.decode())
+        self.assertFalse(body['success'])
+        self.assertIn('Email is required', body['error'])
+        self.assertIn('Subject is required', body['error'])
+        self.assertIn('Description is required', body['error'])
+        mock_client_cls.assert_not_called()
+
+    @patch('thunderbird_accounts.support.views.ZendeskClient')
     @override_settings(ZENDESK_FORM_ID='42')
     def test_contact_submit_upload_failure(self, mock_client_cls):
         instance = Mock()

--- a/src/thunderbird_accounts/support/views.py
+++ b/src/thunderbird_accounts/support/views.py
@@ -3,6 +3,7 @@ import json
 
 import sentry_sdk
 from django.conf import settings
+from django.core.validators import EMPTY_VALUES
 from django.http import HttpRequest, JsonResponse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import cache_page
@@ -12,6 +13,7 @@ from thunderbird_accounts.support.zendesk import ZendeskClient
 
 # Add browser and OS information to hidden custom fields
 from thunderbird_accounts.core.utils import parse_user_agent_info
+
 
 @require_http_methods(['GET'])
 @cache_page(60 * 15)
@@ -74,8 +76,8 @@ def contact_submit(request: HttpRequest):
 
     # Name is optional in the UI,
     # but it is required for the Zendesk Requests API's requester object
-    # So we default to the email address if the name is not provided
-    name = data_json.get('name', email)
+    # So we default to the email address if the name is missing or empty.
+    name = data_json.get('name') or email
 
     fields = data_json.get('fields', [])
 
@@ -109,6 +111,16 @@ def contact_submit(request: HttpRequest):
             custom_fields.append({'id': field_id, 'value': field_value})
 
     uploaded_files = request.FILES.getlist('attachments')
+
+    # TODO: Refactor this view to use Django's Forms API instead of direct EMPTY_VALUES access.
+    if email in EMPTY_VALUES:
+        validation_errors.append('Email is required')
+
+    if subject in EMPTY_VALUES:
+        validation_errors.append('Subject is required')
+
+    if description in EMPTY_VALUES:
+        validation_errors.append('Description is required')
 
     # Check for validation errors
     if validation_errors:


### PR DESCRIPTION
This keeps us from calling Zendesk with data that would be rejected.

## Why?

This addresses errors we were getting with Zendesk rejecting empty request
with HTTP 422 status.

## Notes

Had we used Django's standard Forms API for form validation, it would
have caught that issue.

A larger refactor is recommended to switch to that design.

What we continue to do here is to post the key data as a JSON structure instead of as form fields, bypassing the ability to use Django's standard form processing methods.

## Applicable Issues

 * Fixes #1117 

## QA Log

 * It appears the frontend was already doing some validation, but apparently bots or other user agents were posting directly to the backend, which triggered the exceptions.
 * Added automated tests.
