### PR TITLE
Fix sign-in race condition on android

### DIFF
--- a/test/e2e/pages/tb-accts-oidc-page.ts
+++ b/test/e2e/pages/tb-accts-oidc-page.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, type Locator } from '@playwright/test';
-import { ACCTS_OIDC_EMAIL, ACCTS_OIDC_PWORD, TIMEOUT_2_SECONDS, TIMEOUT_10_SECONDS, TIMEOUT_30_SECONDS } from '../const/constants';
+import { ACCTS_OIDC_EMAIL, ACCTS_OIDC_PWORD, TIMEOUT_1_SECOND, TIMEOUT_10_SECONDS } from '../const/constants';
 
 export class TBAcctsOIDCPage {
   readonly page: Page;
@@ -40,6 +40,10 @@ export class TBAcctsOIDCPage {
     await expect(this.emailInput).toBeVisible({ timeout: TIMEOUT_10_SECONDS });
     await this.emailInput.fill(username);
     await this.passwordInput.fill(password);
+
+    // on android we need a force click because the sign-in button doesn't settle for some reason; sometimes
+    // the click is too fast and the sign-in doesn't actually happen; a 1 second pause here fixes this
+    await this.page.waitForTimeout(TIMEOUT_1_SECOND);
     await this.signInButton.click({ force: true });
     await this.page.waitForTimeout(TIMEOUT_10_SECONDS);
   }

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
   // Global timeout: Playwright will timeout if the entire session (includes all test runs) exceeds this.
   // Must take into account running on mulitple browsers (and BrowserStack is much slower too!). Odds are the
   // tests will time out at the locator/test level first anyway; but there is no default so best to specify
-  globalTimeout: 10 * 60 * 1000,
+  globalTimeout: 12 * 60 * 1000,
   // Individual test timeout - a single test will time out if it is still running after this time (ms)
   timeout: 150 * 1000, // 2.5 minutes
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
## What changed?
During sign in, add a 1 second pause between filling out the credentials and clicking the sign-in button.

## Why?
On Android we have to use the 'force' option when clicking the sign-in button because the sign-in button locator doesn't become stable/settle on android. The problem is sometimes the sign-in button is not quite ready because of the android keyboard still active after filling in the credentials inputs. Fixed by adding a 1 second pause before clicking the sign-in button. Also had to increase the overall playwright suite timeout because the tests run very slow in BrowserStack and sometimes were just creeping over the 10 minute maximum test suite timeout.

Making the change in the sign-in utility that is used on both mobile and desktop; on desktop the tests just sign in once and save the context so this will just add 1 second to the desktop suite.

## Applicable Issues
Fixes #1121.

## QA Log
Ran the updated E2E tests on:

- The playwright google pixel 7 viewport simulator
- Firefox desktop
- Android chrome [in BrowserStack](https://automate.browserstack.com/projects/Thunderbird+Accounts/builds/TB+Accounts+Nightly+Tests+Android+Chrome/107?bls_projects=771446%7CThunderbird%2520Accounts&testListView=spec) where all tests now pass
