### PR TITLE
Promote Keycloak 99bdead3 image to production

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -6,7 +6,7 @@
 .accounts_image: &ACCOUNTS_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:v1.16.12
 
 # Update this value to update all containers based on this Keycloak image
-.keycloak_image: &KEYCLOAK_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-af57d549f0a7fe9fe7b724d5c6390c9eb4c87a82
+.keycloak_image: &KEYCLOAK_IMAGE 768512802988.dkr.ecr.eu-central-1.amazonaws.com/thunderbird/accounts:keycloak-99bdead307c8c58ee9c8990041fe1b6db60de211
 
 # These variables are common to Accounts application environments. Some tasks will require additional configuration.
 .admin_contact: &VAR_ADMIN_CONTACT {name: "ADMIN_CONTACT", value: "dummy@example.org"}


### PR DESCRIPTION
## What changed?

Pin the production Keycloak image to `keycloak-99bdead307c8c58ee9c8990041fe1b6db60de211`, the stage-verified build from main that includes the double-submit fix from #1230.