### PR TITLE
Add dinero.js to detect and correctly display currency. (Fixes #1152)

### DIFF
--- a/assets/app/vue/router.ts
+++ b/assets/app/vue/router.ts
@@ -51,7 +51,7 @@ const routes: RouteRecordRaw[] = window._page?.isErrorPage ? [
       isPublic: true,
       useAppTemplate: false,
     },
-    beforeEnter: (async (to, from) => {
+    beforeEnter: (async (to, _from) => {
       /* This is a bit too long but we cannot use beforeEnter in-component. :( */
       let failQueryParam = '';
 

--- a/assets/app/vue/views/DashboardView/utils.ts
+++ b/assets/app/vue/views/DashboardView/utils.ts
@@ -1,7 +1,8 @@
 import type { ComposerNumberFormatting, ComposerTranslation, ComposerDateTimeFormatting } from 'vue-i18n';
 import type { SubscriptionData } from './types';
 import { i18n } from '@/composables/i18n';
-
+import { dinero, add, toDecimal, toSnapshot, allocate } from 'dinero.js';
+import * as currencies from 'dinero.js/currencies';
 /**
  * Converts bytes to the most appropriate unit (KB, MB, or GB) with the unit label
  * @param bytes - The number of bytes to convert
@@ -34,10 +35,40 @@ export const formatBytes = (bytes: string | null): string | null => {
 }
 
 /**
+ * Takes in the amount in cents (raw data from Paddle), currency code and billingInterval and outputs the correctly formatted price in monthly interval.
+ * Ex/
+ *  * (12_000, CAD, year) = CA$10
+ *  * (12_000, USD, year) = $10
+ *  * (11_700, JPY, year) = ¥975
+ */
+export const formatLocalizedMonthlyPrice = (
+  amountCents: number,
+  currency: string,
+  billingInterval: string | undefined
+): string => {
+  // Use currency if supported, otherwise fallback to USD.
+  const currencyType = currency in currencies ? currencies[currency as keyof typeof currencies] : currencies['USD'];
+  const annualBilling = billingInterval?.toLowerCase() === 'year';
+
+  const priceObj = dinero({ amount: amountCents, currency: currencyType });
+
+  // allocate expects a list of equal amounts, so in order to split this by 12 correctly we must fill a list 12 times...bleh  
+  const allocation = Array(12).fill(0, 0, 12).map(() => (1.0 / 12.0) * 100.0);
+  const price = annualBilling ? toDecimal(allocate(priceObj, allocation)[0]) : toDecimal(priceObj);
+
+  return new Intl.NumberFormat(i18n.locale.value, {
+    style: 'currency',
+    currency,
+    // @ts-ignore: lsp is complaining this property doesn't exist, so ignore that "error".
+    trailingZeroDisplay: 'stripIfInteger' 
+  }).format(parseFloat(price));
+};
+
+/**
  * Formats subscription data from the backend into a display-friendly format
  * @param subscriptionData - The subscription data from the backend
- * @param n - The number formatting function from vue-i18n
- * @param t - The translation function from vue-i18n
+ * @param n - The number formatting function from vue-i18n (not used)
+ * @param t - The translation function from vue-i18n (not used)
  * @param d - The date formatting function from vue-i18n
  * - Converts currency code to symbol
  * - Converts price from cents to dollars
@@ -47,30 +78,11 @@ export const formatBytes = (bytes: string | null): string | null => {
  */
 export const formatSubscriptionData = (
   subscriptionData: SubscriptionData,
-  n: ComposerNumberFormatting,
-  t: ComposerTranslation,
+  _n: ComposerNumberFormatting,
+  _t: ComposerTranslation,
   d: ComposerDateTimeFormatting
 ): SubscriptionData => {
-  // Convert price from cents to dollars
-  let priceInDollars = parseFloat(subscriptionData.price) / 100;
-
-  // Convert yearly pricing to monthly equivalent
-  const period = subscriptionData.period.toLowerCase();
-  if (period === 'year') {
-    priceInDollars = priceInDollars / 12;
-  }
-
-  const fractionDigits = Number.isInteger(priceInDollars) ? 0 : 2;
-  
-  // n is not doing a good job in letting us specify the actual currency...so use javascript
-  const intlN = new Intl.NumberFormat(i18n.locale.value, {
-    style: "currency",
-    currency: subscriptionData.currency,
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: fractionDigits
-  });
-
-  const formattedPrice = intlN.format(priceInDollars);
+  const formattedPrice = formatLocalizedMonthlyPrice(parseInt(subscriptionData.price, 10), subscriptionData.currency, subscriptionData.period);
 
   // Format autoRenewal date if it exists
   const formattedAutoRenewal = subscriptionData.autoRenewal 

--- a/assets/app/vue/views/DashboardView/utils.ts
+++ b/assets/app/vue/views/DashboardView/utils.ts
@@ -1,7 +1,7 @@
 import type { ComposerNumberFormatting, ComposerTranslation, ComposerDateTimeFormatting } from 'vue-i18n';
 import type { SubscriptionData } from './types';
 import { i18n } from '@/composables/i18n';
-import { dinero, add, toDecimal, toSnapshot, allocate } from 'dinero.js';
+import { dinero, toDecimal, allocate } from 'dinero.js';
 import * as currencies from 'dinero.js/currencies';
 /**
  * Converts bytes to the most appropriate unit (KB, MB, or GB) with the unit label

--- a/assets/app/vue/views/SignUpView/index.vue
+++ b/assets/app/vue/views/SignUpView/index.vue
@@ -8,13 +8,12 @@ import BaseTemplate from '@kc/vue/BaseTemplate.vue';
 import Step1Username from './views/Step1Username/index.vue';
 import StepConfirmPlan from './views/StepConfirmPlan/index.vue';
 import Step2Password from './views/Step2Password/index.vue';
-import Step3Verify from './views/Step3Verify/index.vue';
 import SignUpLayout from './components/SignUpLayout.vue';
 
 // Import our i18n composable
 import CsrfToken from '@/components/forms/CsrfToken.vue';
 import { NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
-import { onBeforeRouteUpdate, useRoute } from 'vue-router';
+import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { SIGN_UP_STEPS, useSignUpFlowStore } from './stores/signUpFlowStore';
 import { storeToRefs } from 'pinia';

--- a/assets/app/vue/views/SignUpView/views/StepConfirmPlan/index.vue
+++ b/assets/app/vue/views/SignUpView/views/StepConfirmPlan/index.vue
@@ -8,7 +8,6 @@ import { useI18n } from 'vue-i18n';
 import SignUpLayout from '../../components/SignUpLayout.vue';
 import { useSignUpFlowStore } from '../../stores/signUpFlowStore';
 import { formatLocalizedMonthlyPrice } from '@/views/DashboardView/utils';
-import { dinero, add, toDecimal, toSnapshot } from 'dinero.js';
 const DEFAULT_MONTHLY_PRICE = '$6';
 
 const { t } = useI18n();
@@ -49,7 +48,6 @@ const loadPlanPrice = async () => {
         quantity: 1,
         priceId,
       })),
-      currencyCode: 'JPY',
     });
 
     const lineItem = preview.data.details.lineItems[0];

--- a/assets/app/vue/views/SignUpView/views/StepConfirmPlan/index.vue
+++ b/assets/app/vue/views/SignUpView/views/StepConfirmPlan/index.vue
@@ -4,11 +4,11 @@ import { NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import { initializePaddle, type Environments } from '@paddle/paddle-js';
 import { NOT_INTERESTED_SURVEY_LINK } from '@/defines';
 import PlanCard from '@/components/PlanCard.vue';
-import { i18n } from '@/composables/i18n';
 import { useI18n } from 'vue-i18n';
 import SignUpLayout from '../../components/SignUpLayout.vue';
 import { useSignUpFlowStore } from '../../stores/signUpFlowStore';
-
+import { formatLocalizedMonthlyPrice } from '@/views/DashboardView/utils';
+import { dinero, add, toDecimal, toSnapshot } from 'dinero.js';
 const DEFAULT_MONTHLY_PRICE = '$6';
 
 const { t } = useI18n();
@@ -21,27 +21,6 @@ const planDescription = ref(window._page?.planInfo?.description ?? '');
 const priceDisplay = ref(DEFAULT_MONTHLY_PRICE);
 const priceLoading = ref(true);
 const priceError = ref<string | null>(null);
-
-const formatLocalizedMonthlyPrice = (
-  amountCents: string,
-  currency: string,
-  billingInterval: string | undefined
-): string => {
-  let price = parseFloat(amountCents) / 100;
-
-  if (billingInterval?.toLowerCase() === 'year') {
-    price = price / 12;
-  }
-
-  const fractionDigits = Number.isInteger(price) ? 0 : 2;
-
-  return new Intl.NumberFormat(i18n.locale.value, {
-    style: 'currency',
-    currency,
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: fractionDigits,
-  }).format(price);
-};
 
 const loadPlanPrice = async () => {
   const planInfo = window._page?.planInfo;
@@ -70,12 +49,13 @@ const loadPlanPrice = async () => {
         quantity: 1,
         priceId,
       })),
+      currencyCode: 'JPY',
     });
 
     const lineItem = preview.data.details.lineItems[0];
     if (lineItem) {
       priceDisplay.value = formatLocalizedMonthlyPrice(
-        lineItem.totals.total,
+        parseInt(lineItem.totals.total, 10),
         preview.data.currencyCode,
         lineItem.price.billingCycle?.interval
       );
@@ -109,17 +89,11 @@ export default {
 </script>
 
 <template>
-  <sign-up-layout
-    step-id="step-confirm-plan"
-    :title="$t('views.mail.views.signUp.stepConfirmPlan.title')"
-    :subtitle="$t('views.mail.views.signUp.stepConfirmPlan.subtitle')"
-    :submit-disabled="priceLoading"
-    :submit-title="$t('views.mail.views.signUp.stepConfirmPlan.action')"
-    :show-alternative-action="true"
+  <sign-up-layout step-id="step-confirm-plan" :title="$t('views.mail.views.signUp.stepConfirmPlan.title')"
+    :subtitle="$t('views.mail.views.signUp.stepConfirmPlan.subtitle')" :submit-disabled="priceLoading"
+    :submit-title="$t('views.mail.views.signUp.stepConfirmPlan.action')" :show-alternative-action="true"
     :alternative-action-title="$t('views.mail.views.signUp.stepConfirmPlan.notInterested')"
-    @alternative-action="onNotInterested"
-    @submit="onSubmit"
-  >
+    @alternative-action="onNotInterested" @submit="onSubmit">
     <template v-slot:notice-bars>
       <notice-bar :type="NoticeBarTypes.Critical" v-if="priceError">
         {{ priceError }}
@@ -127,12 +101,8 @@ export default {
     </template>
     <template v-slot:form-elements>
       <div class="plan-card-container">
-        <plan-card
-          :name="planName"
-          :description="planDescription"
-          :price="priceDisplay"
-          :price-loading="priceLoading"
-        />
+        <plan-card :name="planName" :description="planDescription" :price="priceDisplay"
+          :price-loading="priceLoading" />
       </div>
     </template>
   </sign-up-layout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@phosphor-icons/vue": "^2.2.1",
         "@thunderbirdops/services-ui": "^1.6.7",
         "@vueuse/core": "^14.2.1",
+        "dinero.js": "^2.0.2",
         "pinia": "^3.0.4",
         "qr": "^0.5.5",
         "thunderbird-account-qr-code": "^1.1.0",
@@ -2646,6 +2647,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dinero.js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dinero.js/-/dinero.js-2.0.2.tgz",
+      "integrity": "sha512-d+4egJTvNinkb66KSed11Daqz6MWaOHzyalLu6h3p+BLrsmwKFjHjvOKivOWeM7WyoX89te+xx4cKI6zrDtCfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@phosphor-icons/vue": "^2.2.1",
     "@thunderbirdops/services-ui": "^1.6.7",
     "@vueuse/core": "^14.2.1",
+    "dinero.js": "^2.0.2",
     "pinia": "^3.0.4",
     "qr": "^0.5.5",
     "thunderbird-account-qr-code": "^1.1.0",

--- a/src/thunderbird_accounts/subscription/admin.py
+++ b/src/thunderbird_accounts/subscription/admin.py
@@ -108,7 +108,7 @@ class CustomPriceAdmin(CustomReadonlyAdmin):
         'billing_cycle',
     )
 
-    @admin.display(description=_('Amount'), ordering='amount')
+    @admin.display(description=_('Amount (in USD)'), ordering='amount')
     def formatted_amount(self, obj):
         try:
             amount = int(obj.amount) / 100
@@ -165,7 +165,7 @@ class CustomSubscriptionItemAdmin(CustomReadonlyAdmin):
             return obj.price.name
         return None
 
-    @admin.display(description=_('Price Amount'), ordering='price__amount')
+    @admin.display(description=_('Price Amount (in USD)'), ordering='price__amount')
     def price_amount(self, obj):
         if obj.price:
             try:

--- a/src/thunderbird_accounts/support/customer.py
+++ b/src/thunderbird_accounts/support/customer.py
@@ -294,6 +294,7 @@ def _get_total_spend(user: User) -> list[dict]:
     for transaction in transactions:
         totals[transaction.currency] += int(transaction.total)
 
+    # FIXME: Support is getting the incorrect value, we should just pull directly from Paddle instead.
     return [{'currency': currency, 'amount': f'{amount / 100:.2f}'} for currency, amount in sorted(totals.items())]
 
 


### PR DESCRIPTION
Fixes #1152 

[Dinero.js](https://www.dinerojs.com/) seems to be a choice for this. I'm sort of shocked there's no native js (or python) library function for this but oh well. Paddle doesn't provide the monthly price because we're billing annually. It'd be better if we just gave up on displaying pricing in monthly, it's kinda weird tbh. 

Technically support's "total spend" value will still be incorrect for non 100 cents = 1 dollar currencies. We should just pull in a Paddle price preview but we can cut another ticket for that later. 