### PR TITLE
Start to enforce pathlib over os.path.join

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,10 @@ quote-style = "single"
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # Enable flagging print (T201)
+# Require pathlib path joining instead of os.path.join (PTH118).
 # Require f-strings for interpolation instead of printf-style formatting (UP031)
 # or `.format` calls (UP032).
-select = ["E", "F", "T201", "UP031", "UP032"]
+select = ["E", "F", "T201", "PTH118", "UP031", "UP032"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
We are already compliant with the rule. This prevents regressions.

Ref: https://docs.astral.sh/ruff/rules/os-path-join/

## What changed and why?

This is a follow-up to an earlier PR where we could have saved some time
if we had this automated linting enforcement.

## Limitations and Notes

The code base was already compliant with the rule, so no changes
were required there.

Like related rules, we don't enforce this rule via the test suite, but we do enforce in CI.


## Applicable Issues

* https://github.com/thunderbird/thunderbird-accounts/pull/1169#discussion_r3716051460

