### PR TITLE
Fix MFA login timeout loop (#1133)

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/components/CancelForm.vue
+++ b/keycloak/themes/tbpro/assets/vue/components/CancelForm.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {ref, useTemplateRef, watch} from "vue";
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 defineProps({
   action: 'string',
@@ -20,7 +21,7 @@ const cancel = () => {
   watch(
     cancelForm,
     () => {
-      cancelForm?.value?.submit();
+      submitKeycloakForm(cancelForm?.value);
     }, {once: true});
 
   // This will cause the cancelForm not be null

--- a/keycloak/themes/tbpro/assets/vue/keycloakForm.ts
+++ b/keycloak/themes/tbpro/assets/vue/keycloakForm.ts
@@ -1,0 +1,8 @@
+type KeycloakWindow = Window & {
+  stopKeycloakSessionPolling?: () => void;
+};
+
+export function submitKeycloakForm(form?: HTMLFormElement | null) {
+  (window as KeycloakWindow).stopKeycloakSessionPolling?.();
+  form?.submit();
+}

--- a/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
@@ -9,6 +9,7 @@ import {
 import { computed, ref, useTemplateRef } from "vue";
 import { i18n } from '@kc/composables/i18n.js';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 const isManualMode = ref(false);
 const formAction = window._page.currentView?.formAction;
 const settingsForm = useTemplateRef('settings-form');
@@ -67,7 +68,7 @@ const otpManualUrl = computed(() => {
 });
 
 const onSubmit = () => {
-  settingsForm?.value?.submit();
+  submitKeycloakForm(settingsForm?.value);
 };
 const onCancel = () => {
   cancelForm?.value?.cancel();

--- a/keycloak/themes/tbpro/assets/vue/views/DeleteCredentialView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/DeleteCredentialView/index.vue
@@ -2,6 +2,7 @@
 import { DangerButton, PrimaryButton } from '@thunderbirdops/services-ui';
 import { useTemplateRef } from 'vue';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 const formAction = window._page.currentView?.formAction;
 const loginForm = useTemplateRef('login-form');
 const cancelForm = useTemplateRef('cancel-form');
@@ -10,7 +11,7 @@ const deleteCredentialTitle = window._page.currentView?.deleteCredentialTitle;
 const deleteCredentialMessage = window._page.currentView?.deleteCredentialMessage;
 
 const onSubmit = () => {
-  loginForm?.value?.submit();
+  submitKeycloakForm(loginForm?.value);
 };
 const onCancel = () => {
   cancelForm?.value?.cancel();

--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { TextInput, PrimaryButton, NoticeBar, NoticeBarTypes } from "@thunderbirdops/services-ui";
 import { ref, computed, useTemplateRef } from 'vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 const errors = window._page.currentView?.errors;
 const formAction = window._page.currentView?.formAction;
@@ -10,7 +11,7 @@ const resetPasswordForm = useTemplateRef('reset-password-form');
 
 const onSubmit = () => {
   if (resetPasswordForm.value.checkValidity()) {
-    resetPasswordForm?.value?.submit();
+    submitKeycloakForm(resetPasswordForm?.value);
   }
 };
 

--- a/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
@@ -2,6 +2,7 @@
 import { TextInput, PrimaryButton, LinkButton } from "@thunderbirdops/services-ui";
 import { computed, useTemplateRef } from "vue";
 import CancelForm from '@kc/vue/components/CancelForm.vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 const formAction = window._page.currentView?.formAction;
 const recoveryCodePrompt = window._page.currentView?.recoveryCodePrompt;
@@ -12,7 +13,7 @@ const loginForm = useTemplateRef('login-form');
 const tryAnotherWayForm = useTemplateRef('try-another-way-form');
 
 const onSubmit = () => {
-  loginForm?.value?.submit();
+  submitKeycloakForm(loginForm?.value);
 };
 
 const onTryAnotherWay = () => {

--- a/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
@@ -2,6 +2,7 @@
 import { TextInput, PrimaryButton, SelectInput, LinkButton } from "@thunderbirdops/services-ui";
 import { computed, ref, useTemplateRef } from "vue";
 import CancelForm from '@kc/vue/components/CancelForm.vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 const errors = window._page.currentView?.errors;
 const formAction = window._page.currentView?.formAction;
@@ -13,7 +14,7 @@ const loginForm = useTemplateRef('login-form');
 const tryAnotherWayForm = useTemplateRef('try-another-way-form');
 
 const onSubmit = () => {
-  loginForm?.value?.submit();
+  submitKeycloakForm(loginForm?.value);
 };
 
 const onTryAnotherWay = () => {

--- a/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
@@ -3,6 +3,7 @@ import { ref, computed, useTemplateRef } from 'vue';
 import { TextInput, BrandButton, CheckboxInput, NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import { PhArrowRight } from '@phosphor-icons/vue';
 import { TBPRO_WAIT_LIST } from '@kc/defines';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 const firstError = window._page.currentView?.firstError;
 const formAction = window._page.currentView?.formAction;
@@ -15,7 +16,7 @@ const tbProPrimaryDomain = window._page.currentView?.tbProPrimaryDomain;
 
 const onSubmit = () => {
   if (loginForm.value.checkValidity()) {
-    loginForm?.value?.submit();
+    submitKeycloakForm(loginForm?.value);
   }
 };
 

--- a/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
@@ -1,13 +1,14 @@
 <script setup>
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import { useTemplateRef } from 'vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 const formAction = window._page.currentView?.formAction;
 const logoutForm = useTemplateRef('logout-form');
 
 const sessionCode = window._page.currentView?.sessionCode;
 const clientUrl = window._page.currentView?.clientUrl;
 const onSubmit = () => {
-  logoutForm?.value?.submit();
+  submitKeycloakForm(logoutForm?.value);
 };
 </script>
 

--- a/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
@@ -3,6 +3,7 @@ import { TextInput, BrandButton, NoticeBar, NoticeBarTypes } from '@thunderbirdo
 import { computed, ref, useTemplateRef } from 'vue';
 import { useRoute } from 'vue-router';
 import { PhArrowRight } from '@phosphor-icons/vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 const route = useRoute();
 
@@ -54,7 +55,7 @@ const onSubmit = () => {
   }
 
   if (registerForm.value.checkValidity()) {
-    registerForm?.value?.submit();
+    submitKeycloakForm(registerForm?.value);
   }
 };
 

--- a/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { TextInput, PrimaryButton, CheckboxInput } from "@thunderbirdops/services-ui";
 import { computed, useTemplateRef } from 'vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 const formAction = window._page.currentView?.formAction;
 const updatePasswordForm = useTemplateRef('update-password-form');
 const errors = window._page.currentView?.errors;
@@ -12,7 +13,7 @@ const passwordConfirmError = computed(() => {
 });
 
 const onSubmit = () => {
-  updatePasswordForm?.value?.submit();
+  submitKeycloakForm(updatePasswordForm?.value);
 };
 </script>
 

--- a/keycloak/themes/tbpro/assets/vue/views/VerifyEmailView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/VerifyEmailView/index.vue
@@ -2,6 +2,7 @@
 import { PrimaryButton } from '@thunderbirdops/services-ui';
 import { computed, useTemplateRef } from 'vue';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
+import { submitKeycloakForm } from '@kc/vue/keycloakForm';
 
 const formAction = window._page.currentView?.formAction;
 const showForm = computed(() => window._page.appInitiatedAction !== 'false');
@@ -12,7 +13,7 @@ const verifyEmailForm = useTemplateRef('verify-email-form');
 const cancelForm = useTemplateRef('cancel-form');
 
 const onSubmit = () => {
-  verifyEmailForm?.value?.submit();
+  submitKeycloakForm(verifyEmailForm?.value);
 };
 
 const onCancel = () => {

--- a/keycloak/themes/tbpro/login/resources/js/authChecker.js
+++ b/keycloak/themes/tbpro/login/resources/js/authChecker.js
@@ -49,6 +49,8 @@ function stopSessionPolling() {
   }
 }
 
+globalThis.stopKeycloakSessionPolling = stopSessionPolling;
+
 export function checkAuthSession(pageAuthSessionHash) {
   setTimeout(() => {
     const cookieAuthSessionHash = getKcAuthSessionHash();


### PR DESCRIPTION
Since we implmented MFA, the Keycloak login forms started bypassesing the
native submit event that Keycloak's authChecker uses to stop session polling.

After a timed-out MFA challenge, that poller could keep running during the next
successful submit and redirect the browser back into the expired login flow,
making it impossible to login without refreshing the browser state.

Here we restore the logic to stop polling Keycloak upon form submission
that was accidentally lost during MFA impementation.

## Applicable Issues

 * Fixes #1133

## QA Log

 * Used AI to pinpoint the regression.
 * Manually tested MFA setup and login after this flow.
 * I did not wait the 30 minutes during MFA login to repro the issue exactly.
