### PR TITLE
Store paddle transaction_id in sessionStorage for reuse

### DIFF
--- a/assets/app/vue/defines.ts
+++ b/assets/app/vue/defines.ts
@@ -15,3 +15,4 @@ export const COMMUNITY_SUPPORT_URL = 'https://support.mozilla.org/questions/thun
 export const NOT_INTERESTED_SURVEY_LINK = 'https://www.surveymonkey.com/r/HYYMDB6';
 export const TBPRO_WAIT_LIST = 'https://tb.pro/waitlist/';
 export const CAPTURE_TELEMETRY = true;
+export const PADDLE_TRANSACTION_STORAGE_KEY = 'accounts/subscribe/paddleTransactionId';

--- a/assets/app/vue/views/DashboardView/index.vue
+++ b/assets/app/vue/views/DashboardView/index.vue
@@ -4,6 +4,10 @@ import YourServices from '@/components/YourServices.vue';
 import AccountCard from './components/AccountCard.vue';
 import PrivacyAndDataCard from './components/PrivacyAndDataCard.vue';
 import YourCurrentSubscription from './components/YourCurrentSubscription.vue';
+import { PADDLE_TRANSACTION_STORAGE_KEY } from '@/defines';
+
+// Just in case, attempt to empty the stored Paddle transaction id here too.
+window.localStorage?.removeItem(PADDLE_TRANSACTION_STORAGE_KEY);
 </script>
 
 <script lang="ts">

--- a/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
@@ -4,6 +4,7 @@ import { LoadingSkeleton, NoticeBar, NoticeBarTypes, VisualDivider } from '@thun
 import { initializePaddle, PaddleEventData, CheckoutEventNames } from '@paddle/paddle-js';
 import CardContainer from '@/components/CardContainer.vue';
 import { onUnmounted, ref } from 'vue';
+import { useSessionStorage } from '@vueuse/core';
 
 const { t } = useI18n();
 
@@ -28,6 +29,9 @@ let doneCheckerHandler = null;
 let exceptionCounter = 0;
 let transactionId = null;
 let paymentType = DEFAULT_PAYMENT_TYPE;
+let isResumingTransaction = false;
+
+const storedTransactionId = useSessionStorage<string | null>('accounts/subscribe/paddleTransactionId', null);
 
 const planName = ref();
 const planSystemError = ref(false);
@@ -85,6 +89,7 @@ const areWeDoneHere = async () => {
     if (['completed', 'paid'].indexOf(status) > -1) {
       // Remove the Paddle checkout form, and after a short wait reload the page.
       paymentComplete.value = true;
+      storedTransactionId.value = null;
       // We re-use this handler since it's not currently used, and it's hooked up to unMount.
       doneCheckerHandler = window.setTimeout(() => {
         window.location.reload();
@@ -112,18 +117,28 @@ const areWeDoneHere = async () => {
 /**
  * "Open" the checkout, which just really involves passing Paddle some settings for the iframe that is loaded inline.
  * Here we'll set the checkout product (paddleItems) and the signed user id which will be used to track the transaction.
+ *
+ * If we already have a transaction id from a previous mount (stored in session storage), resume that transaction
+ * instead of passing items/discountId, so Paddle doesn't spin up a new draft transaction on every reload.
  * @param paddleItems
  * @param signedUserId
  */
 const openCheckout = (paddleItems: any, signedUserId: string, discountId: string | null) => {
   const checkoutOptions: any = {
-    items: paddleItems,
-    discountId,
     customData: {
       // This will tie the transaction and subscription to our user uuid
       signed_user_id: signedUserId,
     },
   };
+
+  if (storedTransactionId.value) {
+    isResumingTransaction = true;
+    transactionId = storedTransactionId.value;
+    checkoutOptions.transactionId = storedTransactionId.value;
+  } else {
+    checkoutOptions.items = paddleItems;
+    checkoutOptions.discountId = discountId;
+  }
 
   paddle.Checkout.open(checkoutOptions);
 };
@@ -138,6 +153,19 @@ const openCheckout = (paddleItems: any, signedUserId: string, discountId: string
 const onPaddleEvent = async (evt: PaddleEventData) => {
   if (evt?.name == CheckoutEventNames.CHECKOUT_COMPLETED) {
     paymentComplete.value = true;
+    storedTransactionId.value = null;
+    return;
+  }
+
+  if (evt?.name == CheckoutEventNames.CHECKOUT_ERROR) {
+    if (isResumingTransaction) {
+      storedTransactionId.value = null;
+      isResumingTransaction = false;
+      window.location.reload();
+      return;
+    }
+
+    paddleUnknownError.value = true;
     return;
   }
 
@@ -153,6 +181,7 @@ const onPaddleEvent = async (evt: PaddleEventData) => {
     // Transaction ID should only update if we're not falsey.
     if (data?.transaction_id) {
       transactionId = data?.transaction_id ?? null;
+      storedTransactionId.value = transactionId;
     }
 
     // Payment type is only reliably updated on payment selected.

--- a/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/CheckoutStep.vue
@@ -4,7 +4,8 @@ import { LoadingSkeleton, NoticeBar, NoticeBarTypes, VisualDivider } from '@thun
 import { initializePaddle, PaddleEventData, CheckoutEventNames } from '@paddle/paddle-js';
 import CardContainer from '@/components/CardContainer.vue';
 import { onUnmounted, ref } from 'vue';
-import { useSessionStorage } from '@vueuse/core';
+import { useLocalStorage } from '@vueuse/core';
+import { PADDLE_TRANSACTION_STORAGE_KEY } from '@/defines';
 
 const { t } = useI18n();
 
@@ -31,7 +32,7 @@ let transactionId = null;
 let paymentType = DEFAULT_PAYMENT_TYPE;
 let isResumingTransaction = false;
 
-const storedTransactionId = useSessionStorage<string | null>('accounts/subscribe/paddleTransactionId', null);
+const storedTransactionId = useLocalStorage<string | null>(PADDLE_TRANSACTION_STORAGE_KEY, null);
 
 const planName = ref();
 const planSystemError = ref(false);


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

- Store paddle `transaction_id` in sessionStorage when loading the checkout page and removing it once checkout has been completed or if there's an error state.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

- Not re-using the `transaction_id` generates all sorts of problems such as: double payments creating double subscriptions, reloading the checkout page without paying creating duplicated draft transactions, etc.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

- It is still possible to reproduce seeing the checkout page if you reload the page exactly after clicking the payment button. However, filling the checkout form again doesn't cause double payments!

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/805

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->


https://github.com/user-attachments/assets/6c0d70f5-637f-4398-8508-f0230ac946d7

