### PR TITLE
fix(jmap): keep the configured origin when the session advertises another host

### DIFF
--- a/d_get_session.json
+++ b/d_get_session.json
@@ -1,0 +1,245 @@
+{
+  "capabilities": {
+    "urn:ietf:params:jmap:core": {
+      "maxSizeUpload": 50000000,
+      "maxConcurrentUpload": 4,
+      "maxSizeRequest": 10000000,
+      "maxConcurrentRequests": 4,
+      "maxCallsInRequest": 16,
+      "maxObjectsInGet": 500,
+      "maxObjectsInSet": 500,
+      "collationAlgorithms": [
+        "i;ascii-numeric",
+        "i;ascii-casemap",
+        "i;unicode-casemap"
+      ]
+    },
+    "urn:ietf:params:jmap:sieve": {
+      "implementation": "Stalwart v1.0.0"
+    },
+    "urn:ietf:params:jmap:websocket": {
+      "url": "wss://stalwart.local/jmap/ws",
+      "supportsPush": true
+    },
+    "urn:ietf:params:jmap:mail": {},
+    "urn:ietf:params:jmap:calendars": {},
+    "urn:ietf:params:jmap:calendars:parse": {},
+    "urn:ietf:params:jmap:contacts": {},
+    "urn:ietf:params:jmap:contacts:parse": {},
+    "urn:ietf:params:jmap:filenode": {},
+    "urn:ietf:params:jmap:principals": {},
+    "urn:ietf:params:jmap:principals:availability": {},
+    "urn:ietf:params:jmap:submission": {},
+    "urn:ietf:params:jmap:vacationresponse": {},
+    "urn:ietf:params:jmap:blob": {},
+    "urn:ietf:params:jmap:quota": {},
+    "urn:ietf:params:jmap:emailpush": {}
+  },
+  "accounts": {
+    "d333333": {
+      "name": "admin",
+      "isPersonal": true,
+      "isReadOnly": false,
+      "accountCapabilities": {
+        "urn:ietf:params:jmap:mail": {
+          "maxMailboxesPerEmail": null,
+          "maxMailboxDepth": 10,
+          "maxSizeMailboxName": 255,
+          "maxSizeAttachmentsPerEmail": 50000000,
+          "emailQuerySortOptions": [
+            "receivedAt",
+            "size",
+            "from",
+            "to",
+            "subject",
+            "sentAt",
+            "hasKeyword",
+            "allInThreadHaveKeyword",
+            "someInThreadHaveKeyword"
+          ],
+          "mayCreateTopLevelMailbox": true
+        },
+        "urn:ietf:params:jmap:submission": {
+          "maxDelayedSend": 2592000,
+          "submissionExtensions": {
+            "FUTURERELEASE": [],
+            "SIZE": [],
+            "DSN": [],
+            "DELIVERYBY": [],
+            "MT-PRIORITY": [
+              "MIXER"
+            ],
+            "REQUIRETLS": []
+          }
+        },
+        "urn:ietf:params:jmap:vacationresponse": {},
+        "urn:ietf:params:jmap:contacts": {
+          "maxAddressBooksPerCard": null,
+          "mayCreateAddressBook": true
+        },
+        "urn:ietf:params:jmap:contacts:parse": {},
+        "urn:ietf:params:jmap:calendars": {
+          "maxCalendarsPerEvent": null,
+          "minDateTime": "0001-01-01T00:00:00Z",
+          "maxDateTime": "9999-12-31T23:59:59Z",
+          "maxExpandedQueryDuration": "P52W1D",
+          "maxParticipantsPerEvent": 20,
+          "mayCreateCalendar": true
+        },
+        "urn:ietf:params:jmap:calendars:parse": {},
+        "urn:ietf:params:jmap:websocket": {},
+        "urn:ietf:params:jmap:sieve": {
+          "maxSizeScriptName": 512,
+          "maxSizeScript": 102400,
+          "maxNumberScripts": 100,
+          "maxNumberRedirects": 1,
+          "sieveExtensions": [
+            "body",
+            "comparator-elbonia",
+            "comparator-i;ascii-casemap",
+            "comparator-i;ascii-numeric",
+            "comparator-i;octet",
+            "convert",
+            "copy",
+            "date",
+            "duplicate",
+            "editheader",
+            "enclose",
+            "encoded-character",
+            "enotify",
+            "envelope",
+            "envelope-deliverby",
+            "envelope-dsn",
+            "environment",
+            "ereject",
+            "extlists",
+            "extracttext",
+            "fcc",
+            "fileinto",
+            "foreverypart",
+            "ihave",
+            "imap4flags",
+            "imapsieve",
+            "include",
+            "index",
+            "mailbox",
+            "mailboxid",
+            "mboxmetadata",
+            "mime",
+            "redirect-deliverby",
+            "redirect-dsn",
+            "regex",
+            "reject",
+            "relational",
+            "replace",
+            "servermetadata",
+            "spamtest",
+            "spamtestplus",
+            "special-use",
+            "subaddress",
+            "vacation",
+            "vacation-seconds",
+            "variables",
+            "virustest"
+          ],
+          "notificationMethods": [
+            "mailto"
+          ],
+          "externalLists": null
+        },
+        "urn:ietf:params:jmap:blob": {
+          "maxSizeBlobSet": 7499488,
+          "maxDataSources": 16,
+          "supportedTypeNames": [
+            "Email",
+            "Thread",
+            "SieveScript"
+          ],
+          "supportedDigestAlgorithms": [
+            "sha",
+            "sha-256",
+            "sha-512"
+          ]
+        },
+        "urn:ietf:params:jmap:quota": {},
+        "urn:ietf:params:jmap:principals": {
+          "currentUserPrincipalId": "d333333"
+        },
+        "urn:ietf:params:jmap:principals:availability": {
+          "maxAvailabilityDuration": "P52W1D"
+        },
+        "urn:ietf:params:jmap:filenode": {
+          "maxFileNodeDepth": null,
+          "maxSizeFileNodeName": 255,
+          "forbiddenNameChars": "/<>:\"\\|?*",
+          "forbiddenNodeNames": [
+            ".",
+            "..",
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM0",
+            "COM1",
+            "COM2",
+            "COM3",
+            "COM4",
+            "COM5",
+            "COM6",
+            "COM7",
+            "COM8",
+            "COM9",
+            "LPT0",
+            "LPT1",
+            "LPT2",
+            "LPT3",
+            "LPT4",
+            "LPT5",
+            "LPT6",
+            "LPT7",
+            "LPT8",
+            "LPT9"
+          ],
+          "fileNodeQuerySortOptions": [
+            "name",
+            "size",
+            "nodeType"
+          ],
+          "mayCreateTopLevelFileNode": true,
+          "caseInsensitiveNames": false,
+          "webTrashUrl": null,
+          "webUrlTemplate": null,
+          "webWriteUrlTemplate": null
+        },
+        "urn:ietf:params:jmap:mail:share": {},
+        "urn:stalwart:jmap": {},
+        "urn:ietf:params:jmap:emailpush": {}
+      }
+    }
+  },
+  "primaryAccounts": {
+    "urn:ietf:params:jmap:mail": "d333333",
+    "urn:ietf:params:jmap:submission": "d333333",
+    "urn:ietf:params:jmap:vacationresponse": "d333333",
+    "urn:ietf:params:jmap:contacts": "d333333",
+    "urn:ietf:params:jmap:contacts:parse": "d333333",
+    "urn:ietf:params:jmap:calendars": "d333333",
+    "urn:ietf:params:jmap:calendars:parse": "d333333",
+    "urn:ietf:params:jmap:websocket": "d333333",
+    "urn:ietf:params:jmap:sieve": "d333333",
+    "urn:ietf:params:jmap:blob": "d333333",
+    "urn:ietf:params:jmap:quota": "d333333",
+    "urn:ietf:params:jmap:principals": "d333333",
+    "urn:ietf:params:jmap:principals:availability": "d333333",
+    "urn:ietf:params:jmap:filenode": "d333333",
+    "urn:ietf:params:jmap:mail:share": "d333333",
+    "urn:stalwart:jmap": "d333333",
+    "urn:ietf:params:jmap:emailpush": "d333333"
+  },
+  "username": "admin",
+  "apiUrl": "https://stalwart.internal.example:8443/jmap/",
+  "downloadUrl": "https://stalwart.local/jmap/download/{accountId}/{blobId}/{name}?accept={type}",
+  "uploadUrl": "https://stalwart.local/jmap/upload/{accountId}/",
+  "eventSourceUrl": "https://stalwart.local/jmap/eventsource/?types={types}&closeafter={closeafter}&ping={ping}",
+  "state": "c682b0ec"
+}

--- a/src/thunderbird_accounts/mail/clients/jmap_client.py
+++ b/src/thunderbird_accounts/mail/clients/jmap_client.py
@@ -1,6 +1,7 @@
 import logging
 from base64 import b64encode
 from typing import Literal
+from urllib.parse import urljoin, urlparse
 from thunderbird_accounts.mail.types.jmap import SessionResource, JMapRequest, Invocation, JMapResponse
 import enum
 import json
@@ -57,7 +58,11 @@ class JMAPClient:
             fh.write(json.dumps(session.model_dump(), indent=2))
         if not self.session:
             raise RuntimeError('Failed to get session')
-        self.api_url = session.api_url
+        # Take the PATH from the session but keep the ORIGIN we were configured with, so a
+        # server can never redirect this client (and its credentials) to another host. Stalwart
+        # advertises its public URL here, which is not necessarily the address we should use --
+        # e.g. split-horizon DNS, or an internal-only deployment reached by Service DNS.
+        self.api_url = urljoin(self.base_url, urlparse(session.api_url).path)
         return session
 
     def get_account_id(self) -> str:

--- a/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
@@ -133,3 +133,50 @@ class TestCreateDkim(SimpleTestCase):
 
         self.assertIsNotNone(response_data)
         self.assertEqual(3, requests_mock.call_count)
+
+
+class TestSessionApiUrlOrigin(SimpleTestCase):
+    """The session resource must not be able to relocate the client to another host.
+
+    Stalwart advertises its PUBLIC url as ``apiUrl``. That is frequently not the address this
+    app should use (split-horizon DNS, an internal-only deployment reached by Service DNS), and
+    following it blindly sends the configured admin credential to a host we never configured.
+    """
+
+    def _session(self, api_url: str) -> dict:
+        fixture_path = Path(__file__).parent.parent.joinpath(Path('fixtures') / 'jmap_get_session.json')
+        with open(fixture_path, 'r') as fh:
+            data = json.loads(fh.read())
+        data['apiUrl'] = api_url
+        return data
+
+    @patch('thunderbird_accounts.mail.clients.jmap_client.requests.get')
+    def _api_url_for(self, advertised: str, requests_get: MagicMock) -> str:
+        response = MagicMock()
+        response.json.return_value = self._session(advertised)
+        requests_get.return_value = response
+
+        client = JMAPClient('https://stalwart.internal.example:8443', 'admin', 'secret')
+        client.get_session()
+        return client.api_url
+
+    def test_offhost_api_url_is_not_followed(self):
+        """An advertised url on a DIFFERENT host keeps our configured origin, path preserved."""
+        self.assertEqual(
+            'https://stalwart.internal.example:8443/jmap/',
+            self._api_url_for('https://mail.public.example/jmap/'),
+        )
+
+    def test_nonstandard_path_is_preserved(self):
+        """We take the PATH from the server, so a non-default JMAP path still works."""
+        self.assertEqual(
+            'https://stalwart.internal.example:8443/custom/jmap/api',
+            self._api_url_for('https://mail.public.example/custom/jmap/api'),
+        )
+
+    def test_matching_host_is_unchanged(self):
+        """When the server already advertises our configured host, nothing changes."""
+        self.assertEqual(
+            'https://stalwart.internal.example:8443/jmap/',
+            self._api_url_for('https://stalwart.internal.example:8443/jmap/'),
+        )


### PR DESCRIPTION
Fixes #1216.

`JMAPClient` dropped `STALWART_JMAP_API_URL` after the handshake — `get_session()` set `self.api_url = session.api_url`, and `request()` used only that. So the setting decided where we *asked* for a url, not where we sent requests, and a server could point the client (and its credentials) at any host.

## Change

```python
self.api_url = urljoin(self.base_url, urlparse(session.api_url).path)
```

Path from the session, origin from config. Non-default JMAP paths still work; off-host redirection becomes impossible.

Three tests: off-host advertised url, non-default path, already-matching host.

## Not included

Left out to keep this reviewable, both described in #1216: hardcoded `verify_ssl = False` (ignores `VERIFY_PRIVATE_LINK_SSL`), and the `./d_get_session.json` debug write.