### PR TITLE
Fix ruff format failure on main

### DIFF
--- a/src/thunderbird_accounts/mail/tests/test_views.py
+++ b/src/thunderbird_accounts/mail/tests/test_views.py
@@ -1534,4 +1534,3 @@ class AppointmentCalDAVSetupTestCase(TestCase):
         payload = json.loads(response.content.decode())
         self.assertFalse(payload['success'])
         self.assertEqual(payload['error'], _('An error has occurred while setting up the Appointment CalDAV.'))
-


### PR DESCRIPTION
`main` has been red on `validate` since #720, which added a trailing blank line to `test_views.py`. `ruff format --check` rejects it.

CI evaluates `refs/pull/N/merge`, so every open PR inherits the failure.

Verified in-container: `ruff check` clean, `ruff format --check` clean (150 files), 523 tests OK.
