### PR TITLE
Update dashboard tests to verify app content loads after clicking service icons

### DIFF
--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -41,6 +41,7 @@ export const TIMEOUT_3_SECONDS = 3000;
 export const TIMEOUT_5_SECONDS = 5000;
 export const TIMEOUT_10_SECONDS = 5000;
 export const TIMEOUT_30_SECONDS = 30000;
+export const TIMEOUT_60_SECONDS = 60000;
 
 // connection info
 export const ACCTS_HOST = String(process.env.ACCTS_HOST);

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -37,6 +37,7 @@ export const PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY = '@e2e-prod-mobile-nightly'
 // timeouts
 export const TIMEOUT_1_SECOND = 1000;
 export const TIMEOUT_2_SECONDS = 2000;
+export const TIMEOUT_3_SECONDS = 3000;
 export const TIMEOUT_5_SECONDS = 5000;
 export const TIMEOUT_10_SECONDS = 5000;
 export const TIMEOUT_30_SECONDS = 30000;

--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -12,6 +12,7 @@ import {
   TIMEOUT_3_SECONDS,
   TIMEOUT_5_SECONDS,
   TIMEOUT_30_SECONDS,
+  TIMEOUT_60_SECONDS,
 } from '../const/constants';
 import { waitForVueApp } from '../utils/utils';
 
@@ -25,6 +26,10 @@ type PopupPageAssertion = {
   expectedUrl: string;
   expectedElementName: string;
   expectedElement: (page: Page) => Locator;
+  beforeExpectedElements?: Array<{
+    expectedElementName: string;
+    expectedElement: (page: Page) => Locator;
+  }>;
 };
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -134,12 +139,20 @@ export class DashboardPage {
     await this.verifyPopupServiceAppLoads({
       link: this.appointmentLink,
       expectedUrl: serviceUrls.appointment,
+      beforeExpectedElements: [{
+        expectedElementName: 'Need help? Visit support',
+        expectedElement: page => page.locator('footer').getByRole('link', { name: /visit support/i }),
+      }],
       expectedElementName: 'Copy booking link',
       expectedElement: page => page.getByRole('button', { name: /copy booking link/i }),
     });
     await this.verifyPopupServiceAppLoads({
       link: this.sendLink,
       expectedUrl: serviceUrls.send,
+      beforeExpectedElements: [{
+        expectedElementName: 'Need help? Visit support',
+        expectedElement: page => page.locator('footer').getByRole('link', { name: /visit support/i }),
+      }],
       expectedElementName: 'Recover access',
       expectedElement: page => page.getByTestId('recover-access-button'),
     });
@@ -189,6 +202,7 @@ export class DashboardPage {
   private async verifyPopupServiceAppLoads({
     link,
     expectedUrl,
+    beforeExpectedElements = [],
     expectedElementName,
     expectedElement,
   }: PopupPageAssertion) {
@@ -207,10 +221,16 @@ export class DashboardPage {
     await popup.waitForLoadState('domcontentloaded');
     await popup.waitForLoadState('networkidle', { timeout: TIMEOUT_30_SECONDS }).catch(() => {});
     expect(new URL(popup.url()).origin).toBe(new URL(expectedUrl).origin);
+    for (const beforeExpectedElement of beforeExpectedElements) {
+      await expect(
+        beforeExpectedElement.expectedElement(popup),
+        `${beforeExpectedElement.expectedElementName} should be visible after navigating to ${expectedUrl}`,
+      ).toBeVisible({ timeout: TIMEOUT_60_SECONDS }); // browserstack is super slow
+    }
     await expect(
       expectedElement(popup),
       `${expectedElementName} should be visible after navigating to ${expectedUrl}`,
-    ).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    ).toBeVisible({ timeout: TIMEOUT_60_SECONDS }); // browserstack is super slow
     await popup.close();
   }
 }

--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -9,6 +9,7 @@ import {
   DASHBOARD_CURRENT_SUBSCRIPTION_SEND_STORAGE,
   PADDLE_HOST,
   TIMEOUT_2_SECONDS,
+  TIMEOUT_3_SECONDS,
   TIMEOUT_5_SECONDS,
   TIMEOUT_30_SECONDS,
 } from '../const/constants';
@@ -18,6 +19,13 @@ interface ServiceUrls {
   appointment: string;
   send: string;
 }
+
+type PopupPageAssertion = {
+  link: Locator;
+  expectedUrl: string;
+  expectedElementName: string;
+  expectedElement: (page: Page) => Locator;
+};
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -109,15 +117,32 @@ export class DashboardPage {
   }
 
   async verifyThundermailNavigation() {
+    await this.thundermailLink.scrollIntoViewIfNeeded();
     await this.thundermailLink.click();
+    await this.page.waitForTimeout(TIMEOUT_3_SECONDS);
     await this.waitForPageToSettle();
     await expect.poll(async () => new URL(this.page.url()).pathname).toBe('/mail');
+    await expect(this.page.getByRole('heading', { name: 'Get started with Thundermail' })).toBeVisible({
+      timeout: TIMEOUT_30_SECONDS,
+    });
   }
 
-  async verifyServiceLinksOpenConfiguredUrls() {
+  async verifyServiceAppsLoadAfterNavigation() {
     const serviceUrls = await this.getConfiguredServiceUrls();
-    await this.verifyLinkOpensPopup(this.appointmentLink, serviceUrls.appointment);
-    await this.verifyLinkOpensPopup(this.sendLink, serviceUrls.send);
+    // Thundermail is an internal Accounts route and reuses the current page, while
+    // Appointment and Send are configured external services that open in popups.
+    await this.verifyPopupServiceAppLoads({
+      link: this.appointmentLink,
+      expectedUrl: serviceUrls.appointment,
+      expectedElementName: 'Copy booking link',
+      expectedElement: page => page.getByRole('button', { name: /copy booking link/i }),
+    });
+    await this.verifyPopupServiceAppLoads({
+      link: this.sendLink,
+      expectedUrl: serviceUrls.send,
+      expectedElementName: 'Recover access',
+      expectedElement: page => page.getByTestId('recover-access-button'),
+    });
   }
 
   async verifyManageSubscriptionOpensPortal() {
@@ -161,8 +186,14 @@ export class DashboardPage {
     }));
   }
 
-  private async verifyLinkOpensPopup(link: Locator, expectedUrl: string) {
+  private async verifyPopupServiceAppLoads({
+    link,
+    expectedUrl,
+    expectedElementName,
+    expectedElement,
+  }: PopupPageAssertion) {
     expect(expectedUrl).toBeTruthy();
+    await link.scrollIntoViewIfNeeded();
     await expect(link).toHaveAttribute('href', expectedUrl);
     await expect(link).toHaveAttribute('target', '_blank');
 
@@ -171,8 +202,15 @@ export class DashboardPage {
       link.click(),
     ]);
 
+    await popup.waitForTimeout(TIMEOUT_3_SECONDS);
     await expect.poll(async () => popup.url()).not.toBe('about:blank');
-    expect(new URL(popup.url()).href).toBe(new URL(expectedUrl).href);
+    await popup.waitForLoadState('domcontentloaded');
+    await popup.waitForLoadState('networkidle', { timeout: TIMEOUT_30_SECONDS }).catch(() => {});
+    expect(new URL(popup.url()).origin).toBe(new URL(expectedUrl).origin);
+    await expect(
+      expectedElement(popup),
+      `${expectedElementName} should be visible after navigating to ${expectedUrl}`,
+    ).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
     await popup.close();
   }
 }

--- a/test/e2e/tests/desktop/dashboard.spec.ts
+++ b/test/e2e/tests/desktop/dashboard.spec.ts
@@ -42,7 +42,7 @@ test.describe('dashboard controls on desktop browser', {
     await dashboardPage.verifyThundermailNavigation();
     await dashboardPage.navigateToDashboard();
 
-    await dashboardPage.verifyServiceLinksOpenConfiguredUrls();
+    await dashboardPage.verifyServiceAppsLoadAfterNavigation();
     await dashboardPage.verifyManageSubscriptionOpensPortal();
     await dashboardPage.verifyUserMenuControls();
   });

--- a/test/e2e/tests/mobile/dashboard.spec.ts
+++ b/test/e2e/tests/mobile/dashboard.spec.ts
@@ -42,7 +42,7 @@ test.describe('dashboard controls on mobile browser', {
     await dashboardPage.verifyThundermailNavigation();
     await dashboardPage.navigateToDashboard();
 
-    await dashboardPage.verifyServiceLinksOpenConfiguredUrls();
+    await dashboardPage.verifyServiceAppsLoadAfterNavigation();
     await dashboardPage.verifyManageSubscriptionOpensPortal();
     await dashboardPage.verifyUserMenuControls();
   });


### PR DESCRIPTION
## What changed?
Updating the dashboard E2E tests to verify that app/page content actually loads after clicking on the Thundermail/Appointment/Send service icons on the dashboard page.

## Why?
There was an issue in production where clicking on the Send icon on the dashboard page resulted in the Send URL opening but a 404 error was displayed. The test previously just ensured the correct URL was loaded, but now let's actually verify the app page content loads.

## Limitations and Notes
Only checks one element on each of the app pages after clicking the icons. This is sufficient for this accounts dashboard test as the other app pages are testing in detail in their corresponding E2E tests in their own repos.

Worked with Codex AI to write this patch.

## Applicable Issues
Fixes #1092.

## QA Log
Ran the new updated dashboard test:

- On my local Firefox desktop
- On my local playwright google pixel 7 viewport simulator
- On Firefox desktop on OSX [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Firefox+Desktop/168?tab=sessions&testListView=spec)
- On Chromium desktop on Win11 [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Chromium+Desktop/161?tab=sessions)
- On Safari desktop on OSX [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Safari+Desktop/81?tab=sessions&testListView=spec)
- On Android Chrome on a real Google Pixel 10 device [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Android+Chrome/100?testListView=spec)