### PR TITLE
Add basic accounts sign-in test for new k8s env

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -148,6 +148,18 @@ To run the E2E tests in debug mode (still in `test/e2e`):
 npm run e2e-test-debug
 ```
 
+To run the deployment-analysis E2E tests, follow the above setup instructions and then run:
+
+```bash
+npm run deployment-analysis-e2e
+```
+
+Or to watch the tests run:
+
+```bash
+npm run deployment-analysis-e2e-headed
+```
+
 ## Running on BrowserStack
 
 You can run the E2E tests from your local machine pointed at the stage environment, but against browsers provided in the BrowserStack Automate cloud.

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -1,5 +1,5 @@
 // environment where the tests will run
-export const ACCTS_TARGET_ENV = String(process.env.ACCTS_TARGET_ENV);
+export const ACCTS_TARGET_ENV = String(process.env.ACCTS_TARGET_ENV ?? 'dev');
 
 // tb accounts urls
 export const ACCTS_HUB_URL = String(process.env.ACCTS_HUB_URL);

--- a/test/e2e/const/constants.ts
+++ b/test/e2e/const/constants.ts
@@ -33,6 +33,7 @@ export const PLAYWRIGHT_TAG_E2E_SUITE = '@e2e-suite';
 export const PLAYWRIGHT_TAG_E2E_PROD_DESKTOP_NIGHTLY = '@e2e-prod-desktop-nightly';
 export const PLAYWRIGHT_TAG_E2E_SUITE_MOBILE = '@e2e-mobile-suite';
 export const PLAYWRIGHT_TAG_E2E_PROD_MOBILE_NIGHTLY = '@e2e-prod-mobile-nightly';
+export const PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS = '@deployment-analysis';
 
 // timeouts
 export const TIMEOUT_1_SECOND = 1000;

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -14,6 +14,8 @@
     "prod-nightly-tests-browserstack-desktop-safari": "npx browserstack-node-sdk playwright test --grep e2e-prod-desktop-nightly --project=Safari-OSX --browserstack.buildName 'TB Accounts Nightly Tests Safari Desktop' --browserstack.config 'browserstack-desktop-nightly.yml'",
     "prod-nightly-tests-mobile-browserstack-android-chrome": "npx browserstack-node-sdk playwright test --grep prod-mobile-nightly --project=android-chrome --browserstack.buildName 'TB Accounts Nightly Tests Android Chrome' --browserstack.config 'browserstack-mobile-nightly.yml'",
     "prod-nightly-tests-mobile-browserstack-ios-safari": "npx browserstack-node-sdk playwright test --grep prod-mobile-nightly --project=ios-safari --browserstack.buildName 'TB Accounts Nightly Tests iOS Safari' --browserstack.config 'browserstack-mobile-nightly.yml'",
+    "deployment-analysis-e2e": "npx playwright test --grep deployment-analysis --project=firefox",
+    "deployment-analysis-e2e-headed": "npx playwright test --grep deployment-analysis --project=firefox --headed",
     "postinstall": "npm update browserstack-node-sdk"
   },
   "keywords": [],

--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -83,36 +83,36 @@ export class DashboardPage {
     await expect.poll(async () => new URL(this.page.url()).pathname).toBe('/dashboard');
   }
 
-  async verifyDashboardDisplayed(smoketest: boolean = false) {
-    // for smoketest we just want to verify we are signed in and header appears
+  async verifyDashboardSignedIn() {
+    // just verify we are signed in and header appears
     await expect(this.myAccountHeading).toBeVisible( { timeout: TIMEOUT_30_SECONDS });
     await expect(this.privacyAndDataHeading).toBeVisible();
     await expect(this.manageYourServicesHeading).toBeVisible();
-
-    if (!smoketest) {
-      await expect(this.myAccountCard).toContainText(ACCTS_OIDC_EMAIL);
-      await expect(this.currentSubscriptionHeading).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
-      await expect(this.currentSubscriptionSection).toContainText(DASHBOARD_CURRENT_SUBSCRIPTION_PRICE);
-      await expect(this.currentSubscriptionSection).toContainText(
-        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_MAIL_STORAGE)}\\s*of Mail Storage`),
-      );
-      await expect(this.currentSubscriptionSection).toContainText(
-        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_SEND_STORAGE)}\\s*of Send Storage`),
-      );
-      await expect(this.currentSubscriptionSection).toContainText(
-        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_EMAIL_ADDRESSES)}\\s*Email Addresses`),
-      );
-      await expect(this.currentSubscriptionSection).toContainText(
-        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_CUSTOM_DOMAINS)}\\s*Custom Domains`),
-      );
-      await expect(this.passwordChangeLink).toBeVisible();
-      await expect(this.deleteAccountLink).toBeVisible();
-      await expect(this.thundermailLink).toBeVisible();
-      await expect(this.appointmentLink).toBeVisible();
-      await expect(this.sendLink).toBeVisible();
-      await expect(this.manageSubscriptionButton).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
-    }
   }
+
+  async verifyDashboardDisplayed() {
+    await expect(this.myAccountCard).toContainText(ACCTS_OIDC_EMAIL);
+    await expect(this.currentSubscriptionHeading).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    await expect(this.currentSubscriptionSection).toContainText(DASHBOARD_CURRENT_SUBSCRIPTION_PRICE);
+    await expect(this.currentSubscriptionSection).toContainText(
+      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_MAIL_STORAGE)}\\s*of Mail Storage`),
+    );
+    await expect(this.currentSubscriptionSection).toContainText(
+      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_SEND_STORAGE)}\\s*of Send Storage`),
+    );
+    await expect(this.currentSubscriptionSection).toContainText(
+      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_EMAIL_ADDRESSES)}\\s*Email Addresses`),
+    );
+    await expect(this.currentSubscriptionSection).toContainText(
+      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_CUSTOM_DOMAINS)}\\s*Custom Domains`),
+    );
+    await expect(this.passwordChangeLink).toBeVisible();
+    await expect(this.deleteAccountLink).toBeVisible();
+    await expect(this.thundermailLink).toBeVisible();
+    await expect(this.appointmentLink).toBeVisible();
+    await expect(this.sendLink).toBeVisible();
+    await expect(this.manageSubscriptionButton).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+}
 
   async verifyPasswordChangeNavigation() {
     await this.passwordChangeLink.click();

--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -83,31 +83,35 @@ export class DashboardPage {
     await expect.poll(async () => new URL(this.page.url()).pathname).toBe('/dashboard');
   }
 
-  async verifyDashboardDisplayed() {
-    await expect(this.myAccountHeading).toBeVisible();
-    await expect(this.myAccountCard).toContainText(ACCTS_OIDC_EMAIL);
+  async verifyDashboardDisplayed(smoketest: boolean = false) {
+    // for smoketest we just want to verify we are signed in and header appears
+    await expect(this.myAccountHeading).toBeVisible( { timeout: TIMEOUT_30_SECONDS });
     await expect(this.privacyAndDataHeading).toBeVisible();
     await expect(this.manageYourServicesHeading).toBeVisible();
-    await expect(this.currentSubscriptionHeading).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
-    await expect(this.currentSubscriptionSection).toContainText(DASHBOARD_CURRENT_SUBSCRIPTION_PRICE);
-    await expect(this.currentSubscriptionSection).toContainText(
-      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_MAIL_STORAGE)}\\s*of Mail Storage`),
-    );
-    await expect(this.currentSubscriptionSection).toContainText(
-      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_SEND_STORAGE)}\\s*of Send Storage`),
-    );
-    await expect(this.currentSubscriptionSection).toContainText(
-      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_EMAIL_ADDRESSES)}\\s*Email Addresses`),
-    );
-    await expect(this.currentSubscriptionSection).toContainText(
-      new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_CUSTOM_DOMAINS)}\\s*Custom Domains`),
-    );
-    await expect(this.passwordChangeLink).toBeVisible();
-    await expect(this.deleteAccountLink).toBeVisible();
-    await expect(this.thundermailLink).toBeVisible();
-    await expect(this.appointmentLink).toBeVisible();
-    await expect(this.sendLink).toBeVisible();
-    await expect(this.manageSubscriptionButton).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+
+    if (!smoketest) {
+      await expect(this.myAccountCard).toContainText(ACCTS_OIDC_EMAIL);
+      await expect(this.currentSubscriptionHeading).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+      await expect(this.currentSubscriptionSection).toContainText(DASHBOARD_CURRENT_SUBSCRIPTION_PRICE);
+      await expect(this.currentSubscriptionSection).toContainText(
+        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_MAIL_STORAGE)}\\s*of Mail Storage`),
+      );
+      await expect(this.currentSubscriptionSection).toContainText(
+        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_SEND_STORAGE)}\\s*of Send Storage`),
+      );
+      await expect(this.currentSubscriptionSection).toContainText(
+        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_EMAIL_ADDRESSES)}\\s*Email Addresses`),
+      );
+      await expect(this.currentSubscriptionSection).toContainText(
+        new RegExp(`${escapeRegExp(DASHBOARD_CURRENT_SUBSCRIPTION_CUSTOM_DOMAINS)}\\s*Custom Domains`),
+      );
+      await expect(this.passwordChangeLink).toBeVisible();
+      await expect(this.deleteAccountLink).toBeVisible();
+      await expect(this.thundermailLink).toBeVisible();
+      await expect(this.appointmentLink).toBeVisible();
+      await expect(this.sendLink).toBeVisible();
+      await expect(this.manageSubscriptionButton).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
+    }
   }
 
   async verifyPasswordChangeNavigation() {

--- a/test/e2e/tests/desktop/dashboard.spec.ts
+++ b/test/e2e/tests/desktop/dashboard.spec.ts
@@ -31,6 +31,7 @@ test.describe('dashboard controls on desktop browser', {
     test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack until we automate tb subsrcibe step');
 
     await dashboardPage.navigateToDashboard();
+    await dashboardPage.verifyDashboardSignedIn();
     await dashboardPage.verifyDashboardDisplayed();
 
     await dashboardPage.verifyPasswordChangeNavigation();

--- a/test/e2e/tests/desktop/sign-in.spec.ts
+++ b/test/e2e/tests/desktop/sign-in.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '@playwright/test';
+import { DashboardPage } from '../../pages/dashboard-page';
+import { ensureWeAreSignedIn } from '../../utils/utils';
+
+import {
+  PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS,
+  ACCTS_TARGET_ENV,
+} from '../../const/constants';
+
+let dashboardPage: DashboardPage;
+
+test.beforeEach(async ({ page }) => {
+  dashboardPage = new DashboardPage(page);
+  await ensureWeAreSignedIn(page);
+});
+
+/**
+ * Prerequisite: This test assumes that the test user (ACCTS_OIDC_EMAIL) already has a
+ * Thundermail subscription and therefore after signing in, the main dashboard is visible
+ * (and not redirected to the subscription page). If this test is running in CI on a new
+ * local stack (i.e. on PRs) the test user (admin) won't yet have a subscription, therefore
+ * skip this test when running in CI on PRs.
+ * 
+ * The actual sign-in is perfomed automatically (via `auth.desktop.setup.ts`) before this
+ * test starts, because it is setup as a desktop-setup dependency in the `playwright.config.ts`.
+ */
+test.describe('tb accounts sign-in is succssful', {
+  tag: [PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS],
+}, () => {
+  test('accounts dashboard appears', async () => {
+    test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack until we automate subscribe');
+    await dashboardPage.navigateToDashboard();
+    await dashboardPage.verifyDashboardDisplayed(true);
+  });
+});

--- a/test/e2e/tests/desktop/sign-in.spec.ts
+++ b/test/e2e/tests/desktop/sign-in.spec.ts
@@ -20,16 +20,14 @@ test.beforeEach(async ({ page }) => {
  * (and not redirected to the subscription page). If this test is running in CI on a new
  * local stack (i.e. on PRs) the test user (admin) won't yet have a subscription, therefore
  * skip this test when running in CI on PRs.
- * 
- * The actual sign-in is perfomed automatically (via `auth.desktop.setup.ts`) before this
- * test starts, because it is setup as a desktop-setup dependency in the `playwright.config.ts`.
  */
-test.describe('tb accounts sign-in is succssful', {
+test.describe('tb accounts sign-in is successful', {
   tag: [PLAYWRIGHT_TAG_DEPLOYMENT_ANALYSIS],
 }, () => {
   test('accounts dashboard appears', async () => {
+    // at this point regardless of env we will be signed in via the beforeEach
     test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack until we automate subscribe');
     await dashboardPage.navigateToDashboard();
-    await dashboardPage.verifyDashboardDisplayed(true);
+    await dashboardPage.verifyDashboardSignedIn();
   });
 });

--- a/test/e2e/tests/mobile/dashboard.spec.ts
+++ b/test/e2e/tests/mobile/dashboard.spec.ts
@@ -31,6 +31,7 @@ test.describe('dashboard controls on mobile browser', {
     test.skip(ACCTS_TARGET_ENV == 'dev', 'Skipping this test when running on local dev stack until we automate tb subsrcibe step');
 
     await dashboardPage.navigateToDashboard();
+    await dashboardPage.verifyDashboardSignedIn();
     await dashboardPage.verifyDashboardDisplayed();
 
     await dashboardPage.verifyPasswordChangeNavigation();

--- a/test/e2e/utils/utils.ts
+++ b/test/e2e/utils/utils.ts
@@ -75,7 +75,6 @@ export const navigateToAccountsHubAndSignIn = async (page: Page, username: strin
         await tbAcctsSignInPage.signIn(username, password);
     }
 
-
     await waitForVueApp(page);
 
     // if tests are running on a new local stack (or new account) the terms of service page might be


### PR DESCRIPTION
## What changed?
Adding a basic sign-in test that will be used to verify TB Accounts sign-in on the new K8s environment.

## Why?
Add a basic Accounts sign-in E2E test that will be triggered by kargo when verifying the health of kargo freight (i.e. TB Accounts deployment artifacts). The test is added with a new playwright tag `deployment-analysis`. In the future we can expand the suite by tagging more E2E tests; but this will get the process working.

## Limitations and Notes
This test is built to run on desktop browsers only; there is no BrowserStack support as that is not necessary (see #1137) for more info.

Prerequisite: The test requires and existing TB Accounts / Thundermail test user on the target environment (credentials read from a local test/e2e/.env).

To run the test:

```
cd test/e2e
cp .env.stage.example .env
```

Then edit your tests/e2e/.env and set the Accounts URL and existing test user credentials. Then:

``` 
npm ci
npx playwright install
npm run deployment-analysis-e2e
```
Or to watch the test run:

```
npm run deployment-analysis-e2e-headed
```

## Applicable Issues
Fixes #1137.

## QA Log
Ran the new test on my local machine against Firefox desktop, in headless and non-headless mode and the test passes fine.