### PR TITLE
fix(keycloak-theme): guard the OTP, recovery-code and reset forms against double submit (#1133)

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -8,9 +8,6 @@ const loginUrl = window._page.currentView?.loginUrl;
 const username = window._page.currentView?.attemptedUserName;
 const resetPasswordForm = useTemplateRef('reset-password-form');
 
-// Enter can reach onSubmit twice: the form's implicit submission fires @submit.prevent and
-// the bubbling keyup fires @keyup.enter. Guard so only one POST goes out (#1133). The flag is
-// set after checkValidity so a failed validation leaves the form usable.
 const isSubmitting = ref(false);
 
 const onSubmit = () => {

--- a/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ForgotPasswordView/index.vue
@@ -8,8 +8,15 @@ const loginUrl = window._page.currentView?.loginUrl;
 const username = window._page.currentView?.attemptedUserName;
 const resetPasswordForm = useTemplateRef('reset-password-form');
 
+// Enter can reach onSubmit twice: the form's implicit submission fires @submit.prevent and
+// the bubbling keyup fires @keyup.enter. Guard so only one POST goes out (#1133). The flag is
+// set after checkValidity so a failed validation leaves the form usable.
+const isSubmitting = ref(false);
+
 const onSubmit = () => {
+  if (isSubmitting.value) return;
   if (resetPasswordForm.value.checkValidity()) {
+    isSubmitting.value = true;
     resetPasswordForm?.value?.submit();
   }
 };
@@ -59,7 +66,7 @@ export default {
         <primary-button variant="outline" :href="loginUrl" data-testid="back-url">{{ $t('backToLogin') }}</primary-button>
       </template>
 
-      <primary-button class="submit" @click="onSubmit" data-testid="submit">{{ $t('doSubmit') }}</primary-button>
+      <primary-button class="submit" @click="onSubmit" :disabled="isSubmitting" data-testid="submit">{{ $t('doSubmit') }}</primary-button>
     </div>
   </form>
 </template>

--- a/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { TextInput, PrimaryButton, LinkButton } from "@thunderbirdops/services-ui";
-import { computed, useTemplateRef } from "vue";
+import { computed, ref, useTemplateRef } from "vue";
 import CancelForm from '@kc/vue/components/CancelForm.vue';
 
 const formAction = window._page.currentView?.formAction;
@@ -11,11 +11,24 @@ const showTryAnotherWay = window._page.currentView?.showTryAnotherWay === 'true'
 const loginForm = useTemplateRef('login-form');
 const tryAnotherWayForm = useTemplateRef('try-another-way-form');
 
+// Enter can reach onSubmit twice: the form's implicit submission fires @submit.prevent and
+// the bubbling keyup fires @keyup.enter. Both call form.submit(); here the first POST spends a
+// single-use recovery code and the second hits a spent session_code, so Keycloak restarts the
+// login flow and the retry costs a second code (#1133).
+const isSubmitting = ref(false);
+
 const onSubmit = () => {
-  loginForm?.value?.submit();
+  if (isSubmitting.value) return;
+  // Native submit() skips constraint validation, so check it here as the other views do.
+  if (!loginForm.value?.checkValidity()) return;
+  isSubmitting.value = true;
+  loginForm.value.submit();
 };
 
 const onTryAnotherWay = () => {
+  // Posts to the same action as the login form, so it shares the guard.
+  if (isSubmitting.value) return;
+  isSubmitting.value = true;
   tryAnotherWayForm?.value?.cancel();
 };
 
@@ -42,7 +55,7 @@ export default {
         </text-input>
       </div>
       <div class="buttons">
-        <primary-button class="submit" @click="onSubmit" data-testid="submit-btn">{{ $t('doLogIn') }}</primary-button>
+        <primary-button class="submit" @click="onSubmit" :disabled="isSubmitting" data-testid="submit-btn">{{ $t('doLogIn') }}</primary-button>
       </div>
     </form>
 

--- a/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginRecoveryAuthnCodeView/index.vue
@@ -11,22 +11,16 @@ const showTryAnotherWay = window._page.currentView?.showTryAnotherWay === 'true'
 const loginForm = useTemplateRef('login-form');
 const tryAnotherWayForm = useTemplateRef('try-another-way-form');
 
-// Enter can reach onSubmit twice: the form's implicit submission fires @submit.prevent and
-// the bubbling keyup fires @keyup.enter. Both call form.submit(); here the first POST spends a
-// single-use recovery code and the second hits a spent session_code, so Keycloak restarts the
-// login flow and the retry costs a second code (#1133).
 const isSubmitting = ref(false);
 
 const onSubmit = () => {
   if (isSubmitting.value) return;
-  // Native submit() skips constraint validation, so check it here as the other views do.
   if (!loginForm.value?.checkValidity()) return;
   isSubmitting.value = true;
   loginForm.value.submit();
 };
 
 const onTryAnotherWay = () => {
-  // Posts to the same action as the login form, so it shares the guard.
   if (isSubmitting.value) return;
   isSubmitting.value = true;
   tryAnotherWayForm?.value?.cancel();

--- a/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
@@ -12,11 +12,23 @@ const OtpCredentialModel = ref(selectedOtpCredential);
 const loginForm = useTemplateRef('login-form');
 const tryAnotherWayForm = useTemplateRef('try-another-way-form');
 
+// Enter can reach onSubmit twice: the form's implicit submission fires @submit.prevent and
+// the bubbling keyup fires @keyup.enter. Both call form.submit(), and the second POST reuses
+// a spent session_code, so Keycloak restarts the login flow (#1133).
+const isSubmitting = ref(false);
+
 const onSubmit = () => {
-  loginForm?.value?.submit();
+  if (isSubmitting.value) return;
+  // Native submit() skips constraint validation, so check it here as the other views do.
+  if (!loginForm.value?.checkValidity()) return;
+  isSubmitting.value = true;
+  loginForm.value.submit();
 };
 
 const onTryAnotherWay = () => {
+  // Posts to the same action as the login form, so it shares the guard.
+  if (isSubmitting.value) return;
+  isSubmitting.value = true;
   tryAnotherWayForm?.value?.cancel();
 };
 
@@ -49,7 +61,7 @@ export default {
         </text-input>
       </div>
       <div class="buttons">
-        <primary-button class="submit" @click="onSubmit" data-testid="submit-btn">{{ $t('doLogIn') }}</primary-button>
+        <primary-button class="submit" @click="onSubmit" :disabled="isSubmitting" data-testid="submit-btn">{{ $t('doLogIn') }}</primary-button>
       </div>
     </form>
 

--- a/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginTotpView/index.vue
@@ -12,21 +12,16 @@ const OtpCredentialModel = ref(selectedOtpCredential);
 const loginForm = useTemplateRef('login-form');
 const tryAnotherWayForm = useTemplateRef('try-another-way-form');
 
-// Enter can reach onSubmit twice: the form's implicit submission fires @submit.prevent and
-// the bubbling keyup fires @keyup.enter. Both call form.submit(), and the second POST reuses
-// a spent session_code, so Keycloak restarts the login flow (#1133).
 const isSubmitting = ref(false);
 
 const onSubmit = () => {
   if (isSubmitting.value) return;
-  // Native submit() skips constraint validation, so check it here as the other views do.
   if (!loginForm.value?.checkValidity()) return;
   isSubmitting.value = true;
   loginForm.value.submit();
 };
 
 const onTryAnotherWay = () => {
-  // Posts to the same action as the login form, so it shares the guard.
   if (isSubmitting.value) return;
   isSubmitting.value = true;
   tryAnotherWayForm?.value?.cancel();

--- a/test/e2e/utils/mfa.ts
+++ b/test/e2e/utils/mfa.ts
@@ -109,8 +109,6 @@ export const completeOtpChallenge = async (page: Page, manualSecret: string, las
   for (let attempt = 0; attempt < 3; attempt++) {
     await expect(otpInput).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
     await otpInput.fill(code);
-    // Submit the first attempt with Enter: that is the input path that used to fire
-    // form.submit() twice and bounce the user back to the start of sign-in (#1133).
     if (attempt === 0) {
       await otpInput.press('Enter');
     } else {

--- a/test/e2e/utils/mfa.ts
+++ b/test/e2e/utils/mfa.ts
@@ -109,7 +109,13 @@ export const completeOtpChallenge = async (page: Page, manualSecret: string, las
   for (let attempt = 0; attempt < 3; attempt++) {
     await expect(otpInput).toBeVisible({ timeout: TIMEOUT_30_SECONDS });
     await otpInput.fill(code);
-    await page.getByTestId('submit-btn').click();
+    // Submit the first attempt with Enter: that is the input path that used to fire
+    // form.submit() twice and bounce the user back to the start of sign-in (#1133).
+    if (attempt === 0) {
+      await otpInput.press('Enter');
+    } else {
+      await page.getByTestId('submit-btn').click();
+    }
     try {
       await page.waitForURL((url) => !url.pathname.startsWith('/realms/'), { timeout: 10_000 });
       return code;


### PR DESCRIPTION
Pressing Enter on the OTP, recovery-code, or password-reset form submits it twice. The second POST reuses a spent `session_code`, so Keycloak restarts the flow and the user lands back at the start of sign-in. On the recovery-code form the first POST also spends a single-use code, so the retry costs another one.

All three views bind `onSubmit` to both `@submit.prevent` and `@keyup.enter`, and `onSubmit` calls the native `form.submit()`. Enter reaches it once through implicit submission and once through the bubbling keyup.

Each form now submits once and disables its button while a submission is in flight. Native `submit()` skips constraint validation, so the code forms check it explicitly; previously an empty code posted anyway.

Six other views share the dual binding. Enter on a focused button double-fires there at any field count, so the follow-up should cover all six. Tracked in #1231.

Refs #1133. Does not fix the separate `/oidc/callback/` state-replay errors.

