### PR TITLE
Promote Keycloak 26.7.2 image to production

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -6,7 +6,7 @@
 .accounts_image: &ACCOUNTS_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:v1.16.12
 
 # Update this value to update all containers based on this Keycloak image
-.keycloak_image: &KEYCLOAK_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-1b20b5c2be2a9906c92ab86e69b283033dd3a862
+.keycloak_image: &KEYCLOAK_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-af57d549f0a7fe9fe7b724d5c6390c9eb4c87a82
 
 # These variables are common to Accounts application environments. Some tasks will require additional configuration.
 .admin_contact: &VAR_ADMIN_CONTACT {name: "ADMIN_CONTACT", value: "dummy@example.org"}


### PR DESCRIPTION
## What changed?

Update the production Keycloak image anchor to the commit-tagged image built and exercised by the successful staging deployment for #1227.

## Limitations and Notes

This PR does not deploy production. After merge, a manual pulumi up from somebody's laptop is needed.

Candidate image:
`768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-af57d549f0a7fe9fe7b724d5c6390c9eb4c87a82`