### PR TITLE
Upgraded sqlparse from 0.5.5 to 0.6.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "cloudflare>=5.2.0",
     # CVE pins
     "idna>=3.15", # CVE-2026-45409 fix
+    "sqlparse>=0.6.0", # CVE fixes
     "django-waffle>=5.0.0",
     "pydantic[email,timezone]>=2.13.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1766,11 +1766,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]
@@ -1819,6 +1819,7 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "servestatic" },
+    { name = "sqlparse" },
     { name = "ua-parser" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1890,6 +1891,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
     { name = "sphinxcontrib-django", marker = "extra == 'docs'" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'" },
+    { name = "sqlparse", specifier = ">=0.6.0" },
     { name = "ua-parser", specifier = ">=1.0.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.48.0" },
 ]


### PR DESCRIPTION
## Changes

- Added `sqlparse>=0.6.0` as a security floor

## Application issues

The four open Dependabot alerts are #154–#157: three high-severity DoS issues and one medium-severity output-format injection issue.

## QA Log


- The only compatibility-breaking requirement in [sqlparse 0.6.0’s changelog](https://github.com/andialbrecht/sqlparse/blob/0.6.0/CHANGELOG) is dropping Python 3.8/3.9. This project requires Python 3.12+, and its container uses Python 3.13.
- The application does not directly import sqlparse or call `parse()`, `format()`, `split()`, or the affected output formats.
- Django 6.0.8 declares `sqlparse>=0.5.0`, so 0.6.0 satisfies its supported dependency range.

- Confirmed the rebuilt accounts image installed new version.
- Successfully tests deps install and frontend build.
- Ran all backend tests.
- Django system checks reported no issues.
- `uv lock --check` passed.
- `git diff --check` passed.
