### PR TITLE
Improve dev ergonomics for running tests and using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Make sure that the containers are already running.
 To run all tests:
 
 ```shell
-./run-tests.sh thunderbird_accounts
+./run-tests.sh
 ```
 
 this will execute the following command for you:

--- a/boot-docker-build.sh
+++ b/boot-docker-build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sudo docker compose up --build accounts vite-dev celery
+docker compose up --build accounts vite-dev celery

--- a/boot-docker-deps.sh
+++ b/boot-docker-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sudo docker compose up postgres redis kcpostgres keycloak stalwart mailpit
+docker compose up postgres redis kcpostgres keycloak stalwart mailpit

--- a/run-tests-and-generate-coverage.sh
+++ b/run-tests-and-generate-coverage.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 echo '----------------------  TEST  ----------------------'
-sudo docker compose exec accounts uv run coverage run manage.py test $1
+docker compose exec accounts uv run coverage run manage.py test $1
 
 echo '---------------------- REPORT ----------------------'
-sudo docker compose exec accounts uv run coverage report
+docker compose exec accounts uv run coverage report
 
 echo '----------------------  HTML  ----------------------'
-sudo docker compose exec accounts uv run coverage html
+docker compose exec accounts uv run coverage html
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-sudo docker compose exec accounts uv run manage.py test $1
+if [ "$#" -eq 0 ]; then
+  set -- thunderbird_accounts
+fi
+
+docker compose exec accounts uv run python manage.py test "$@"


### PR DESCRIPTION
Before, `./run-tests.sh` ran zero-tests by default, expected /bin/bash
to exist and unnecessarily used `sudo` to call Docker. This changes
are backwards compatible for passing args: that still runs tests as before.

`sudo` was removed from other calls to docker as well. Under normally configured
Mac and Linux configurations, the `docker` command is a client command that permission
to run communicate with a docker daemon that's running as root. It's not necessary
to call the client with `sudo`.

This change simplifies the syntax for devs and removes a password prompt.
It's not expected to change security much, as the docker daemon normally
runs as root with or without sudo.



## QA Log

 - Before/after manual testing of ./run-tests.sh
 - Reserching `sudo docker` vs `docker` impact
 - Testing `sudo docker` vs `docker` on Linux

 - Manually testing on Mac appreciated!
