### PR TITLE
fix(mail): make custom domain removal idempotent

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -621,6 +621,32 @@ class RemoveCustomDomainTestCase(TestCase):
 
     @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
     @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_repeated_delete_is_idempotent(
+        self,
+        mock_mail_client_cls,
+        mock_delete_hosted_dkim_dns_records,
+    ):
+        mock_instance = Mock()
+        mock_mail_client_cls.return_value = mock_instance
+
+        first_response = self._delete_domain()
+        with self.assertLogs(level='INFO') as captured_logs:
+            second_response = self._delete_domain()
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        self.assertEqual(json.loads(second_response.content.decode()), {'success': True})
+        self.assertIn(
+            'Custom domain removal found no local domain; treating the request as already complete',
+            captured_logs.output[0],
+        )
+        mock_mail_client_cls.assert_called_once_with()
+        mock_instance.delete_domain.assert_called_once_with(self.domain.name)
+        mock_instance.delete_dkim.assert_called_once_with(self.domain.name)
+        mock_delete_hosted_dkim_dns_records.assert_called_once_with(self.domain.name)
+
+    @patch('thunderbird_accounts.mail.views.mail_tasks.delete_hosted_dkim_dns_records.delay')
+    @patch('thunderbird_accounts.mail.views.MailClient')
     def test_pending_domain_still_deletes_dkim_and_cloudflare_records(
         self,
         mock_mail_client_cls,

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -344,9 +344,11 @@ def remove_custom_domain(request: HttpRequest):
         return JsonResponse({'success': False, 'error': _('Domain name is required')}, status=400)
 
     domain_name = domain_name.lower()
-    domain = request.user.domains.get(name=domain_name)
-    if not domain:
-        return JsonResponse({'success': False, 'error': _('Domain not found')}, status=404)
+    try:
+        domain = request.user.domains.get(name=domain_name)
+    except Domain.DoesNotExist:
+        logging.info('Custom domain removal found no local domain; treating the request as already complete')
+        return JsonResponse({'success': True})
 
     # Check if we have any aliases for that domain setup
     try:


### PR DESCRIPTION
## What changed?

- Catch `Domain.DoesNotExist` when the local custom-domain record is already gone.
- Log that state at info level and return the same successful JSON response as a completed deletion.
- Add a regression test that submits the delete request twice and verifies that remote, DKIM, and hosted-DNS cleanup only run for the first request.

AI disclosure: OpenAI Codex wrote this small patch and regression test under the contributor's direction, including root-cause tracing and local validation.

## Why?

A rapid second click, retry, or replay can reach the endpoint after the first request has already deleted the local record. That means the requested end state is already satisfied, so the follow-up should be idempotent instead of raising `Domain.DoesNotExist` and producing a 500/Sentry event.

## Limitations and Notes

This intentionally addresses the post-delete retry reported in #1164. Coordination between two requests that both begin before either one deletes the local row is unchanged.

Validation:

- `uv run python manage.py test thunderbird_accounts.mail.tests` (173/173 passed)
- Full `thunderbird_accounts` Django suite after the frontend builds (516/516 passed)
- `uv run ruff check`
- `npm run build`
- `npm run build-theme`

## Applicable Issues

Closes #1164

## Screenshots

Not applicable; there is no UI change.
