### PR TITLE
Fix bug with log level

### DIFF
--- a/src/thunderbird_accounts/telemetry/tasks.py
+++ b/src/thunderbird_accounts/telemetry/tasks.py
@@ -19,7 +19,7 @@ def _retry_or_report(task, exc, message):
     Keeps transient PostHog/DB/Redis outages from spamming Sentry with one event
     per retry attempt while still surfacing persistent failures.
     """
-    logger.error(f'{message}: {exc}')
+    logger.warning(f'{message}: {exc}')
     if task.request.retries >= task.max_retries:
         sentry_sdk.capture_exception(exc)
     raise task.retry(exc=exc)


### PR DESCRIPTION
The intent here was to not notify Sentry until retries were exhausted,
but logs at the "error" level triggered Sentry exceptions anyway.
Downgrade the log level to Warning resolves that.

Fixes: Sentry#THUNDERBIRD-ACCOUNTS-7Z

## References

 * Sentry issue which shows trigger from log level error here: https://thunderbird.sentry.io/issues/7496109276/?alert_rule_id=15849274&alert_timestamp=1785778317551&alert_type=email&environment=prod&notification_uuid=75687b49-013b-44f9-aad8-7bec525351f3&project=4508965616680960&referrer=alert_email

## QA Log

- Confirmed that "warning" is the correct log level name
- Analyzed Sentry SDK to confirm that errors starting at log-level error trigger calls.
