### PR TITLE
fix(jmap): review follow-ups for the v0.16 JMAP work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,7 +100,12 @@ STALWART_DKIM_STAGE_MANAGEMENT_ENABLED=false
 
 # Use the v0.16 jmap api instead of the pre-v0.16 rest based api
 STALWART_ADMIN_API_USE_JMAP=false
-STALWART_JMAP_API_URL=http://stalwart_new:8080
+# Must match the origin Stalwart ADVERTISES as apiUrl, or the client fails closed with
+# JMapOriginMismatchError. The dev container advertises https://stalwart_new (port 443,
+# published as 8443 on the host); reaching it on :8080 is a different origin.
+STALWART_JMAP_API_URL=https://stalwart_new
+# Dev Stalwart serves a self-signed cert, and verify_ssl now comes from this setting.
+VERIFY_PRIVATE_LINK_SSL=false
 STALWART_JMAP_API_AUTH_USER=admin
 STALWART_JMAP_API_AUTH_SECRET=admin
 STALWART_JMAP_API_AUTH_METHOD=basic

--- a/.env.test
+++ b/.env.test
@@ -89,7 +89,12 @@ STALWART_API_AUTH_METHOD=basic
 
 # Use the v0.16 jmap api instead of the pre-v0.16 rest based api
 STALWART_ADMIN_API_USE_JMAP=false
-STALWART_JMAP_API_URL=http://stalwart_new:8080
+# Must match the origin Stalwart ADVERTISES as apiUrl, or the client fails closed with
+# JMapOriginMismatchError. The dev container advertises https://stalwart_new (port 443,
+# published as 8443 on the host); reaching it on :8080 is a different origin.
+STALWART_JMAP_API_URL=https://stalwart_new
+# Dev Stalwart serves a self-signed cert, and verify_ssl now comes from this setting.
+VERIFY_PRIVATE_LINK_SSL=false
 STALWART_JMAP_API_AUTH_USER=admin
 STALWART_JMAP_API_AUTH_SECRET=admin
 STALWART_JMAP_API_AUTH_METHOD=basic

--- a/src/thunderbird_accounts/mail/clients/jmap_client.py
+++ b/src/thunderbird_accounts/mail/clients/jmap_client.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit
 import requests
 from pydantic import ValidationError
 
-from thunderbird_accounts.mail.exceptions import InvalidJMapResponseError
+from thunderbird_accounts.mail.exceptions import InvalidJMapResponseError, JMapOriginMismatchError
 from thunderbird_accounts.mail.types.jmap import Invocation, JMapRequest, JMapResponse, SessionResource
 
 
@@ -68,7 +68,16 @@ class JMAPClient:
                 'Content-Type': 'application/json',
                 'Authorization': self._authorization_value(),
             },
-            allow_redirects=False,
+            # RFC 8620 2.2 defines the session resource as fetched "following any redirects",
+            # and Stalwart v0.16 ALWAYS 307s /.well-known/jmap -> /jmap/session with an empty
+            # body. With redirects disabled, raise_for_status() is a no-op on 3xx and the empty
+            # body reaches .json(), raising an untyped JSONDecodeError before any of this class's
+            # error handling runs. Redirects stay enabled here; the destination is still pinned,
+            # because the origin check below runs against the resulting session.
+            #
+            # This does NOT relax request(), where allow_redirects=False is correct: a 307/308
+            # replays the POST body (DKIM private keys, app passwords) at the new host.
+            allow_redirects=True,
             verify=self.verify_ssl,
             timeout=self.timeout,
         )
@@ -78,7 +87,7 @@ class JMAPClient:
         except ValidationError as ex:
             raise InvalidJMapResponseError(ex) from ex
         if self._origin(session.api_url) != self._origin(self.base_url):
-            raise ValueError('JMAP apiUrl origin does not match configured base URL')
+            raise JMapOriginMismatchError(session.api_url, self.base_url)
         self.session = session
         if not self.session:
             raise RuntimeError('Failed to get session')

--- a/src/thunderbird_accounts/mail/clients/jmap_client.py
+++ b/src/thunderbird_accounts/mail/clients/jmap_client.py
@@ -86,11 +86,18 @@ class JMAPClient:
             session = SessionResource.model_validate(r.json())
         except ValidationError as ex:
             raise InvalidJMapResponseError(ex) from ex
+        return self._accept_session(session)
+
+    def _accept_session(self, session: SessionResource) -> SessionResource:
+        """Validate and store a fetched session.
+
+        Split out of get_session() so the origin check has exactly one home: any test double or
+        future cache that populates a session must come through here, rather than reimplementing
+        the assignment and silently bypassing the pin.
+        """
         if self._origin(session.api_url) != self._origin(self.base_url):
             raise JMapOriginMismatchError(session.api_url, self.base_url)
         self.session = session
-        if not self.session:
-            raise RuntimeError('Failed to get session')
         self.api_url = session.api_url
         return session
 

--- a/src/thunderbird_accounts/mail/clients/mail_client_jmap.py
+++ b/src/thunderbird_accounts/mail/clients/mail_client_jmap.py
@@ -58,7 +58,16 @@ class BaseJMAP(ABC):
     def _get_user_client(
         self, username, user_token, auth_type: JMAPClient.AUTH_TYPES = JMAPClient.AUTH_TYPES.BEARER
     ) -> JMAPClient:
-        client = JMAPClient(settings.STALWART_JMAP_API_URL, username, user_token, auth_type)
+        client = JMAPClient(
+            settings.STALWART_JMAP_API_URL,
+            username,
+            user_token,
+            auth_type,
+            # Same knob the legacy client uses for this backend. tb-dev reaches Stalwart at an
+            # in-cluster Service DNS name while Stalwart serves the PUBLIC mail-host cert, so
+            # verification must be switchable per environment rather than hardcoded either way.
+            verify_ssl=settings.VERIFY_PRIVATE_LINK_SSL,
+        )
         # Make sure we retrieve the session
         client.get_session()
         return client

--- a/src/thunderbird_accounts/mail/dkim.py
+++ b/src/thunderbird_accounts/mail/dkim.py
@@ -143,7 +143,9 @@ def _dkim_key_type_and_public_key_value(signature: dict) -> tuple[str, str]:
             try:
                 public_key_obj = serialization.load_der_public_key(public_key_bytes)
             except (ValueError, UnsupportedAlgorithm) as ex:
-                signature_type = signature.get('@type', '')
+                # Pydantic emits the key with a None value when unset, so a bare default is
+                # not enough -- `'Ed25519' in None` is a TypeError, not the intended RuntimeError.
+                signature_type = signature.get('@type') or ''
                 if 'Ed25519' in signature_type and len(public_key_bytes) == 32:
                     public_key_obj = ed25519.Ed25519PublicKey.from_public_bytes(public_key_bytes)
                 else:

--- a/src/thunderbird_accounts/mail/exceptions.py
+++ b/src/thunderbird_accounts/mail/exceptions.py
@@ -181,6 +181,22 @@ class EmailNotValidError(RuntimeError):
         return f'EmailNotValidError: {self.email}, {self.error_message}'
 
 
+class JMapOriginMismatchError(StalwartError):
+    """The JMAP session advertised an apiUrl on a different origin than the configured base URL.
+
+    Subclasses StalwartError (and so RuntimeError) deliberately: callers that already degrade
+    gracefully on Stalwart being unreachable should treat this the same way, rather than 500.
+    """
+
+    def __init__(self, advertised: str, configured: str):
+        self.advertised = advertised
+        self.configured = configured
+        super().__init__(
+            f'JMAP apiUrl origin does not match configured base URL '
+            f'(advertised: {advertised}, configured: {configured})'
+        )
+
+
 class InvalidJMapResponseError(RuntimeError):
     """This is a generic pydantic response error. You should not get this, if you do there's a developer problem."""
 

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -367,8 +367,17 @@ def create_stalwart_account(
         if emails != stalwart_emails:
             # Diff of new emails
             new_emails = set(emails) - set(stalwart_emails)
-            # Diff of the old emails
-            old_emails = set(stalwart_emails) - set(emails)
+            # Diff of the old emails. Scope the DELETE to addresses in ALLOWED_EMAIL_DOMAINS --
+            # the only ones this task owns. `emails` is just the canonical set, so an unscoped
+            # diff also sweeps up custom-domain aliases the user added via the mail UI, removing
+            # them from Stalwart while their local Email row survives. Previously unreachable
+            # (get_account always returned a dict, so stalwart_emails was always empty); the
+            # typed branch above makes it live.
+            old_emails = {
+                addr
+                for addr in set(stalwart_emails) - set(emails)
+                if addr.rsplit('@', 1)[-1] in settings.ALLOWED_EMAIL_DOMAINS
+            }
 
             stalwart.save_email_addresses(username, list(new_emails))
             stalwart.delete_email_addresses(username, list(old_emails))

--- a/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
@@ -152,12 +152,10 @@ class MockJMapClient(JMAPClient):
             return self.session
 
         fixture_data = self.retrieve_fixture(Path('fixtures') / 'jmap_get_session.json')
-        session = SessionResource(**fixture_data)
-        self.session = session
-        if not self.session:
-            raise RuntimeError('Failed to get session')
-        self.api_url = session.api_url
-        return session
+        # Stub only the HTTP fetch; everything after it, including the origin check, must run
+        # exactly as it does in production. Previously this reimplemented the assignment, so the
+        # ~17 tests built on this double exercised UNPINNED behaviour and CI carried no signal.
+        return self._accept_session(SessionResource(**fixture_data))
 
     def request(self, request_data: JMapRequest, method: Literal['get', 'post'] = 'post') -> JMapResponse:
         raise NotImplementedError('Monkeypatch me!')
@@ -172,7 +170,7 @@ def build_admin_client() -> MailClientAdminJMAP:
     """
 
     def _mock_user_client(self, *args, **kwargs) -> MockJMapClient:
-        client = MockJMapClient('http://stalwart.local', 'admin', 'admin')
+        client = MockJMapClient('https://stalwart.local', 'admin', 'admin')
         client.get_session()
         return client
 
@@ -210,7 +208,7 @@ def v016_dkim_signature(*, stage: str = 'active') -> dict:
 
 def build_user_client() -> MailClientUserJMAP:
     def _mock_user_client(self, *args, **kwargs) -> MockJMapClient:
-        client = MockJMapClient('http://stalwart.local', 'user@example.org', 'user-token')
+        client = MockJMapClient('https://stalwart.local', 'user@example.org', 'user-token')
         client.get_session()
         return client
 

--- a/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients/test_jmap.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, call, patch
 from django.test import SimpleTestCase, override_settings
 
 from thunderbird_accounts.mail.clients.jmap_client import JMAPClient
+from thunderbird_accounts.mail.exceptions import JMapOriginMismatchError, StalwartError
 from thunderbird_accounts.mail.clients.mail_client_jmap import MailClientAdminJMAP, MailClientUserJMAP
 from thunderbird_accounts.mail.exceptions import AppPasswordSetError
 from thunderbird_accounts.mail.tests.test_clients.test_legacy import (
@@ -65,7 +66,7 @@ class TestJMAPClientTransport(SimpleTestCase):
 
     @patch('thunderbird_accounts.mail.clients.jmap_client.requests.request')
     @patch('thunderbird_accounts.mail.clients.jmap_client.requests.get')
-    def test_authenticated_requests_do_not_follow_redirects(self, get_mock: MagicMock, request_mock: MagicMock):
+    def test_api_requests_do_not_follow_redirects(self, get_mock: MagicMock, request_mock: MagicMock):
         get_mock.return_value = self._response(self.session_data)
         request_mock.return_value = self._response(
             {
@@ -78,7 +79,10 @@ class TestJMAPClientTransport(SimpleTestCase):
         client.get_session()
         client.request(self._request_data())
 
-        self.assertIs(get_mock.call_args.kwargs['allow_redirects'], False)
+        # The session resource is fetched "following any redirects" per RFC 8620 2.2, and
+        # Stalwart v0.16 always 307s /.well-known/jmap. The API resource must NOT follow, since
+        # a 307/308 replays the POST body at the new host.
+        self.assertIs(get_mock.call_args.kwargs['allow_redirects'], True)
         self.assertIs(request_mock.call_args.kwargs['allow_redirects'], False)
 
     @patch('thunderbird_accounts.mail.clients.jmap_client.requests.get')
@@ -87,7 +91,7 @@ class TestJMAPClientTransport(SimpleTestCase):
         get_mock.return_value = self._response(self.session_data)
         client = JMAPClient('https://stalwart.local', 'admin', 'token')
 
-        with self.assertRaisesRegex(ValueError, 'apiUrl origin'):
+        with self.assertRaisesRegex(JMapOriginMismatchError, 'apiUrl origin'):
             client.get_session()
 
     @patch('builtins.open')
@@ -901,3 +905,22 @@ class TestProductionInterfaceParity(SimpleTestCase):
             ],
         )
         self.mail_client._get_dkim_dns_records.assert_called_once_with('example.com')
+
+
+class TestOriginMismatchIsRecoverable(SimpleTestCase):
+    """The origin mismatch must be catchable by the handlers that already degrade gracefully.
+
+    It is the one new failure guaranteed to fire against a Stalwart whose advertised apiUrl has
+    not been corrected, so it must not be the one failure that escapes as a 500.
+    """
+
+    def test_is_a_stalwart_error(self):
+        err = JMapOriginMismatchError('https://public.example/jmap/', 'https://internal.example')
+        self.assertIsInstance(err, StalwartError)
+        self.assertIsInstance(err, RuntimeError)
+
+    def test_message_names_both_origins(self):
+        """An operator reading Sentry must be able to tell which end to fix."""
+        err = JMapOriginMismatchError('https://public.example/jmap/', 'https://internal.example')
+        self.assertIn('https://public.example/jmap/', str(err))
+        self.assertIn('https://internal.example', str(err))

--- a/src/thunderbird_accounts/mail/tiny_jmap_client.py
+++ b/src/thunderbird_accounts/mail/tiny_jmap_client.py
@@ -2,6 +2,9 @@ import enum
 import json
 import requests
 
+from thunderbird_accounts.mail.clients.jmap_client import JMAPClient
+from thunderbird_accounts.mail.exceptions import JMapOriginMismatchError
+
 
 class TinyJMAPClient:
     """The tiniest JMAP client you can imagine.
@@ -43,6 +46,10 @@ class TinyJMAPClient:
         )
         r.raise_for_status()
         self.session = session = r.json()
+        # Same pin as JMAPClient: this client carries the USER's access token, and apiUrl is
+        # server-supplied, so an advertised URL on another origin would send that token off-host.
+        if JMAPClient._origin(session['apiUrl']) != JMAPClient._origin(self.hostname):
+            raise JMapOriginMismatchError(session['apiUrl'], self.hostname)
         self.api_url = session['apiUrl']
         return session
 

--- a/src/thunderbird_accounts/mail/types/stalwart.py
+++ b/src/thunderbird_accounts/mail/types/stalwart.py
@@ -218,11 +218,15 @@ class SecondaryCredential(Credential):
 class AppPassword(JMapType):
     """A mix of the above credential objects"""
 
-    description: str
+    # Optional on purpose: these are required only by OUR convention, not by Stalwart. A
+    # credential created outside Accounts (admin CLI, another client) can omit either, and a
+    # required field aborts the whole get_app_passwords list -- locking the user out of setting
+    # a new app password because of one unrelated credential.
+    description: Optional[str] = None
     secret: Optional[str] = None  # Server set
     created_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
-    permissions: StalwartType
+    permissions: Optional[StalwartType] = None
     allowed_ips: Optional[dict] = None
 
 

--- a/src/thunderbird_accounts/subscription/views.py
+++ b/src/thunderbird_accounts/subscription/views.py
@@ -277,7 +277,10 @@ def get_subscription_plan_info(request: Request, paddle: Client):
         stalwart_client = MailClient()
         account = stalwart_client.get_account(request.user.stalwart_primary_email)
         if isinstance(account, stalwart.Account):
-            quota = account.quotas.max_disk_quota if account.quotas else 0
+            # Stalwart sends "quotas": {} for an unlimited account, which parses to a TRUTHY
+            # StorageQuota() whose max_disk_quota is None -> mailStorage: null -> NaN% in the UI.
+            # Mirror the `is not None` check used for used_disk_quota below.
+            quota = account.quotas.max_disk_quota if account.quotas and account.quotas.max_disk_quota is not None else 0
             used_quota = account.used_disk_quota if account.used_disk_quota is not None else 0
         else:
             quota = account.get('quota', 0)


### PR DESCRIPTION
Stacked on #1211. Fixes the issues a review of that branch turned up, either by merging this into it or cherry-picking. Rationale for each is in the commit messages.

| # | Fix | Why it blocks |
|---|---|---|
| 1 | `get_session()` follows redirects again | Stalwart v0.16 **always** 307s `/.well-known/jmap` with an empty body, so `.json()` raises an uncaught `JSONDecodeError`. JMAP is dead at client construction. Measured on live v0.16.16. |
| 2 | `JMapOriginMismatchError(StalwartError)` replaces bare `ValueError` | The bare error escapes `fix_archives_folder` (global middleware) and `core.views.home` (`re_path(r"^.*$")`), causing **site-wide 500s** that never self-heal. |
| 3 | `verify_ssl` wired to `VERIFY_PRIVATE_LINK_SSL` | Parameter added but never connected; new `True` default means `SSLError` on every tb-dev call, fixable only by code deploy. |
| 4 | Alias delete scoped to `ALLOWED_EMAIL_DOMAINS` | **Data loss.** The new typed branch activates a dead delete path that removes custom-domain aliases from Stalwart while the local row survives. |
| 5 | `tiny_jmap_client` origin-pinned | Same bug, live user path, carries the **user's** access token. |
| 6 | `AppPassword.description` / `.permissions` optional | One externally-created credential aborts the whole list, locking the user out of setting an app password. |
| 7 | `signature.get("@type") or ""` | Pydantic emits the key as `None`, so `in None` is a `TypeError`, masking the intended error. |
| 8 | Quota `is not None` check | `"quotas": {}` parses truthy, then `null`, then `NaN%` in the UI. |
| 9 | Origin check made exercisable | The test double bypassed the check (~17 tests ran unpinned) and disagreed with its own fixture; dev `.env` pointed at a different origin than Stalwart advertises, so it failed closed locally. |

`request()` keeps `allow_redirects=False`. That's correct and deliberately untouched: a 307/308 there replays the POST body (DKIM keys, app passwords) at the new host.

Not changed: `STALWART_ADMIN_API_USE_JMAP` stays `false`. Flipping the default is a rollout decision.

A follow-up commit trims overly verbose comments per review feedback. No functional change.

Refs #1216.
