### PR TITLE
fix(keycloak): trust X-Forwarded-* so auth-session cookies keep Secure (#1133)

### DIFF
--- a/scripts/entry-keycloak.sh
+++ b/scripts/entry-keycloak.sh
@@ -15,7 +15,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ "$KC_DEV" == "yes" ]]; then
     /bin/bash /opt/keycloak/bin/kc.sh start-dev --import-realm &
 else
-    /bin/bash /opt/keycloak/bin/kc.sh start --http-enabled=true --proxy-headers forwarded &
+    # xforwarded, not forwarded: the load balancer in front of Keycloak terminates TLS and
+    # forwards over plain HTTP with X-Forwarded-*. It never sends the RFC 7239 Forwarded
+    # header, so `forwarded` left Keycloak treating every request as a non-secure context.
+    # In that state it cannot emit SameSite=None (invalid without Secure) and falls back to
+    # SameSite=Lax, which the browser then withholds on the cross-site POST back from the
+    # MFA step -- surfacing as error="cookie_not_found" and a restarted login flow.
+    # This is a CLI flag, so it also overrides KC_PROXY_HEADERS: setting that env var alone
+    # cannot fix it.
+    /bin/bash /opt/keycloak/bin/kc.sh start --http-enabled=true --proxy-headers xforwarded &
 fi
 KC_PID=$!
 


### PR DESCRIPTION
Keycloak ran with `--proxy-headers forwarded`, which trusts only the RFC 7239 `Forwarded` header. The load balancer terminates TLS on :443 and forwards HTTP to the container on :8080, sending `X-Forwarded-*` and never `Forwarded`.

Keycloak therefore treated every request as a non-secure context. In that state it cannot emit `SameSite=None` (invalid without `Secure`), so it falls back to `Lax` — and a `Lax` cookie is not sent on the cross-site POST back from the MFA step. Verified against production `auth.tb.pro`:

```
AUTH_SESSION_ID=<redacted>;Path=/realms/tbpro/;HttpOnly;SameSite=Lax
```

No `Secure` on an HTTPS response. Production counters over 48h:

| Signal | Count |
|---|---|
| `Non-secure context detected; cookies are not secured` | 25,547 |
| `LOGIN_ERROR ... error="cookie_not_found"` | 643 |
| `expired_code` | 293 |

Keycloak also records the load balancer's private address as the client IP, independent confirmation that the forwarded headers were being ignored.

`--proxy-headers` is passed as a CLI flag, so it overrides `KC_PROXY_HEADERS`; setting that env var alone cannot fix this.

## Deploying

Merging this does **not** ship the fix. The script is baked into the image (`Dockerfile.keycloak`), so it needs a rebuild, and prod pins its own tag:

- stage — auto-bumped by `.github/workflows/merge.yml`
- **prod — requires bumping `.keycloak_image` in `pulumi/config.prod.yaml:9`**, which this PR does not touch

## Verifying after deploy

```
aws logs filter-log-events --log-group-name accounts-prod-fargate-keycloak-fargate-logs \
  --filter-pattern '"Non-secure context detected"' --start-time $(( ($(date +%s) - 900) * 1000 ))
```

Expect this to drop sharply. It will not reach zero — in-cluster callers send no `X-Forwarded-Proto` and stay non-secure by design. Then confirm the cookie carries `Secure`:

```
curl -sD - -o /dev/null 'https://auth.tb.pro/realms/tbpro/protocol/openid-connect/auth?client_id=account-console&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fauth.tb.pro%2Frealms%2Ftbpro%2Faccount%2F&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256' | grep -i set-cookie
```

Users already stuck may see the timeout error once more before it clears, since the browser reaches Keycloak over HTTPS and can overwrite the stale non-Secure cookie. The guidance is "use the restart-login link, or clear cookies once" — not "everyone must clear cookies".

## Not in scope

Found while investigating, each worth its own issue:

- `--proxy-headers` now trusts forwarded headers from any source; `--proxy-trusted-addresses` is unset (defaults to trusting all). Note the ALB *appends* to `X-Forwarded-For` rather than overwriting, so a client-supplied value survives as the leftmost entry and can forge the logged client IP. Strictly less spoofable than `forwarded` was, but worth closing.
- The `tbpro` login theme emits `formAction` inside a `<script>` block with `&amp;` escaping, so the POST carries parameters named `amp;execution`, `amp;tab_id`, `amp;client_id`. This is cosmetic, not a bug: a controlled experiment in keycloak-customer-deploy#11 showed `&` and `&amp;` produce identical results, and tb-dev carries the same escaping today while working correctly. Left as-is deliberately.
- Duplicate DOM ids in the same template (`<label id="username">` alongside `<input id="username">`).
- The entrypoint never consumes `"$@"`, so the `command: [start]` passed by the task definition is silently discarded.

Refs #493 (this is the issue that filed the warning and asked whether it had impact — it does)
Refs #886 (why prod needs a manual `.keycloak_image` bump; this PR does not deploy itself)

Not #1133: a user HAR plus the matching server event show that failure was `expired_code` /
`restart_after_timeout` with the cookie present, i.e. a different mechanism. This PR fixes the
cookie/proxy-header defect on its own evidence and should not be described as fixing #1133.

