### PR TITLE
Allow token introspection during audience migration

### DIFF
--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -53,6 +53,9 @@ COPY --chown=keycloak:keycloak keycloak/providers/keycloak-mfa-rest.jar /opt/key
 # (MFA_JAR_MODE is declared as a global ARG at the top of this file.)
 FROM mfa-${MFA_JAR_MODE}
 
+# Temporary compatibility while introspecting clients migrate to explicit token audiences.
+ENV KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK=true
+
 # Load in our dev setup
 COPY --chown=keycloak:keycloak keycloak/data/import /opt/keycloak/data/import
 COPY --from=build /app/keycloak/themes/tbpro /opt/keycloak/themes/tbpro

--- a/test/e2e/tests/token-introspection.spec.ts
+++ b/test/e2e/tests/token-introspection.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  KEYCLOAK_ADMIN_BASE_URL,
+  KEYCLOAK_ADMIN_CLIENT_ID,
+  KEYCLOAK_ADMIN_CLIENT_SECRET,
+  PLAYWRIGHT_TAG_E2E_SUITE,
+} from '../const/constants';
+
+test.describe('token introspection compatibility', {
+  tag: [PLAYWRIGHT_TAG_E2E_SUITE],
+}, () => {
+  test.skip(
+    !KEYCLOAK_ADMIN_CLIENT_SECRET || KEYCLOAK_ADMIN_CLIENT_SECRET === 'undefined',
+    'Keycloak admin client credentials are required for the introspection compatibility test.',
+  );
+
+  test('allows a client to introspect a token without its audience', async () => {
+    const masterRealmUrl = `${KEYCLOAK_ADMIN_BASE_URL}/realms/master`;
+    const tokenResponse = await fetch(`${masterRealmUrl}/protocol/openid-connect/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: KEYCLOAK_ADMIN_CLIENT_ID,
+        client_secret: KEYCLOAK_ADMIN_CLIENT_SECRET,
+        grant_type: 'client_credentials',
+      }),
+    });
+    const tokenData = await tokenResponse.json();
+
+    expect(tokenResponse.ok, JSON.stringify(tokenData)).toBe(true);
+    expect(tokenData.access_token).toBeTruthy();
+
+    const tokenPayload = JSON.parse(
+      Buffer.from(String(tokenData.access_token).split('.')[1], 'base64url').toString('utf8'),
+    );
+    const audiences = Array.isArray(tokenPayload.aud)
+      ? tokenPayload.aud
+      : tokenPayload.aud
+        ? [tokenPayload.aud]
+        : [];
+    expect(audiences).not.toContain(KEYCLOAK_ADMIN_CLIENT_ID);
+
+    const introspectionResponse = await fetch(
+      `${masterRealmUrl}/protocol/openid-connect/token/introspect`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${KEYCLOAK_ADMIN_CLIENT_ID}:${KEYCLOAK_ADMIN_CLIENT_SECRET}`,
+          ).toString('base64')}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          token: tokenData.access_token,
+          token_type_hint: 'access_token',
+        }),
+      },
+    );
+    const introspectionData = await introspectionResponse.json();
+
+    expect(introspectionResponse.ok, JSON.stringify(introspectionData)).toBe(true);
+    expect(introspectionData.active).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed?

- Enable Keycloak's temporary compatibility option that permits authenticated clients to introspect tokens without matching the token audience.
- Add an E2E regression test using the existing Keycloak admin client to verify an audience-less token remains active during introspection.

This change was agent-written with the implementation approach and scope directed by the user.

## Why?

Keycloak 26.7.2 enforces introspection audiences, but not every token issuer currently adds every introspecting service to its audience. Preserve existing integrations while those client mappings are evaluated.

## Limitations and Notes

This is a deprecated, server-wide compatibility option: any authenticated client can introspect any valid token. It should be removed once explicit audiences are configured for all introspection paths. The Stalwart audience mapper added in #1226 remains in place.

## Applicable Issues

Follow-up to #1226.

## Verification

- Built and started the Keycloak 26.7.2 image locally.
- Confirmed Keycloak reports that the global audience check is disabled.
- `npx playwright test tests/token-introspection.spec.ts --project=firefox --no-deps` (1 passed)

## Screenshots

Not applicable.