### PR TITLE
Fix CI on the v0.16 JMAP branch: ruff format + offline test setUp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,8 +88,8 @@ ZENDESK_FORM_BROWSER_FIELD_ID=
 ZENDESK_FORM_OS_FIELD_ID=
 
 # These can be the same if they're configured within stalwart as the same port
-STALWART_BASE_JMAP_URL=http://stalwart:8081
-STALWART_BASE_API_URL=http://stalwart:8080
+STALWART_BASE_JMAP_URL=http://stalwart_legacy:8081
+STALWART_BASE_API_URL=http://stalwart_legacy:8080
 # Bearer token auth (prefixed with api_) or basic auth (username:password base64'd)
 # Defaults to admin:accounts
 STALWART_API_AUTH_STRING=YWRtaW46YWNjb3VudHM=

--- a/.env.test
+++ b/.env.test
@@ -82,8 +82,8 @@ ZENDESK_FORM_BROWSER_FIELD_ID=
 ZENDESK_FORM_OS_FIELD_ID=
 
 # This URL should not be called without a mock
-STALWART_BASE_JMAP_URL=http://stalwart:8081
-STALWART_BASE_API_URL=http://stalwart:8080
+STALWART_BASE_JMAP_URL=http://stalwart_legacy:8081
+STALWART_BASE_API_URL=http://stalwart_legacy:8080
 STALWART_API_KEY=this-is-mocked
 STALWART_API_AUTH_METHOD=basic
 

--- a/boot-docker-deps.sh
+++ b/boot-docker-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose up postgres redis kcpostgres keycloak stalwart mailpit
+docker compose up postgres redis kcpostgres keycloak stalwart_legacy mailpit

--- a/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
@@ -37,6 +37,23 @@ class MockJMapClient(JMAPClient):
         raise NotImplementedError('Monkeypatch me!')
 
 
+def build_admin_client() -> MailClientAdminJMAP:
+    """Build a MailClientAdminJMAP that never touches the network.
+
+    ``MailClientAdminJMAP.__init__`` builds a real ``JMAPClient`` and eagerly fetches the session
+    resource over HTTP, so patch ``_get_user_client`` for the duration of construction to hand back
+    a ``MockJMapClient`` (which reads the session from a fixture) instead.
+    """
+
+    def _mock_user_client(self, *args, **kwargs) -> MockJMapClient:
+        client = MockJMapClient('http://stalwart.local', 'admin', 'admin')
+        client.get_session()
+        return client
+
+    with patch.object(MailClientAdminJMAP, '_get_user_client', _mock_user_client):
+        return MailClientAdminJMAP()
+
+
 @override_settings(
     STALWART_BASE_API_URL='http://stalwart.test',
     STALWART_API_AUTH_STRING='secret',
@@ -48,16 +65,15 @@ class MockJMapClient(JMAPClient):
 )
 class TestCheckDomainDNS(TestMailClientCheckDomainDNS):
     def setUp(self):
-        self.mail_client = MailClientAdminJMAP()
+        self.mail_client = build_admin_client()
         self.domain = 'example.com'
         self.expected_host = 'mail.test.com'
 
 
 class TestCreateDkim(SimpleTestCase):
     def setUp(self):
-        self.mail_client = MailClientAdminJMAP()
+        self.mail_client = build_admin_client()
         self.mail_client.preflight_check = MagicMock()
-        self.mail_client.client = MockJMapClient('http://stalwart.local', 'admin', 'admin')
         self.domain = 'example.com'
         self.expected_host = 'mail.test.com'
 


### PR DESCRIPTION
Stacked on #1131 (base = `features/628-v016-stalwart-upgrade`). Makes that branch's CI green. Default (flag-off) runtime behaviour is unchanged.

Three fixes:

1. **ruff format** — `mail_client_jmap.py`: `#with` → `# with`.
2. **JMAP unit tests** — all 10 errored because `MailClientAdminJMAP()` fetches a JMAP session over HTTP in `__init__`, before the test's mock was installed (and CI runs no Stalwart). Added `build_admin_client()` to construct it against a mocked session.
3. **e2e `/health` 500** — flag-off `get_telemetry()` hit `http://stalwart:8080`, but #1131 renamed the service to `stalwart_legacy`; the unresolvable host raised `ConnectionError`, which `__check_stalwart` doesn't catch. Repointed `STALWART_BASE_API_URL`/`STALWART_BASE_JMAP_URL` at `stalwart_legacy` (`.env.example`, `.env.test`) and fixed `boot-docker-deps.sh`.

Verified on the full compose stack: both health gates → 200, ruff clean, 533 tests OK.

Left for follow-up: `stalwart_new` still can't boot in CI (unseeded `main.db`/`config.json`), but nothing on the flag-off path uses it.
