### PR TITLE
Refactor: enforce keeping Vue and Django routes in sync.

### DIFF
--- a/assets/app/vue/router.ts
+++ b/assets/app/vue/router.ts
@@ -25,6 +25,7 @@ import { isWaffleFlagActive } from '@/utils';
 // waffle flag is active, so /manage-mfa falls through to the 404 route until it's enabled.
 const showMfa = isWaffleFlagActive('multi-factor-authentication');
 
+// Keep public routes in sync with PUBLIC_VUE_ROUTES in src/thunderbird_accounts/core/views.py.
 // If the page template is marked as error page, only show the error page.
 const routes: RouteRecordRaw[] = window._page?.isErrorPage ? [
   {

--- a/src/thunderbird_accounts/core/tests/test_views.py
+++ b/src/thunderbird_accounts/core/tests/test_views.py
@@ -1,14 +1,48 @@
 import json
+import os
+import re
 from django.utils.html import strip_tags
 from unittest.mock import patch, Mock
 
 from django.conf import settings
-from django.test import TestCase, Client as RequestClient
+from django.test import SimpleTestCase, TestCase, Client as RequestClient
 from django.urls import reverse
 
 from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.core.views import PUBLIC_VUE_ROUTES
 from thunderbird_accounts.legal.models import LegalDocument, LegalDocumentResponse
 from thunderbird_accounts.mail.models import Account
+
+
+class PublicVueRouteSyncTestCase(SimpleTestCase):
+    """Test that public routes stay in sync between Vue and Django"""
+
+    def test_django_public_vue_routes_match_vue_router_public_routes(self):
+        vue_public_routes = self._extract_vue_public_routes()
+
+        self.assertSetEqual(vue_public_routes, PUBLIC_VUE_ROUTES)
+
+    def _extract_vue_public_routes(self):
+        router_path = os.path.join(settings.BASE_DIR, 'assets', 'app', 'vue', 'router.ts')
+        router_source = router_path.read_text()
+        route_matches = list(re.finditer(r"^\s+path:\s*'([^']+)'", router_source, re.MULTILINE))
+        public_routes = set()
+
+        for index, route_match in enumerate(route_matches):
+            route_end = route_matches[index + 1].start() if index + 1 < len(route_matches) else len(router_source)
+            route_definition = router_source[route_match.start():route_end]
+            if not re.search(r'isPublic:\s*true\b', route_definition):
+                continue
+
+            path = route_match.group(1)
+            if self._is_concrete_vue_path(path):
+                public_routes.add(path)
+
+        return public_routes
+
+    @staticmethod
+    def _is_concrete_vue_path(path):
+        return path.startswith('/') and ':' not in path and '*' not in path and path != '/'
 
 
 class HomeViewRedirectTestCase(TestCase):
@@ -34,17 +68,13 @@ class HomeViewRedirectTestCase(TestCase):
                 self.assertEqual(response.status_code, 302)
                 self.assertEqual(response.url, reverse('login'))
 
-    def test_unauthenticated_user_can_access_privacy_page(self):
-        """Test that unauthenticated users can access the /privacy public route."""
-        response = self.client.get('/privacy')
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'index.html')
-
-    def test_unauthenticated_user_can_access_terms_page(self):
-        """Test that unauthenticated users can access the /terms public route."""
-        response = self.client.get('/terms')
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'index.html')
+    def test_unauthenticated_user_can_access_public_vue_routes(self):
+        """Test that unauthenticated users can access public Vue routes."""
+        for path in PUBLIC_VUE_ROUTES:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 200)
+                self.assertTemplateUsed(response, 'index.html')
 
     def test_authenticated_user_can_access_home(self):
         """Test that authenticated users can access home without redirect."""

--- a/src/thunderbird_accounts/core/views.py
+++ b/src/thunderbird_accounts/core/views.py
@@ -25,6 +25,17 @@ from thunderbird_accounts.mail.utils import decode_app_password, filter_app_pass
 from thunderbird_accounts.legal.models import LegalDocument, LegalDocumentResponse
 
 
+# Keep in sync with the public routes in assets/app/vue/router.ts.
+PUBLIC_VUE_ROUTES = frozenset(
+    {
+        '/sign-up',
+        '/sign-up/complete',
+        '/contact',
+        '/chill',
+    }
+)
+
+
 def handle_500(request: HttpRequest, template_name=None):
     """Overrides Django's default 500 error page with our own"""
     # Retrieve the last known exception
@@ -107,19 +118,7 @@ def home(request: HttpRequest):
             max_custom_domains = request.user.plan.mail_domain_count
             max_email_aliases = request.user.plan.mail_address_count
     elif not request.user.is_authenticated:  # Only if the user is not authenticated
-        # Check if path is included in Vue's public routes (assets/app/vue/router.ts)
-        public_routes = [
-            '/privacy',
-            '/terms',
-            '/contact',
-            '/sign-up',
-            '/sign-up/complete',
-            '/logout',
-            '/error',
-            '/chill',
-        ]
-
-        if request.path not in public_routes:
+        if request.path not in PUBLIC_VUE_ROUTES:
             return HttpResponseRedirect(reverse('login'))
 
     # Check if the user needs to accept the latest legal documents


### PR DESCRIPTION
## What changed?

Forces public Vue routes to stay since with list in Django by using
a unit test that fails if they go out of sync.

## Why?

This fixes #408.

The solution is an alternative to #473, which solved the issue with a
shared JSON file.

Here, instead of adding another layer of abstraction, we use a "trust but verify"
design. Comments on both sides hint to the user to keep the other side in
sync, and then a unit test verifies this actually done.

This meets the quality goal to keep these in sync. with less complexity in the codebase.

## Notes

The refactor exposed that the current had been of sync, with Django
listing several routes as public Vue routes that are not.

The removed entries were /privacy, /terms, /logout, and /error.
They are no longer Vue routes.

## Applicable Issues

 * #408

## QA Log

- Automated tests
- Checked and double-checked that the removed routes are no longer Vue routes.
