### PR TITLE
fix(keycloak-theme): guard remaining forms against double submit (#1133)

### DIFF
--- a/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/ConfigToptView/index.vue
@@ -10,6 +10,8 @@ import { computed, ref, useTemplateRef } from "vue";
 import { i18n } from '@kc/composables/i18n.js';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
 const isManualMode = ref(false);
+// @submit and @keyup.enter can both fire for one Enter keypress; keep the POST single-shot (#1231).
+const isSubmitting = ref(false);
 const formAction = window._page.currentView?.formAction;
 const settingsForm = useTemplateRef('settings-form');
 const cancelForm = useTemplateRef('cancel-form');
@@ -67,7 +69,10 @@ const otpManualUrl = computed(() => {
 });
 
 const onSubmit = () => {
-  settingsForm?.value?.submit();
+  if (isSubmitting.value) return;
+  if (!settingsForm.value?.checkValidity()) return;
+  isSubmitting.value = true;
+  settingsForm.value.submit();
 };
 const onCancel = () => {
   cancelForm?.value?.cancel();
@@ -94,10 +99,11 @@ const copyLink = async () => {
 };
 
 const onNext = () => {
-  totpStep.value += 1;
-  if (totpStep.value >= 3) {
+  if (totpStep.value >= 2) {
     onSubmit();
+    return;
   }
+  totpStep.value += 1;
 };
 const onPrevious = () => {
   totpStep.value -= 1;
@@ -183,7 +189,7 @@ export default {
       </div>
       <div class="buttons">
         <primary-button data-testid="submit-btn" id="saveTOTPBtn" :value="$t('doSubmit')" class="submit"
-                        @click="onNext">{{
+                        @click="onNext" :disabled="isSubmitting">{{
             $t('doSubmit')
           }}
         </primary-button>

--- a/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LoginView/index.vue
@@ -10,12 +10,16 @@ const rememberMe = window._page.currentView?.rememberMe;
 const forgotPasswordUrl = window._page.currentView?.forgotPasswordUrl;
 const supportUrl = window._page.currentView?.supportUrl;
 const loginForm = useTemplateRef('login-form');
+// @submit and @keyup.enter can both fire for one Enter keypress; keep the POST single-shot (#1231).
+const isSubmitting = ref(false);
 const message = window._page?.message;
 const tbProPrimaryDomain = window._page.currentView?.tbProPrimaryDomain;
 
 const onSubmit = () => {
+  if (isSubmitting.value) return;
   if (loginForm.value.checkValidity()) {
-    loginForm?.value?.submit();
+    isSubmitting.value = true;
+    loginForm.value.submit();
   }
 };
 
@@ -129,7 +133,7 @@ export default {
     ></checkbox-input>
 
     <div class="buttons">
-      <brand-button data-testid="submit-btn" class="submit" @click="onSubmit">
+      <brand-button data-testid="submit-btn" class="submit" @click="onSubmit" :disabled="isSubmitting">
         {{ $t('doLogIn') }}
 
         <template #iconRight>

--- a/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/LogoutView/index.vue
@@ -1,13 +1,18 @@
 <script setup>
 import { PrimaryButton } from '@thunderbirdops/services-ui';
-import { useTemplateRef } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 const formAction = window._page.currentView?.formAction;
 const logoutForm = useTemplateRef('logout-form');
+// @submit and @keyup.enter can both fire for one Enter keypress; keep the POST single-shot (#1231).
+const isSubmitting = ref(false);
 
 const sessionCode = window._page.currentView?.sessionCode;
 const clientUrl = window._page.currentView?.clientUrl;
 const onSubmit = () => {
-  logoutForm?.value?.submit();
+  if (isSubmitting.value) return;
+  if (!logoutForm.value?.checkValidity()) return;
+  isSubmitting.value = true;
+  logoutForm.value.submit();
 };
 </script>
 
@@ -25,7 +30,8 @@ export default {
     <div class="buttons">
       <input type="hidden" name="session_code" :value="sessionCode">
 
-      <primary-button data-testid="submit-btn" name="confirmLogout" id="kc-logout" class="submit" @click="onSubmit">
+      <primary-button data-testid="submit-btn" name="confirmLogout" id="kc-logout" class="submit" @click="onSubmit"
+                      :disabled="isSubmitting">
         {{ $t('doLogout') }}
       </primary-button>
 

--- a/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/RegisterView/index.vue
@@ -37,8 +37,11 @@ const recoveryEmailError = computed(() => {
 });
 
 const registerForm = useTemplateRef('register-form');
+// @submit and @keyup.enter can both fire for one Enter keypress; keep the POST single-shot (#1231).
+const isSubmitting = ref(false);
 
 const onSubmit = () => {
+  if (isSubmitting.value) return;
   // Do some basic password/confirm password checking, due to how we inject the i18n between kc and accounts 
   // we'll need to just grab it from the html. 
   const invalidPasswordConfirmMessage = document.getElementById('invalidPasswordConfirmMessage')?.innerText;
@@ -54,7 +57,8 @@ const onSubmit = () => {
   }
 
   if (registerForm.value.checkValidity()) {
-    registerForm?.value?.submit();
+    isSubmitting.value = true;
+    registerForm.value.submit();
   }
 };
 
@@ -141,7 +145,7 @@ export default {
       <slot name="form-extras"/>
     </div>
     <div class="buttons">
-      <brand-button data-testid="submit-button" class="submit" @click="onSubmit">
+      <brand-button data-testid="submit-button" class="submit" @click="onSubmit" :disabled="isSubmitting">
         {{ $t('doRegister') }}
 
         <template #iconRight>

--- a/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/UpdatePasswordView/index.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { TextInput, PrimaryButton, CheckboxInput } from "@thunderbirdops/services-ui";
-import { computed, useTemplateRef } from 'vue';
+import { computed, ref, useTemplateRef } from 'vue';
 const formAction = window._page.currentView?.formAction;
 const updatePasswordForm = useTemplateRef('update-password-form');
+// @submit and @keyup.enter can both fire for one Enter keypress; keep the POST single-shot (#1231).
+const isSubmitting = ref(false);
 const errors = window._page.currentView?.errors;
 const passwordError = computed(() => {
   return errors.value?.password === '' ? null : errors.value?.password;
@@ -12,7 +14,10 @@ const passwordConfirmError = computed(() => {
 });
 
 const onSubmit = () => {
-  updatePasswordForm?.value?.submit();
+  if (isSubmitting.value) return;
+  if (!updatePasswordForm.value?.checkValidity()) return;
+  isSubmitting.value = true;
+  updatePasswordForm.value.submit();
 };
 </script>
 
@@ -32,7 +37,7 @@ export default {
       <checkbox-input data-testid="logout-all-sessions-input" id="logout-sessions" name="logout-sessions" :label="$t('logoutOtherSessions')"></checkbox-input>
       </div>
     <div class="buttons">
-      <primary-button data-testid="submit-btn" class="submit" @click="onSubmit">{{ $t('doSubmit') }}</primary-button>
+      <primary-button data-testid="submit-btn" class="submit" @click="onSubmit" :disabled="isSubmitting">{{ $t('doSubmit') }}</primary-button>
     </div>
   </form>
   <template v-if="loginUrl">

--- a/keycloak/themes/tbpro/assets/vue/views/VerifyEmailView/index.vue
+++ b/keycloak/themes/tbpro/assets/vue/views/VerifyEmailView/index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { PrimaryButton } from '@thunderbirdops/services-ui';
-import { computed, useTemplateRef } from 'vue';
+import { computed, ref, useTemplateRef } from 'vue';
 import CancelForm from '@kc/vue/components/CancelForm.vue';
 
 const formAction = window._page.currentView?.formAction;
@@ -10,9 +10,14 @@ const submitText = window._page.currentView?.submitText;
 
 const verifyEmailForm = useTemplateRef('verify-email-form');
 const cancelForm = useTemplateRef('cancel-form');
+// @submit and @keyup.enter can both fire for one Enter keypress; keep the POST single-shot (#1231).
+const isSubmitting = ref(false);
 
 const onSubmit = () => {
-  verifyEmailForm?.value?.submit();
+  if (isSubmitting.value) return;
+  if (!verifyEmailForm.value?.checkValidity()) return;
+  isSubmitting.value = true;
+  verifyEmailForm.value.submit();
 };
 
 const onCancel = () => {
@@ -34,7 +39,8 @@ export default {
         @submit.prevent="onSubmit" @keyup.enter="onSubmit" v-if="showForm">
     <p>{{ verifyEmailInstruction }}</p>
     <div class="buttons">
-      <primary-button data-testid="submit-btn" id="submit" class="submit" @click="onSubmit" :value="submitText">{{
+      <primary-button data-testid="submit-btn" id="submit" class="submit" @click="onSubmit" :value="submitText"
+                      :disabled="isSubmitting">{{
           submitText
         }}
       </primary-button>

--- a/test/e2e/utils/mfa.ts
+++ b/test/e2e/utils/mfa.ts
@@ -66,7 +66,11 @@ export const signInWithPassword = async (page: Page) => {
   await page.goto(ACCTS_HUB_URL);
   await page.getByTestId('username-input').fill(ACCTS_OIDC_EMAIL);
   await page.getByTestId('password-input').fill(ACCTS_OIDC_PWORD);
-  await page.getByTestId('submit-btn').click();
+  // A focused button receives a synthetic click before its keyup bubbles to the form.
+  // This is the double-submit path guarded by the login theme (#1231).
+  const submitButton = page.getByTestId('submit-btn');
+  await submitButton.focus();
+  await submitButton.press('Enter');
 };
 
 // Sets up an authenticator app via the management UI and leaves the auto-chained


### PR DESCRIPTION
## What changed?

- Added an `isSubmitting` re-entrancy guard to `ConfigToptView`, `LoginView`, `LogoutView`, `RegisterView`, `UpdatePasswordView`, and `VerifyEmailView`.
- Disabled each submit button after the first valid submission and added explicit `checkValidity()` gates before native `form.submit()`.
- Kept `ConfigToptView` on step 2 when validation fails instead of advancing to an empty step.
- Changed the shared MFA sign-in helper to focus the login submit button and press Enter, exercising the exact click-plus-keyup path that previously submitted twice.

AI disclosure: this patch and its validation were performed by Codex. The implementation was constrained to the six views and regression path specified in #1231 and follows the pattern established in #1230.

### Verification

- `npm run build-theme`
- `npm run build`
- `npm run test:frontend` (3 files, 12 tests passed)
- `npx eslint` on the changed files: `LoginView` passes; the remaining diagnostics are pre-existing in the unmodified baseline (legacy Keycloak views lack script `lang` attributes, and the E2E package resolves Playwright from its nested install).
- The repository-hosted E2E workflow will exercise the full Keycloak/Django stack with its required secrets.

## Why?

These forms bind `onSubmit` to both `@submit.prevent` and `@keyup.enter`. Pressing Enter while the submit button is focused fires its click and then a bubbling keyup, issuing two identical POSTs. The second POST reuses a spent Keycloak `session_code` and can restart the sign-in flow.

## Limitations and Notes

#1230 is not required for this PR: it covers three different views, while this PR closes the remaining six. The changes are intentionally disjoint and can merge in either order.

No screenshots are included because this is a submission-control behavior change with no intended visual difference beyond the button disabling while navigation is in flight.

## Applicable Issues

Closes #1231
Refs #1133

## Screenshots

Not applicable; no persistent visual change.