### PR TITLE
Add purge-incomplete-signups waffle switch

### DIFF
--- a/src/thunderbird_accounts/authentication/tasks.py
+++ b/src/thunderbird_accounts/authentication/tasks.py
@@ -3,6 +3,7 @@ import logging
 from datetime import timedelta, datetime, UTC
 
 import sentry_sdk
+import waffle
 from celery import shared_task
 from django.conf import settings
 from django.db import transaction
@@ -10,7 +11,7 @@ from django.db.models import Exists, OuterRef, QuerySet
 from django.utils import timezone
 
 from thunderbird_accounts.authentication.models import User, AllowListEntry
-from thunderbird_accounts.authentication.utils import delete_user_data  #  noqa: F401 - needed for tests
+from thunderbird_accounts.authentication.utils import delete_user_data
 from thunderbird_accounts.celery.exceptions import TaskFailed
 from thunderbird_accounts.subscription.mailchimp import MailchimpClient
 from thunderbird_accounts.subscription.models import Subscription
@@ -20,6 +21,13 @@ logger = logging.getLogger(__name__)
 # While a 400 could indicate other kinds of "bad input", it's our clearest
 # signal when Mailchimp rejects an email.
 PERMANENT_RECOVERY_EMAIL_REJECTION_STATUS_CODE = 400
+
+# When active, purge_incomplete_signups actually deletes stale users (via delete_user_data).
+# When inactive (the default), it just parks them in the "Users to Purge" group so we can
+# confirm the selection criteria are correct before nuking anyone.
+# See https://github.com/thunderbird/thunderbird-accounts/issues/964 for more info.
+PURGE_INCOMPLETE_SIGNUPS_SWITCH = 'purge-incomplete-signups'
+
 
 def is_permanent_recovery_email_rejection(ex: TaskFailed) -> bool:
     """Return True when Mailchimp rejects the member create request."""
@@ -194,11 +202,11 @@ def purge_incomplete_signups(self):
                     )
                     continue
 
-                # Add the user to the group
-                user.groups.add(group)
-                purge_errors = []
-                # TODO: Turn back on once we're confident
-                # purge_errors = delete_user_data(user)
+                if waffle.switch_is_active(PURGE_INCOMPLETE_SIGNUPS_SWITCH):
+                    purge_errors = delete_user_data(user)
+                else:
+                    user.groups.add(group)
+                    purge_errors = []
 
         except User.DoesNotExist:
             skipped += 1
@@ -219,7 +227,7 @@ def purge_incomplete_signups(self):
         else:
             deleted += 1
 
-    # Temp: Until we're confident about this function
+    # Keeping this until we fully remove the switch
     # Remove any users that no longer match criteria
     for user in group.user_set.iterator():
         if any(

--- a/src/thunderbird_accounts/authentication/tasks.py
+++ b/src/thunderbird_accounts/authentication/tasks.py
@@ -203,6 +203,7 @@ def purge_incomplete_signups(self):
                     continue
 
                 if waffle.switch_is_active(PURGE_INCOMPLETE_SIGNUPS_SWITCH):
+                    logger.info('purge_incomplete_signups: purging %s', user.uuid)
                     purge_errors = delete_user_data(user)
                 else:
                     user.groups.add(group)

--- a/src/thunderbird_accounts/authentication/tasks.py
+++ b/src/thunderbird_accounts/authentication/tasks.py
@@ -182,6 +182,9 @@ def purge_incomplete_signups(self):
         }
         return result
 
+    switch_status = waffle.switch_is_active(PURGE_INCOMPLETE_SIGNUPS_SWITCH)
+    logger.info(f'purge_incomplete_signups: Running with {PURGE_INCOMPLETE_SIGNUPS_SWITCH} = {switch_status}')
+
     for user in get_stale_incomplete_signup_users(cutoff_hours=settings.INCOMPLETE_SIGNUP_PURGE_HOURS).iterator():
         try:
             with transaction.atomic():
@@ -202,7 +205,7 @@ def purge_incomplete_signups(self):
                     )
                     continue
 
-                if waffle.switch_is_active(PURGE_INCOMPLETE_SIGNUPS_SWITCH):
+                if switch_status:
                     logger.info('purge_incomplete_signups: purging %s', user.uuid)
                     purge_errors = delete_user_data(user)
                 else:

--- a/src/thunderbird_accounts/authentication/tests/test_tasks.py
+++ b/src/thunderbird_accounts/authentication/tests/test_tasks.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import freezegun
+from waffle.testutils import override_switch
 
 from django.conf import settings
 from django.test import TestCase, override_settings
@@ -16,6 +17,7 @@ from thunderbird_accounts.authentication.tasks import (
     get_stale_incomplete_signup_users,
     purge_incomplete_signups,
     purge_stale_test_allow_list_entries,
+    PURGE_INCOMPLETE_SIGNUPS_SWITCH,
 )
 from thunderbird_accounts.celery.exceptions import TaskFailed
 from thunderbird_accounts.subscription.models import Subscription
@@ -543,6 +545,43 @@ class PurgeIncompleteSignupsTaskTestCase(TestCase):
         # We're out of the group!
         self.user.refresh_from_db()
         self.assertEqual(self.user.groups.count(), 0)
+
+    @override_switch(PURGE_INCOMPLETE_SIGNUPS_SWITCH, active=True)
+    def test_deletes_stale_users_when_switch_is_active(self, mock_delete_user_data):
+        mock_delete_user_data.return_value = []
+
+        result = purge_incomplete_signups.apply().get()
+
+        mock_delete_user_data.assert_called_once_with(self.user)
+
+        # The user was actually purged, not parked in the group
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.groups.count(), 0)
+
+        self.assertEqual(result['deleted'], 1)
+        self.assertEqual(result['errors'], 0)
+
+    @override_switch(PURGE_INCOMPLETE_SIGNUPS_SWITCH, active=True)
+    def test_counts_partial_deletion_as_error_when_switch_is_active(self, mock_delete_user_data):
+        mock_delete_user_data.return_value = ['Keycloak: connection refused']
+
+        result = purge_incomplete_signups.apply().get()
+
+        mock_delete_user_data.assert_called_once_with(self.user)
+        self.assertEqual(result['deleted'], 0)
+        self.assertEqual(result['errors'], 1)
+
+    @override_switch(PURGE_INCOMPLETE_SIGNUPS_SWITCH, active=False)
+    def test_does_not_delete_stale_users_when_switch_is_explicitly_inactive(self, mock_delete_user_data):
+        mock_delete_user_data.return_value = []
+
+        result = purge_incomplete_signups.apply().get()
+
+        mock_delete_user_data.assert_not_called()
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.groups.count(), 1)
+        self.assertEqual(result['deleted'], 1)
 
 
 @patch('thunderbird_accounts.authentication.tasks.delete_user_data')


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Adds a [django-waffle switch](https://waffle.readthedocs.io/en/stable/types/switch.html) to enable / disable the purge of users. 

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- In case something unexpected happens, it would be nice to be able to toggle the purge on / off through Django Admin without having to change code / make a PR.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->
After this lands, we will need to create a `purge-incomplete-signups` switch through click ops in Django Admin and turn it on if / when need be.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Related with https://github.com/thunderbird/thunderbird-accounts/issues/964
