### PR TITLE
Show tooltip upon clicking the Connect Now button in Mail Dashboard

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -114,6 +114,8 @@
               "connectTitle": "Connect Thunderbird Desktop",
               "connectDescription": "Add Thundermail to Thunderbird Desktop automatically.",
               "connectButton": "Connect now",
+              "connectButtonTooltip": "Thunderbird Desktop did not open? Please {downloadLink} and click 'Connect now' again.",
+              "connectButtonTooltipDownloadLink": "download and install the app",
               "downloadTitle": "Download Thunderbird Desktop",
               "downloadDescription": "We recommend using the desktop application for the best experience.",
               "downloadButton": "Download",

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -32,7 +32,10 @@ const showConnectNow = isWaffleFlagActive(WAFFLE_FLAG.SHOW_CONNECT_NOW);
 async function handleConnectClick() {
   isConnecting.value = true;
   error.value = null;
-  isTooltipVisible.value = true;
+
+  setTimeout(() => {
+    isTooltipVisible.value = true;
+  }, 3000);
 
   try {
     // The API on TB Desktop side requires a token to be passed

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { onClickOutside, onKeyStroke } from '@vueuse/core';
 import { PhArrowSquareOut, PhDownloadSimple } from '@phosphor-icons/vue';
-import { PrimaryButton } from '@thunderbirdops/services-ui';
+import { PrimaryButton, ToolTip } from '@thunderbirdops/services-ui';
 import ActionCard from '@/components/ActionCard.vue';
 import { DOWNLOAD_THUNDERBIRD_DESKTOP_URL } from '@/defines';
 import { WAFFLE_FLAG } from '@/types';
@@ -11,6 +12,17 @@ import { isWaffleFlagActive } from '@/utils';
 const { t } = useI18n();
 const isConnecting = ref(false);
 const error = ref<string | null>(null);
+const isTooltipVisible = ref(false);
+
+const connectAction = useTemplateRef('connectAction');
+
+onClickOutside(connectAction, () => {
+  isTooltipVisible.value = false;
+});
+
+onKeyStroke('Escape', () => {
+  isTooltipVisible.value = false;
+});
 
 // From Stalwart, primary email is always the first email address in the list
 const primaryEmail = window._page?.emailAddresses?.[0] || '';
@@ -20,6 +32,7 @@ const showConnectNow = isWaffleFlagActive(WAFFLE_FLAG.SHOW_CONNECT_NOW);
 async function handleConnectClick() {
   isConnecting.value = true;
   error.value = null;
+  isTooltipVisible.value = true;
 
   try {
     // The API on TB Desktop side requires a token to be passed
@@ -59,14 +72,32 @@ export default {
           <ph-arrow-square-out :size="20" />
         </template>
         <template #action>
-          <primary-button
-            size="small"
-            :disabled="isConnecting"
-            @click="handleConnectClick"
-            class="button-link"
-          >
-            {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButton') }}
-          </primary-button>
+          <div class="connect-action" ref="connectAction">
+            <primary-button
+              size="small"
+              :disabled="isConnecting"
+              :aria-expanded="isTooltipVisible"
+              aria-controls="connect-now-tooltip"
+              @click="handleConnectClick"
+              class="button-link"
+            >
+              {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButton') }}
+            </primary-button>
+            <tool-tip
+              v-if="isTooltipVisible"
+              id="connect-now-tooltip"
+              role="status"
+              :alt="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButtonTooltip')"
+            >
+              <i18n-t keypath="views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButtonTooltip" tag="p">
+                <template #downloadLink>
+                  <a :href="DOWNLOAD_THUNDERBIRD_DESKTOP_URL" target="_blank" rel="noopener noreferrer">
+                    {{ t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.connectButtonTooltipDownloadLink') }}
+                  </a>
+                </template>
+              </i18n-t>
+            </tool-tip>
+          </div>
         </template>
       </action-card>
     </template>
@@ -109,6 +140,27 @@ export default {
 
 .button-link {
   height: 2rem;
+}
+
+.connect-action {
+  position: relative;
+  display: inline-flex;
+}
+
+.connect-action :deep(.tooltip) {
+  top: auto;
+  bottom: calc(100% + 1rem);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 17rem;
+
+  p {
+    font-size: 0.75rem;
+  }
+
+  a {
+    color: var(--colour-ti-highlight);
+  }
 }
 
 .error-message {


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

Added a tooltip on click of the `Connect Now` button for better feedback in case TB Desktop is not installed.

To test this, please add the `show-connect-now` to the django-waffle flags in Django Admin.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

In case the user does not have TB Desktop installed, the button feels broken as there's no feedback whatsoever of clicking it.

## Limitations and Notes

<!--
  Optional. List any known gaps, edge cases, or follow up work.
-->

AFAIK, there's no way to reliably catch a failure on the custom mapping protocol so showing the tooltip simply upon click seems to be the best course of action here.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Closes https://github.com/thunderbird/thunderbird-accounts/issues/1209

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->

<img width="996" height="362" alt="image" src="https://github.com/user-attachments/assets/5fe5953b-9f96-4952-9745-63282a45a879" />
