### PR TITLE
fix: make custom domain deletion idempotent

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -621,6 +621,25 @@ class RemoveCustomDomainTestCase(TestCase):
 
     @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
     @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_deleting_an_already_removed_domain_is_successful(
+        self,
+        mock_mail_client_cls,
+        mock_delete_hosted_dkim_dns_records,
+    ):
+        mock_instance = Mock()
+        mock_mail_client_cls.return_value = mock_instance
+
+        self.assertEqual(self._delete_domain().status_code, 200)
+        response = self._delete_domain()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode()), {'success': True})
+        mock_instance.delete_domain.assert_called_once_with(self.domain.name)
+        mock_instance.delete_dkim.assert_called_once_with(self.domain.name)
+        mock_delete_hosted_dkim_dns_records.assert_called_once_with(self.domain.name)
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
     def test_pending_domain_still_deletes_dkim_and_cloudflare_records(
         self,
         mock_mail_client_cls,

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -344,9 +344,11 @@ def remove_custom_domain(request: HttpRequest):
         return JsonResponse({'success': False, 'error': _('Domain name is required')}, status=400)
 
     domain_name = domain_name.lower()
-    domain = request.user.domains.get(name=domain_name)
-    if not domain:
-        return JsonResponse({'success': False, 'error': _('Domain not found')}, status=404)
+    try:
+        domain = request.user.domains.get(name=domain_name)
+    except Domain.DoesNotExist:
+        logging.info(f'Custom domain {domain_name} was already removed for user {request.user.uuid}')
+        return JsonResponse({'success': True})
 
     # Check if we have any aliases for that domain setup
     try:


### PR DESCRIPTION
## Summary
- treat a second custom-domain deletion request as a successful no-op when the domain was already removed
- add regression coverage for the rapid double-delete path

Fixes #1164.

## Testing
- `npm ci && npm run build && npm run build-theme`
- `coverage run --source='thunderbird_accounts' manage.py test thunderbird_accounts -v 0`
- `coverage report` (516 tests passed; 85% total coverage)
- `ruff check`
- `git diff --check`
