### PR TITLE
fix(mail): return 503 instead of 500 when the mail backend is unavailable

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -262,6 +262,7 @@
           "domainAlreadyExists": "Domain already exists",
           "domainAlreadyConfigured": "This domain is already configured. Please {link} in case you believe this is a mistake.",
           "reachOutToSupport": "reach out to support",
+          "mailBackendUnavailable": "Mail server unavailable. Please try again in a few minutes.",
           "verificationValidationErrors": {
             "mxLookupError": "Unable to find MX record pointing to Thundermail",
             "ipLookupError": "Unable to resolve IP addresses",

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/ActionsMenu.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/ActionsMenu.vue
@@ -54,6 +54,14 @@ const handleRetry = async () => {
   try {
     const data = await verifyDomain(props.domain.name);
 
+    // Transient mail-backend outage: surface the error notice and don't touch the
+    // domain's verification state (don't apply results or mark it FAILED).
+    if (data.code === 'mail_backend_unavailable') {
+      emit('custom-domain-error', t('views.mail.sections.customDomains.mailBackendUnavailable'));
+      showMenu.value = false;
+      return;
+    }
+
     emitVerificationResult(data);
 
     if (data.success) {

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -463,6 +463,13 @@ const onVerifyDomain = async () => {
   try {
     const data = await verifyDomain(customDomain.value);
 
+    // Transient mail-backend outage: surface the error notice and leave the
+    // domain's verification state untouched (don't apply results or mark FAILED).
+    if (data.code === 'mail_backend_unavailable') {
+      customDomainError.value = t('views.mail.sections.customDomains.mailBackendUnavailable');
+      return;
+    }
+
     applyVerificationResult(customDomain.value, validationResult(data), {
       showMissingIssues: true,
       cacheResult: true,

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -639,6 +639,14 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
       </div>
     </div>
 
+    <notice-bar
+      :type="NoticeBarTypes.Critical"
+      class="verify-step-notice-bar"
+      v-if="customDomainError"
+    >
+      <p>{{ customDomainError }}</p>
+    </notice-bar>
+
     <!-- TODO: Uncomment this once we have the task / job to automatically verify domains -->
     <!-- <notice-bar :type="NoticeBarTypes.Info" class="verify-step-notice-bar" v-if="showNoticeBar">
       <strong>{{ t('views.mail.sections.customDomains.verifyStepInfoTitle') }}</strong>

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -3,6 +3,7 @@ from thunderbird_accounts.mail.exceptions import DomainNotFoundError
 from django.utils.crypto import get_random_string
 from thunderbird_accounts.subscription.models import Plan, Subscription
 import json
+import requests
 from unittest.mock import patch, Mock
 
 from django.conf import settings
@@ -572,6 +573,52 @@ class VerifyCustomDomainTestCase(TestCase):
         mock_instance.create_domain.assert_not_called()
         mock_instance.ensure_dkim.assert_not_called()
         mock_publish_hosted_dkim.assert_not_called()
+
+        self.domain.refresh_from_db()
+        self.assertEqual(Domain.DomainStatus.FAILED, self.domain.status)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_backend_unavailable_returns_503(self, mock_mail_client_cls):
+        """A backend outage (requests.RequestException) is a transient upstream
+        failure: return 503, not 500, and leave the domain status untouched."""
+        mock_instance = Mock()
+        mock_instance.check_domain_dns.side_effect = requests.exceptions.HTTPError(
+            '500 Server Error: Internal Server Error for url: '
+            'https://mail-backend.example:8080/api/principal/deploy'
+        )
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 503, response.content)
+        self.assertFalse(json.loads(response.content.decode())['success'])
+
+        # A transient backend outage must not permanently mark the domain FAILED.
+        self.domain.refresh_from_db()
+        self.assertEqual(Domain.DomainStatus.PENDING, self.domain.status)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_unexpected_error_still_returns_500(self, mock_mail_client_cls):
+        """A genuine, unexpected error keeps the original 500 behaviour and marks
+        the domain FAILED — only backend outages are downgraded to 503."""
+        mock_instance = Mock()
+        mock_instance.check_domain_dns.side_effect = ValueError('unexpected internal error')
+        mock_mail_client_cls.return_value = mock_instance
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 500, response.content)
+        self.assertFalse(json.loads(response.content.decode())['success'])
 
         self.domain.refresh_from_db()
         self.assertEqual(Domain.DomainStatus.FAILED, self.domain.status)

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -15,7 +15,12 @@ from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.core.tests.utils import oidc_force_login
 from thunderbird_accounts.mail.clients import DomainVerificationErrors, StaleDNSRecordCode
 from thunderbird_accounts.mail.models import Account, Domain, Email
-from thunderbird_accounts.mail.views import create_custom_domain, get_dns_records, remove_custom_domain
+from thunderbird_accounts.mail.views import (
+    _is_transient_backend_error,
+    create_custom_domain,
+    get_dns_records,
+    remove_custom_domain,
+)
 
 
 class AppPasswordApiTestCase(TestCase):
@@ -598,13 +603,32 @@ class VerifyCustomDomainTestCase(TestCase):
         response.status_code = status_code
         return requests.exceptions.HTTPError(f'{status_code} Server Error', response=response)
 
+    def test_backend_error_transience_is_explicit(self):
+        transient_errors = [
+            self._http_error(status_code) for status_code in (500, 502, 503, 504)
+        ] + [
+            requests.ConnectionError('Connection refused'),
+            requests.Timeout('Request timed out'),
+        ]
+        non_transient_errors = [
+            self._http_error(status_code) for status_code in (400, 501, 505)
+        ] + [requests.RequestException('Unclassified request failure')]
+
+        for error in transient_errors:
+            with self.subTest(error=error):
+                self.assertTrue(_is_transient_backend_error(error))
+
+        for error in non_transient_errors:
+            with self.subTest(error=error):
+                self.assertFalse(_is_transient_backend_error(error))
+
     @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
     @patch('thunderbird_accounts.mail.views.check_stale_dns_records')
     @patch('thunderbird_accounts.mail.views.MailClient')
-    def test_backend_5xx_during_create_domain_returns_503(
+    def test_backend_500_during_create_domain_returns_503(
         self, mock_mail_client_cls, mock_check_stale_dns_records
     ):
-        """DNS verification succeeds, then the Stalwart backend 5xxs on
+        """DNS verification succeeds, then the Stalwart backend returns 500 on
         create_domain() (/api/principal/deploy). That transient outage returns 503
         with the stable `mail_backend_unavailable` code, and leaves the domain
         PENDING rather than flipping it to FAILED."""

--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -577,17 +577,39 @@ class VerifyCustomDomainTestCase(TestCase):
         self.domain.refresh_from_db()
         self.assertEqual(Domain.DomainStatus.FAILED, self.domain.status)
 
-    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
-    @patch('thunderbird_accounts.mail.views.MailClient')
-    def test_backend_unavailable_returns_503(self, mock_mail_client_cls):
-        """A backend outage (requests.RequestException) is a transient upstream
-        failure: return 503, not 500, and leave the domain status untouched."""
+    def _mock_client_verified_then_create_raises(self, mock_mail_client_cls, side_effect):
+        """MailClient mock whose DNS check passes (so create_domain() is reached),
+        with create_domain() raising the given side effect."""
         mock_instance = Mock()
-        mock_instance.check_domain_dns.side_effect = requests.exceptions.HTTPError(
-            '500 Server Error: Internal Server Error for url: '
-            'https://mail-backend.example:8080/api/principal/deploy'
-        )
+        mock_instance.check_domain_dns.return_value = {
+            'is_verified': True,
+            'critical_errors': [],
+            'warnings': [],
+            'dns_records': [],
+        }
+        mock_instance.get_domain.side_effect = DomainNotFoundError(self.domain.name)
+        mock_instance.create_domain.side_effect = side_effect
         mock_mail_client_cls.return_value = mock_instance
+        return mock_instance
+
+    @staticmethod
+    def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+        response = requests.Response()
+        response.status_code = status_code
+        return requests.exceptions.HTTPError(f'{status_code} Server Error', response=response)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.check_stale_dns_records')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_backend_5xx_during_create_domain_returns_503(
+        self, mock_mail_client_cls, mock_check_stale_dns_records
+    ):
+        """DNS verification succeeds, then the Stalwart backend 5xxs on
+        create_domain() (/api/principal/deploy). That transient outage returns 503
+        with the stable `mail_backend_unavailable` code, and leaves the domain
+        PENDING rather than flipping it to FAILED."""
+        mock_check_stale_dns_records.return_value = []
+        self._mock_client_verified_then_create_raises(mock_mail_client_cls, self._http_error(500))
 
         response = self.client.post(
             self.url,
@@ -596,17 +618,41 @@ class VerifyCustomDomainTestCase(TestCase):
         )
 
         self.assertEqual(response.status_code, 503, response.content)
-        self.assertFalse(json.loads(response.content.decode())['success'])
+        body = json.loads(response.content.decode())
+        self.assertFalse(body['success'])
+        self.assertEqual('mail_backend_unavailable', body['code'])
 
-        # A transient backend outage must not permanently mark the domain FAILED.
         self.domain.refresh_from_db()
         self.assertEqual(Domain.DomainStatus.PENDING, self.domain.status)
 
     @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
+    @patch('thunderbird_accounts.mail.views.check_stale_dns_records')
+    @patch('thunderbird_accounts.mail.views.MailClient')
+    def test_backend_4xx_is_not_transient_returns_500(
+        self, mock_mail_client_cls, mock_check_stale_dns_records
+    ):
+        """A non-transient backend response (4xx) is a genuine failure, not a
+        retryable outage, so it keeps the original 500 + FAILED behaviour."""
+        mock_check_stale_dns_records.return_value = []
+        self._mock_client_verified_then_create_raises(mock_mail_client_cls, self._http_error(400))
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'domain-name': self.domain.name}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 500, response.content)
+        self.assertFalse(json.loads(response.content.decode())['success'])
+
+        self.domain.refresh_from_db()
+        self.assertEqual(Domain.DomainStatus.FAILED, self.domain.status)
+
+    @override_settings(CUSTOM_DOMAINS_DO_VERIFY=True)
     @patch('thunderbird_accounts.mail.views.MailClient')
     def test_unexpected_error_still_returns_500(self, mock_mail_client_cls):
-        """A genuine, unexpected error keeps the original 500 behaviour and marks
-        the domain FAILED — only backend outages are downgraded to 503."""
+        """A genuine, unexpected (non-requests) error keeps the original 500 +
+        FAILED behaviour — only transient backend outages are downgraded to 503."""
         mock_instance = Mock()
         mock_instance.check_domain_dns.side_effect = ValueError('unexpected internal error')
         mock_mail_client_cls.return_value = mock_instance

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -321,6 +321,21 @@ def verify_custom_domain(request: HttpRequest):
             domain.save()
 
             return JsonResponse({'success': False, **response_data})
+    except requests.RequestException as e:
+        # The Stalwart mail backend is unreachable or returned a server error
+        # (e.g. a 5xx from /api/principal/deploy). That is a transient upstream
+        # outage, not a failure of the user's domain, so we don't mark the domain
+        # FAILED — we surface it as 503 Service Unavailable so the caller knows to
+        # retry, while still reporting it to Sentry so a backend outage is alerted.
+        logging.error(f'Error verifying domain (mail backend unavailable): {e}')
+        sentry_sdk.capture_exception(e)
+        return JsonResponse(
+            {
+                'success': False,
+                'error': _('The mail backend is temporarily unavailable. Please try verifying again in a few minutes.'),
+            },
+            status=503,
+        )
     except Exception as e:
         domain.status = Domain.DomainStatus.FAILED
         domain.save()

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -232,21 +232,24 @@ def get_dns_records(request: HttpRequest):
         )
 
 
-# HTTP status at/above which a backend response counts as a transient outage.
-_TRANSIENT_BACKEND_STATUS_FLOOR = 500
+# Backend responses that indicate the operation may succeed if attempted later.
+# A numeric 5xx range would be too broad: statuses such as 501 and 505 describe
+# conditions that retrying does not normally resolve.
+_TRANSIENT_BACKEND_STATUS_CODES = frozenset({500, 502, 503, 504})
 
 
 def _is_transient_backend_error(exc: requests.RequestException) -> bool:
     """Whether a MailClient/requests failure is a transient upstream outage.
 
-    True for a 5xx response, or a connection/timeout error with no response at all
-    — cases where retrying may succeed. A non-transient response (e.g. a 4xx)
-    returns False so it is treated as a genuine failure rather than "try again".
+    True for an explicitly retryable backend response, or for a connection/timeout
+    error where no response was received. Other request failures are treated as
+    genuine errors rather than assuming that retrying will resolve them.
     """
     response = getattr(exc, 'response', None)
     if response is not None:
-        return response.status_code >= _TRANSIENT_BACKEND_STATUS_FLOOR
-    return True
+        return response.status_code in _TRANSIENT_BACKEND_STATUS_CODES
+
+    return isinstance(exc, (requests.ConnectionError, requests.Timeout))
 
 
 def _domain_verification_error(domain, exc) -> JsonResponse:
@@ -350,15 +353,9 @@ def verify_custom_domain(request: HttpRequest):
 
             return JsonResponse({'success': False, **response_data})
     except requests.RequestException as e:
+        # For transient errors, return 503 to the frontend, warn in the logs but don't call Sentry.
         if _is_transient_backend_error(e):
-            # The Stalwart mail backend is unreachable or returned a 5xx (e.g. from
-            # /api/principal/deploy). That is a transient upstream outage, not a
-            # failure of the user's domain: return a stable `mail_backend_unavailable`
-            # code with 503 so the caller retries, leave the domain status untouched
-            # instead of flipping it to FAILED, and report to Sentry so an outage is
-            # alerted. The frontend localises the code via the shared error notice.
-            logging.error(f'Error verifying domain (mail backend unavailable): {e}')
-            sentry_sdk.capture_exception(e)
+            logging.warn(f'Error verifying domain (mail backend unavailable): {e}')
             return JsonResponse(
                 {'success': False, 'code': 'mail_backend_unavailable'},
                 status=503,

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -232,6 +232,34 @@ def get_dns_records(request: HttpRequest):
         )
 
 
+# HTTP status at/above which a backend response counts as a transient outage.
+_TRANSIENT_BACKEND_STATUS_FLOOR = 500
+
+
+def _is_transient_backend_error(exc: requests.RequestException) -> bool:
+    """Whether a MailClient/requests failure is a transient upstream outage.
+
+    True for a 5xx response, or a connection/timeout error with no response at all
+    — cases where retrying may succeed. A non-transient response (e.g. a 4xx)
+    returns False so it is treated as a genuine failure rather than "try again".
+    """
+    response = getattr(exc, 'response', None)
+    if response is not None:
+        return response.status_code >= _TRANSIENT_BACKEND_STATUS_FLOOR
+    return True
+
+
+def _domain_verification_error(domain, exc) -> JsonResponse:
+    """Mark the domain FAILED and return the generic 500 verification error."""
+    domain.status = Domain.DomainStatus.FAILED
+    domain.save()
+    logging.error(f'Error verifying domain: {exc}')
+    return JsonResponse(
+        {'success': False, 'error': 'An error occurred while verifying the domain. Please try again later.'},
+        status=500,
+    )
+
+
 @login_required
 @require_http_methods(['POST'])
 @active_subscription_required
@@ -322,29 +350,23 @@ def verify_custom_domain(request: HttpRequest):
 
             return JsonResponse({'success': False, **response_data})
     except requests.RequestException as e:
-        # The Stalwart mail backend is unreachable or returned a server error
-        # (e.g. a 5xx from /api/principal/deploy). That is a transient upstream
-        # outage, not a failure of the user's domain, so we don't mark the domain
-        # FAILED — we surface it as 503 Service Unavailable so the caller knows to
-        # retry, while still reporting it to Sentry so a backend outage is alerted.
-        logging.error(f'Error verifying domain (mail backend unavailable): {e}')
-        sentry_sdk.capture_exception(e)
-        return JsonResponse(
-            {
-                'success': False,
-                'error': _('The mail backend is temporarily unavailable. Please try verifying again in a few minutes.'),
-            },
-            status=503,
-        )
+        if _is_transient_backend_error(e):
+            # The Stalwart mail backend is unreachable or returned a 5xx (e.g. from
+            # /api/principal/deploy). That is a transient upstream outage, not a
+            # failure of the user's domain: return a stable `mail_backend_unavailable`
+            # code with 503 so the caller retries, leave the domain status untouched
+            # instead of flipping it to FAILED, and report to Sentry so an outage is
+            # alerted. The frontend localises the code via the shared error notice.
+            logging.error(f'Error verifying domain (mail backend unavailable): {e}')
+            sentry_sdk.capture_exception(e)
+            return JsonResponse(
+                {'success': False, 'code': 'mail_backend_unavailable'},
+                status=503,
+            )
+        # A non-transient backend error (e.g. a 4xx) is a genuine failure.
+        return _domain_verification_error(domain, e)
     except Exception as e:
-        domain.status = Domain.DomainStatus.FAILED
-        domain.save()
-
-        logging.error(f'Error verifying domain: {e}')
-        return JsonResponse(
-            {'success': False, 'error': 'An error occurred while verifying the domain. Please try again later.'},
-            status=500,
-        )
+        return _domain_verification_error(domain, e)
 
 
 @login_required


### PR DESCRIPTION
Picks up #1123.

`verify_custom_domain()` catches everything in one broad `except Exception` and always returns a 500. But the case the issue is about — the Stalwart backend being down — isn't really an internal error on our side; it's a transient upstream outage. The client gets a flat 500 with no way to tell "the backend is having a moment, retry" from "something is actually broken", and the domain ends up marked `FAILED` for what may just be a blip.

So I split the handling: a `requests.RequestException` (what `MailClient` raises via `raise_for_status` on a backend 5xx, plus connection/timeout errors) now returns **503 Service Unavailable** with a "try again in a few minutes" message, leaves the domain status untouched instead of flipping it to `FAILED`, and still reports to Sentry so a real outage is alerted. Anything genuinely unexpected keeps the original 500 + `FAILED` behaviour.

Tests added in `mail/tests/test_views.py`:
- backend raises `requests.RequestException` → 503, domain stays `PENDING`
- an unexpected error → 500, domain marked `FAILED`

Local run: `VerifyCustomDomainTestCase` is green (8 tests), `ruff check` clean.

One thing worth a maintainer's eye: I deliberately stopped marking the domain `FAILED` on the transient path, since telling the user to retry while also marking it `FAILED` felt contradictory. Happy to revert that part if you'd rather keep the status change.

Closes #1123.
