### PR TITLE
Clarify duplicate email alias errors

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -7,6 +7,7 @@ import requests
 from unittest.mock import patch, Mock
 
 from django.conf import settings
+from django.db import IntegrityError
 from django.test import TestCase, Client as RequestClient, override_settings, RequestFactory
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -879,7 +880,7 @@ class AddEmailAliasTestCase(TestCase):
             self.assertEqual(response.status_code, 403)
             self.assertEqual(
                 json.loads(response.content.decode()),
-                {'success': False, 'error': _('You cannot use this email address.')},
+                {'success': False, 'error': _('This email address is already in use. Try another one.')},
             )
 
     def test_failed_catch_all_with_shared_domain(self):
@@ -1038,7 +1039,7 @@ class AddEmailAliasTestCase(TestCase):
             self.assertEqual(response.status_code, 403)
             self.assertEqual(
                 json.loads(response.content.decode()),
-                {'success': False, 'error': _('You cannot use this email address.')},
+                {'success': False, 'error': _('This email address is already in use. Try another one.')},
             )
 
     def test_already_used_alias_case_sensitive(self):
@@ -1058,8 +1059,42 @@ class AddEmailAliasTestCase(TestCase):
             self.assertEqual(response.status_code, 403)
             self.assertEqual(
                 json.loads(response.content.decode()),
-                {'success': False, 'error': _('You cannot use this email address.')},
+                {'success': False, 'error': _('This email address is already in use. Try another one.')},
             )
+
+    @patch('thunderbird_accounts.mail.views.is_address_taken', return_value=False)
+    @patch('thunderbird_accounts.mail.views.Email.objects.get_or_create')
+    def test_alias_found_during_creation_uses_descriptive_error(self, mock_get_or_create, _mock_is_address_taken):
+        """Ensure a duplicate found after the availability check returns the same clear error."""
+        mock_get_or_create.return_value = (Mock(), False)
+
+        response = self.client.post(
+            reverse('add_email_alias'),
+            data={'email-alias': 'duplicate', 'domain': settings.PRIMARY_EMAIL_DOMAIN},
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content.decode()),
+            {'success': False, 'error': _('This email address is already in use. Try another one.')},
+        )
+
+    @patch('thunderbird_accounts.mail.views.is_address_taken', return_value=False)
+    @patch('thunderbird_accounts.mail.views.Email.objects.get_or_create', side_effect=IntegrityError)
+    def test_alias_creation_race_uses_descriptive_error(self, _mock_get_or_create, _mock_is_address_taken):
+        """Ensure a duplicate-address race returns the same clear error."""
+        response = self.client.post(
+            reverse('add_email_alias'),
+            data={'email-alias': 'duplicate', 'domain': settings.PRIMARY_EMAIL_DOMAIN},
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.content.decode()),
+            {'success': False, 'error': _('This email address is already in use. Try another one.')},
+        )
 
     @override_settings(ALLOWED_EMAIL_DOMAINS=['example.org', 'example.com'])
     @override_settings(MIN_CUSTOM_DOMAIN_ALIAS_LENGTH=3)
@@ -1534,4 +1569,3 @@ class AppointmentCalDAVSetupTestCase(TestCase):
         payload = json.loads(response.content.decode())
         self.assertFalse(payload['success'])
         self.assertEqual(payload['error'], _('An error has occurred while setting up the Appointment CalDAV.'))
-

--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -44,6 +44,8 @@ from thunderbird_accounts.mail import tasks as mail_tasks
 from thunderbird_accounts.mail import utils
 from thunderbird_accounts.subscription.decorators import active_subscription_required
 
+EMAIL_ADDRESS_IN_USE_ERROR = _('This email address is already in use. Try another one.')
+
 
 def _critical_errors_from_stale_dns_records(stale_dns_records: list[dict]) -> list[DomainVerificationErrors]:
     stale_record_codes = {record.get('code') for record in stale_dns_records}
@@ -484,8 +486,11 @@ def add_email_alias(request: HttpRequest):
     if (not is_catch_all and not email_alias) or not domain:
         return JsonResponse({'success': False, 'error': _('Email alias and domain are required.')}, status=400)
 
-    if (not is_catch_all and not is_custom_domain and is_reserved(email_alias)) or is_address_taken(full_email_alias):
+    if not is_catch_all and not is_custom_domain and is_reserved(email_alias):
         return JsonResponse({'success': False, 'error': _('You cannot use this email address.')}, status=403)
+
+    if is_address_taken(full_email_alias):
+        return JsonResponse({'success': False, 'error': EMAIL_ADDRESS_IN_USE_ERROR}, status=403)
 
     if (
         domain not in request.user.domains.values_list('name', flat=True)
@@ -528,13 +533,13 @@ def add_email_alias(request: HttpRequest):
         if not created:
             logging.info('Alias creation found an existing local email record for the requested address')
             return JsonResponse(
-                {'success': False, 'error': _('This email address is not available.')},
+                {'success': False, 'error': EMAIL_ADDRESS_IN_USE_ERROR},
                 status=400,
             )
     except IntegrityError:
         logging.info('Alias creation hit a local duplicate-address race')
         return JsonResponse(
-            {'success': False, 'error': _('This email address is not available.')},
+            {'success': False, 'error': EMAIL_ADDRESS_IN_USE_ERROR},
             status=400,
         )
     except Exception as e:


### PR DESCRIPTION
## What changed?

- Return `This email address is already in use. Try another one.` when alias creation finds an address that is already taken.
- Use the same copy for the pre-check, an existing record discovered during creation, and the duplicate-address race path.
- Keep the generic response for reserved addresses so this change does not expose which names are reserved.
- Add regression coverage for the normal duplicate cases and both creation-time fallback paths.

This pull request was produced by OpenAI Codex operating as an AI coding agent. The agent performed the issue and repository analysis, implementation, test updates, diff review, and local verification autonomously; no human-authored code is included.

## Why?

The current generic error leaves users unsure why an alias cannot be created and is generating support questions. This gives a specific, actionable explanation when the address is already in use.

## Limitations and Notes

- Existing HTTP status codes are unchanged; this is a response-copy change.
- Reserved addresses deliberately keep the existing generic error.

Verification:

- `ruff check` (all 158 Python files)
- `ruff format --check` (all 158 Python files)
- `npm run build`
- `npm run build-theme`
- mail test suite: 180 passed
- full Django test suite: 525 passed

## Applicable Issues

Closes #1198

## Screenshots

Not included: this changes backend response copy only. The issue contains a screenshot of the previous message.
