### PR TITLE
Pin Pulumi CLI version in CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -150,7 +150,7 @@ jobs:
         run: |
           cd $PULUMI_DIR
           source ./venv/bin/activate
-          curl -fsSL https://get.pulumi.com | sh
+          curl -fsSL https://get.pulumi.com | sh -s -- --version 3.259.0
           pip install -Ur requirements.txt
 
       # Produce the accounts container image (only when accounts/IaC changed).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install Pulumi
         shell: bash
         run: |
-          curl -fsSL https://get.pulumi.com | sh
+          curl -fsSL https://get.pulumi.com | sh -s -- --version 3.259.0
 
       - name: Deploy version-tagged image to prod
         shell: bash


### PR DESCRIPTION
## What's changing

This PR improves reproducibility and consistency of CI runs by using a known-good version
of the Pulumi CLI instead of the "latest" version.

The version chosen was recently successfully used for both staging and production.

We'll need to periodically bump the version to new known-good versions.

## Why?

This change is recommended on principle, not due to a problem observed so far with using latest.

## QA Log

 - Analyzed recent deploys to find a known good version.
 - The syntax to install a specific version is documented here: https://www.pulumi.com/docs/install/
