### PR TITLE
Add input validation for internal Paddle endpoint (#1180)

### DIFF
--- a/src/thunderbird_accounts/subscription/tests/test_views.py
+++ b/src/thunderbird_accounts/subscription/tests/test_views.py
@@ -26,6 +26,26 @@ class PaddleCheckoutIsDoneTestCase(TestCase):
         data = txid_response.json()
         self.assertTrue(data.get('success'))
 
+    def test_set_paddle_transaction_id_rejects_invalid_json(self):
+        response = self.client.put(
+            reverse('paddle_txid'),
+            data='invalid json',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'success': False, 'error': 'Invalid request data'})
+
+    def test_set_paddle_transaction_id_rejects_invalid_utf8(self):
+        response = self.client.put(
+            reverse('paddle_txid'),
+            data=b'\x80',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'success': False, 'error': 'Invalid request data'})
+
     @override_settings(IS_DEV=False)
     def test_no_tx_id_in_session(self):
         """This route requires a transaction id in their session. So if they don't have a transaction id,

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -78,7 +78,11 @@ def get_paddle_information(request: Request):
 def set_paddle_transaction_id(request: Request):
     """This error is used to work-around the fact we don't get a transaction id from Paddle's successUrl redirect.
     It kinda sucks, but it works for now."""
-    data = json.loads(request.body.decode())
+    try:
+        data = json.loads(request.body.decode())
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({'success': False, 'error': str(_('Invalid request data'))}, status=400)
+
     request.session[SESSION_PADDLE_TRANSACTION_ID] = data.get('txid')
     request.session[SESSION_PADDLE_PAYMENT_TYPE] = data.get('payment_type')
     return JsonResponse({'success': True})


### PR DESCRIPTION
/api/v1/subscription/paddle/tx/set/ is only called by us, internally for a logged-in
user with CSRF protection. Sentry captured a zero-byte request here, perhaps
from a DevTools modification to the call.

The validation covers that edge case. A further investigation was done
to check there could be malicious benefit to custom-crafting the inputs
here and there's no real security risk for a user to do so.

## What changed?

Input validation was added.

## Why?

Sentry picked up an unhandled error due to bad input here.

## Applicable Issues

 * Fixes #1180

## QA Log

- Added automated test coverage
- Confirmed zero-byte call would be handled by this.
- Analyzed further to see if there's a deeper root cause or a security issue.
  Appears it was a likely triggered by DevTools modification and there's not
  deeper security issue found.

