### PR TITLE
Lock the accounts-prod bastion AMI

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -338,6 +338,7 @@ resources:
 
   tb:ec2:SshableInstance:
     bastion:
+      ami: ami-081f88da93d42baeb
       ssh_keypair_name: accounts-prod
       source_cidrs: 
         - 10.10.0.0/16


### PR DESCRIPTION
We're currently having trouble in our automation because the new bastion here is causing Pulumi to do an SSM parameter lookup. While I figure out what the right place to put those permissions is, we can just lock this AMI. By locking the AMI, we prevent [the SSM call](https://github.com/thunderbird/pulumi/blob/main/tb_pulumi/ec2.py#L297-L298) from ever being made.