### PR TITLE
Correctly serve template variables

### DIFF
--- a/src/thunderbird_accounts/core/templates/index.html
+++ b/src/thunderbird_accounts/core/templates/index.html
@@ -18,41 +18,16 @@
 <body>
 {% csrf_token %}
 <script src="{% url 'wafflejs' %}"></script>
+{{ page_load_data_script }}
 <script>
   {% get_form_error_message as form_error %}
 
   const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]');
-  // Site object
+  // Retrieve and decode our json blob from the backend
+  const pageVars = JSON.parse(document.getElementById('pageLoadData').textContent);
   window._page = {
-    csrfToken: csrfToken.value,
-    isAuthenticated: {{ user.is_authenticated|to_json }},
-    hasActiveSubscription: {{ user.has_active_subscription|default:False|to_json|safe }},
-    isAwaitingPaymentVerification: {{ user.is_awaiting_payment_verification|default:False|to_json|safe }},
-    userEmail: {{ user.email|to_json|safe }},
-    userFullName: {{ user.get_full_name|to_json|safe }},
-    userDisplayName: {{ user_display_name|to_json|safe }},
-    username: {{ user.username|to_json|safe }},
-    formError: {{ form_error|to_json|safe|default:'null' }},
-    formData: {{ form_data|to_json|safe|default:'null' }},
-    connectionInfo: {{ connection_info|to_json|safe }},
-    appPasswords: {{ app_passwords|safe|default:'[]' }},
-    allowedDomains: {{ allowed_domains|safe|default:'[]' }},
-    customDomains: {{ custom_domains|safe|default:'[]' }},
-    emailAddresses: {{ email_addresses|safe|default:'[]' }},
-    maxCustomDomains: {{ max_custom_domains|to_json|safe }},
-    maxEmailAliases: {{ max_email_aliases|to_json|safe }},
-    tbProAppointmentUrl: {{ tb_pro_appointment_url|to_json|safe }},
-    tbProSendUrl: {{ tb_pro_send_url|to_json|safe }},
-    tbProWaitListUrl: {{ tb_pro_wait_list_url|to_json|safe }},
-    tbProPrimaryDomain: {{ tb_pro_primary_domain|to_json|safe }},
-    webmailUrl: {{ webmail_url|to_json|safe }},
-    serverMessages: {{ server_messages|default:None|to_json|safe }},
-    features: {{ features|safe|default:'{}' }},
-    needsTosAcceptance: {{ needs_tos_acceptance|to_json|safe }},
-    recoveryEmail: {{ recovery_email|to_json|safe }},
-    planInfo: {{ plan_info|to_json|safe|default:'null' }},
-    paddleToken: {{ paddle_token|to_json|safe|default:'null' }},
-    paddleEnvironment: {{ paddle_environment|to_json|safe|default:'null' }},
+    csrfToken: csrfToken.value, 
+    ...pageVars,
     {% block extra_page_params %}{% endblock %}
   };
   csrfToken.remove();

--- a/src/thunderbird_accounts/core/tests/test_views.py
+++ b/src/thunderbird_accounts/core/tests/test_views.py
@@ -1,3 +1,5 @@
+import json
+from django.utils.html import strip_tags
 from unittest.mock import patch, Mock
 
 from django.conf import settings
@@ -118,10 +120,18 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
             mock_mail_client.return_value = mock_instance
             return self.client.get('/')
 
+    def _retrieve_json_blob(self, response) -> dict:
+        """We inject a javascript script with a plain json blob. 
+        So for testing we can just strip the script tags off and load it up."""
+        blob = response.context['page_load_data_script']
+        blob = strip_tags(blob)
+        return json.loads(blob)
+
     def test_needs_tos_acceptance_false_when_no_current_docs(self):
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertFalse(blob.get('needsTosAcceptance'))
 
     def test_needs_tos_acceptance_true_when_docs_not_accepted(self):
         LegalDocument.objects.create(
@@ -133,7 +143,8 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
 
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertTrue(blob.get('needsTosAcceptance'))
 
     def test_needs_tos_acceptance_false_when_all_docs_accepted(self):
         tos = LegalDocument.objects.create(
@@ -150,15 +161,20 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
         )
 
         LegalDocumentResponse.objects.create(
-            user=self.user, document=tos, action=LegalDocumentResponse.Action.ACCEPTED,
+            user=self.user,
+            document=tos,
+            action=LegalDocumentResponse.Action.ACCEPTED,
         )
         LegalDocumentResponse.objects.create(
-            user=self.user, document=privacy, action=LegalDocumentResponse.Action.ACCEPTED,
+            user=self.user,
+            document=privacy,
+            action=LegalDocumentResponse.Action.ACCEPTED,
         )
 
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertFalse(blob.get('needsTosAcceptance'))
 
     def test_needs_tos_acceptance_true_when_partially_accepted(self):
         tos = LegalDocument.objects.create(
@@ -175,12 +191,15 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
         )
 
         LegalDocumentResponse.objects.create(
-            user=self.user, document=tos, action=LegalDocumentResponse.Action.ACCEPTED,
+            user=self.user,
+            document=tos,
+            action=LegalDocumentResponse.Action.ACCEPTED,
         )
 
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertTrue(blob.get('needsTosAcceptance'))
 
     def test_needs_tos_acceptance_true_when_only_declined(self):
         tos = LegalDocument.objects.create(
@@ -191,12 +210,15 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
         )
 
         LegalDocumentResponse.objects.create(
-            user=self.user, document=tos, action=LegalDocumentResponse.Action.DECLINED,
+            user=self.user,
+            document=tos,
+            action=LegalDocumentResponse.Action.DECLINED,
         )
 
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertTrue(blob.get('needsTosAcceptance'))
 
     def test_needs_tos_acceptance_false_with_duplicate_acceptances(self):
         """Duplicate acceptance responses should not cause the check to fail."""
@@ -215,18 +237,25 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
 
         # Force duplicate responses
         LegalDocumentResponse.objects.create(
-            user=self.user, document=tos, action=LegalDocumentResponse.Action.ACCEPTED,
+            user=self.user,
+            document=tos,
+            action=LegalDocumentResponse.Action.ACCEPTED,
         )
         LegalDocumentResponse.objects.create(
-            user=self.user, document=tos, action=LegalDocumentResponse.Action.ACCEPTED,
+            user=self.user,
+            document=tos,
+            action=LegalDocumentResponse.Action.ACCEPTED,
         )
         LegalDocumentResponse.objects.create(
-            user=self.user, document=privacy, action=LegalDocumentResponse.Action.ACCEPTED,
+            user=self.user,
+            document=privacy,
+            action=LegalDocumentResponse.Action.ACCEPTED,
         )
 
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertFalse(blob.get('needsTosAcceptance'))
 
     def test_needs_tos_acceptance_ignores_non_current_docs(self):
         LegalDocument.objects.create(
@@ -238,4 +267,5 @@ class HomeViewNeedsTosAcceptanceTestCase(TestCase):
 
         response = self._login_and_get_home()
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.context['needs_tos_acceptance'])
+        blob = self._retrieve_json_blob(response)
+        self.assertFalse(blob.get('needsTosAcceptance'))

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -13,6 +13,7 @@ from django.contrib import messages
 from django.http import HttpRequest, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.html import json_script
 from django.utils.translation import gettext_lazy as _
 from django.contrib.messages import get_messages
 
@@ -141,32 +142,48 @@ def home(request: HttpRequest):
         # Clear form_data for any additional reloads
         request.session['form_data'] = {}
 
+    # Json script will create a json blob that's correctly escaped
+    script_tag = json_script(
+        {
+            'connectionInfo': settings.CONNECTION_INFO,
+            'appPasswords': app_passwords,
+            'userDisplayName': user_display_name,
+            'allowedDomains': settings.ALLOWED_EMAIL_DOMAINS if settings.ALLOWED_EMAIL_DOMAINS else [],
+            'customDomains': custom_domains,
+            'emailAddresses': email_addresses,
+            'maxCustomDomains': max_custom_domains,
+            'maxEmailAliases': max_email_aliases,
+            'tbProAppointmentUrl': settings.TB_PRO_APPOINTMENT_URL,
+            'tbProSendUrl': settings.TB_PRO_SEND_URL,
+            'tbProWaitListUrl': settings.TB_PRO_WAIT_LIST_URL,
+            'tbProPrimaryDomain': settings.PRIMARY_EMAIL_DOMAIN,
+            'webmailUrl': settings.WEBMAIL_URL,
+            'serverMessages': [
+                {'level': message.level, 'message': str(message.message)} for message in get_messages(request)
+            ],
+            'formData': form_data or None,
+            'features': get_feature_flags(),
+            'needsTosAcceptance': needs_tos_acceptance,
+            'recoveryEmail': recovery_email,
+            'planInfo': get_visible_plan_info(),
+            'paddleToken': settings.PADDLE_TOKEN,
+            'paddleEnvironment': settings.PADDLE_ENV,
+            'isAuthenticated': request.user.is_authenticated,
+            'hasActiveSubscription': request.user.has_active_subscription if request.user.is_authenticated else False,
+            'isAwaitingPaymentVerification': request.user.is_awaiting_payment_verification
+            if request.user.is_authenticated
+            else False,
+            'userEmail': request.user.email if request.user.is_authenticated else None,
+            'userFullName': request.user.get_full_name() if request.user.is_authenticated else None,
+            'username': request.user.username if request.user.is_authenticated else None,
+        },
+        'pageLoadData',
+    )
+
     return TemplateResponse(
         request,
         'index.html',
         {
-            'connection_info': settings.CONNECTION_INFO,
-            'app_passwords': json.dumps(app_passwords),
-            'user_display_name': user_display_name,
-            'allowed_domains': settings.ALLOWED_EMAIL_DOMAINS if settings.ALLOWED_EMAIL_DOMAINS else [],
-            'custom_domains': json.dumps(custom_domains),
-            'email_addresses': json.dumps(email_addresses),
-            'max_custom_domains': max_custom_domains,
-            'max_email_aliases': max_email_aliases,
-            'tb_pro_appointment_url': settings.TB_PRO_APPOINTMENT_URL,
-            'tb_pro_send_url': settings.TB_PRO_SEND_URL,
-            'tb_pro_wait_list_url': settings.TB_PRO_WAIT_LIST_URL,
-            'tb_pro_primary_domain': settings.PRIMARY_EMAIL_DOMAIN,
-            'webmail_url': settings.WEBMAIL_URL,
-            'server_messages': [
-                {'level': message.level, 'message': str(message.message)} for message in get_messages(request)
-            ],
-            'form_data': form_data or None,
-            'features': json.dumps(get_feature_flags()),
-            'needs_tos_acceptance': needs_tos_acceptance,
-            'recovery_email': recovery_email,
-            'plan_info': get_visible_plan_info(),
-            'paddle_token': settings.PADDLE_TOKEN,
-            'paddle_environment': settings.PADDLE_ENV,
+            'page_load_data_script': script_tag,
         },
     )

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -3,7 +3,6 @@ from thunderbird_accounts.subscription.utils import get_visible_plan_info
 from thunderbird_accounts.authentication.exceptions import AuthenticationUnavailable
 from gettext import gettext
 import sys
-import json
 import requests
 
 import requests.exceptions
@@ -147,7 +146,6 @@ def home(request: HttpRequest):
         {
             'connectionInfo': settings.CONNECTION_INFO,
             'appPasswords': app_passwords,
-            'userDisplayName': user_display_name,
             'allowedDomains': settings.ALLOWED_EMAIL_DOMAINS if settings.ALLOWED_EMAIL_DOMAINS else [],
             'customDomains': custom_domains,
             'emailAddresses': email_addresses,
@@ -176,6 +174,7 @@ def home(request: HttpRequest):
             'userEmail': request.user.email if request.user.is_authenticated else None,
             'userFullName': request.user.get_full_name() if request.user.is_authenticated else None,
             'username': request.user.username if request.user.is_authenticated else None,
+            'userDisplayName': user_display_name,
         },
         'pageLoadData',
     )

--- a/src/thunderbird_accounts/urls.py
+++ b/src/thunderbird_accounts/urls.py
@@ -5,6 +5,8 @@ Thunderbird Accounts Urls
 These are the routes and some light admin panel customization are located.
 """
 
+from django.views.generic import RedirectView
+
 from django.conf import settings
 from django.contrib import admin
 from django.shortcuts import redirect
@@ -146,6 +148,9 @@ urlpatterns += [
         name='admin_stalwart_list',
     ),
 ]
+
+# Serve our favicon.ico
+urlpatterns += [path('favicon.ico', RedirectView.as_view(url='/static/favicon.ico', permanent=True))]
 
 urlpatterns += [
     # Vue App catch-all: keep this last so all explicit Django routes above take precedence


### PR DESCRIPTION
Fixes #1149 
Fixes #1135 

We now let Django handle all of our escaping needs, and then just grab the blob and decode it. From my testing it works fine, I had to adjust the tos tests to read in the blob. 

This fixes some encoding bugs that can lead to a infinite redirect. And also I fixed favicon for admin panel. 