### PR TITLE
Dont link orphaned stalwart accounts to new users (Fixes #1239)

### DIFF
--- a/docs/feature-flags.rst
+++ b/docs/feature-flags.rst
@@ -18,4 +18,7 @@ Please use constants to avoid mistakes.
 | purge-incomplete-signups    | switch | When active, purge_incomplete_signups will delete stale users. When inactive (default) it will move stale users into the "Users to Purge" group. |
 +-----------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 | increased-traffic-banner    | switch | When active, displays a sitewide banner telling users the site is under heavy load. Hidden by default.                                           |
-+-----------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+
++----------------------------------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| is-address-taken-lookup-stalwart | switch | During the is_address_taken function lastly check Stalwart for the address that is being requested, and error if that address exists in Stalwart. |
++----------------------------------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+

--- a/src/thunderbird_accounts/authentication/utils.py
+++ b/src/thunderbird_accounts/authentication/utils.py
@@ -146,12 +146,12 @@ def delete_user_data(user) -> list[str]:
             sentry_sdk.capture_exception(ex)
             errors.append(f'Keycloak: {ex}')
 
-        if user.stalwart_primary_email:
-            try:
-                MailClient().delete_account(user.stalwart_primary_email)
-            except Exception as ex:
-                sentry_sdk.capture_exception(ex)
-                errors.append(f'Stalwart: {ex}')
+    if user.stalwart_primary_email:
+        try:
+            MailClient().delete_account(user.stalwart_primary_email)
+        except Exception as ex:
+            sentry_sdk.capture_exception(ex)
+            errors.append(f'Stalwart: {ex}')
 
     if errors:
         logging.error(f'Errors during user data deletion for {user.username}: {errors}')

--- a/src/thunderbird_accounts/authentication/utils.py
+++ b/src/thunderbird_accounts/authentication/utils.py
@@ -84,15 +84,21 @@ def get_user_by_contact_email(email: str):
     return User.objects.filter(Q(email__iexact=email) | Q(recovery_email__iexact=email)).first()
 
 
-def can_register_with_username(username: str):
+def can_register_with_username(username: str, check_remote: bool = True):
     """Can a user register with this username.
     This checks primary username and any mirrored aliases for our allowed domains
 
-    This does not check is_email_reserved, as we generally use a different error for that check."""
+    This does not check is_email_reserved, as we generally use a different error for that check.
+
+    ``check_remote`` is passed through to ``is_address_taken`` - set it to False for hot paths like the
+    debounced username-availability check to skip the remote Stalwart lookup."""
     from thunderbird_accounts.mail.utils import is_address_taken
 
     username_checks = (
-        [is_address_taken(f'{username}@{alt_domain}') for alt_domain in settings.ALLOWED_EMAIL_DOMAINS]
+        [
+            is_address_taken(f'{username}@{alt_domain}', check_remote=check_remote)
+            for alt_domain in settings.ALLOWED_EMAIL_DOMAINS
+        ]
         if len(settings.ALLOWED_EMAIL_DOMAINS) > 0
         else []
     )

--- a/src/thunderbird_accounts/mail/api.py
+++ b/src/thunderbird_accounts/mail/api.py
@@ -43,7 +43,8 @@ def is_username_available(request: Request):
     except EmailNotValidError as ex:
         raise ValidationError(ex.error_message)
 
-    if not can_register_with_username(username):
+    # Don't check the remote Stalwart lookup here since this call is debounced/polled from the frontend.
+    if not can_register_with_username(username, check_remote=False):
         raise ValidationError(_('This username is already taken. Try another one.'))
 
     return Response(status=200)

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -24,6 +24,7 @@ from thunderbird_accounts.mail.exceptions import (
     DomainNotFoundError,
     HostedDkimDeleteRetry,
     HostedDkimPublishRetry,
+    InvalidJMapResponseError,
 )
 from thunderbird_accounts.mail.models import Account, Email
 from thunderbird_accounts.core.types import TaskReturnStatus
@@ -317,6 +318,9 @@ def create_stalwart_account(
     but is still required. App Passwords can be set now, or later.
 
     Note: Email should be Thundermail address. Stalwart does not need your recovery email."""
+
+    user = User.objects.get(oidc_id=oidc_id)
+
     stalwart = MailClient()
     domain = email.split('@')[1]
 
@@ -326,11 +330,7 @@ def create_stalwart_account(
 
         raise TaskFailed(
             str(error),
-            {
-                'oidc_id': oidc_id,
-                'username': username,
-                'email': email,
-            },
+            {'oidc_id': oidc_id, 'user_uuid': user.uuid},
         )
 
     emails = [
@@ -347,33 +347,35 @@ def create_stalwart_account(
         _domain = alias.split('@')[1]
         _stalwart_check_or_create_domain_entry(stalwart, _domain)
 
-    # Lookup the account first, this shouldn't normally happen but if it does we shouldn't explode.
+    # Lookup the account first, this shouldn't happen but if we have a left-over account then it's a problem.
     try:
         stalwart_account = stalwart.get_account(username)
-        stalwart_emails = stalwart_account.get('emails', [])
-
-        # link the stalwart account
-        pkid = stalwart_account.get('id')
-
-        # Check the aliases
-        if emails != stalwart_emails:
-            # Diff of new emails
-            new_emails = set(emails) - set(stalwart_emails)
-            # Diff of the old emails
-            old_emails = set(stalwart_emails) - set(emails)
-
-            stalwart.save_email_addresses(username, list(new_emails))
-            stalwart.delete_email_addresses(username, list(old_emails))
+        logging.error(f'[create_stalwart_account] Account [{user.uuid}] already exists in Stalwart!')
+        raise TaskFailed(
+            str('Account already exists in Stalwart'),
+            {
+                'oidc_id': oidc_id,
+                'user_uuid': user.uuid,
+                'stalwart_pkid': stalwart_account.get('id'),
+            },
+        )
+    except InvalidJMapResponseError as ex:
+        # Cover any jmap response errors, these also require manual fixing (re-running activate sub features)
+        sentry_sdk.capture_exception(ex)
+        raise TaskFailed(
+            str(ex.validation_error),
+            {'oidc_id': oidc_id, 'user_uuid': user.uuid},
+        )
     except AccountNotFoundError:
-        # We need to create this after dkim and domain records exist
-        pkid = stalwart.create_account(emails, username, full_name, app_password, quota)
+        pass
 
-    user = User.objects.get(oidc_id=oidc_id)
+    # We need to create this after dkim and domain records exist
+    pkid = stalwart.create_account(emails, username, full_name, app_password, quota)
     now = datetime.datetime.now(datetime.UTC)
 
-    # Don't create the account if we already have it
+    # Don't create the account if we already have it (this is safe as this object contains no info by itself)
     # Also create their account objects
-    account, _created = Account.objects.update_or_create(
+    account, account_was_created = Account.objects.update_or_create(
         name=user.username,
         defaults={
             'active': True,
@@ -390,6 +392,13 @@ def create_stalwart_account(
             'stalwart_created_at': now,
         },
     )
+
+    if not account_was_created:
+        # Something is wrong, why wasn't this removed? Let's bug sentry about it.
+        logging.error(
+            f'[create_stalwart_account] Account reference [{account.uuid}] already existed. '
+            'It should probably not exist.'
+        )
 
     # Edge-case: don't override an existing stalwart_created_at timestamp
     if not account.stalwart_created_at:
@@ -419,7 +428,6 @@ def create_stalwart_account(
     return {
         'oidc_id': oidc_id,
         'stalwart_pkid': pkid,
-        'username': username,
-        'email': email,
+        'user_uuid': user.uuid,
         'task_status': TaskReturnStatus.SUCCESS,
     }

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -348,8 +348,29 @@ def create_stalwart_account(
         _stalwart_check_or_create_domain_entry(stalwart, _domain)
 
     # Lookup the account first, this shouldn't happen but if we have a left-over account then it's a problem.
+    stalwart_account = None
+
     try:
         stalwart_account = stalwart.get_account(username)
+    except AccountNotFoundError:
+        pass
+    except InvalidJMapResponseError as ex:
+        # Cover any jmap response errors, these also require manual fixing (re-running activate sub features)
+        sentry_sdk.capture_exception(ex)
+        raise TaskFailed(
+            str(ex.validation_error),
+            {'oidc_id': oidc_id, 'user_uuid': user.uuid},
+        )
+    except Exception as ex:
+        # Any other error means we couldn't confirm the account is absent. Fail the task rather than
+        # continuing on and risk creating a duplicate / linking an orphaned account.
+        sentry_sdk.capture_exception(ex)
+        raise TaskFailed(
+            str(ex),
+            {'oidc_id': oidc_id, 'user_uuid': user.uuid},
+        )
+
+    if stalwart_account is not None:
         logging.error(f'[create_stalwart_account] Account [{user.uuid}] already exists in Stalwart!')
         raise TaskFailed(
             str('Account already exists in Stalwart'),
@@ -359,15 +380,6 @@ def create_stalwart_account(
                 'stalwart_pkid': stalwart_account.get('id'),
             },
         )
-    except InvalidJMapResponseError as ex:
-        # Cover any jmap response errors, these also require manual fixing (re-running activate sub features)
-        sentry_sdk.capture_exception(ex)
-        raise TaskFailed(
-            str(ex.validation_error),
-            {'oidc_id': oidc_id, 'user_uuid': user.uuid},
-        )
-    except AccountNotFoundError:
-        pass
 
     # We need to create this after dkim and domain records exist
     pkid = stalwart.create_account(emails, username, full_name, app_password, quota)

--- a/src/thunderbird_accounts/mail/tests/test_tasks.py
+++ b/src/thunderbird_accounts/mail/tests/test_tasks.py
@@ -279,6 +279,7 @@ class DeleteHostedDkimDNSRecordsTestCase(TaskTestCase):
         set_sentry_context_mock.assert_called_once_with('hosted_dkim_delete_retry', cm.exception.context)
 
 
+@override_settings(USE_MAILCHIMP=False)
 class CreateStalwartAccountTestCase(TaskTestCase):
     def test_success(self):
         with patch('thunderbird_accounts.mail.tasks.MailClient', Mock()) as mail_client_mock:
@@ -295,7 +296,7 @@ class CreateStalwartAccountTestCase(TaskTestCase):
             instance_mock.get_account.side_effect = AccountNotFoundError(username_and_email)
             mail_client_mock.return_value = instance_mock
 
-            User.objects.create(oidc_id=oidc_id, username=username_and_email, email=username_and_email)
+            user = User.objects.create(oidc_id=oidc_id, username=username_and_email, email=username_and_email)
 
             # Run sync so can look at the task results
             task_results = tasks.create_stalwart_account.run(
@@ -316,8 +317,7 @@ class CreateStalwartAccountTestCase(TaskTestCase):
                 [username_and_email, email_alias], username_and_email, None, None, quota
             )
 
-            self.assertEqual(username_and_email, task_results.get('email'))
-            self.assertEqual(username_and_email, task_results.get('username'))
+            self.assertEqual(user.uuid, task_results.get('user_uuid'))
             self.assertEqual(oidc_id, task_results.get('oidc_id'))
             self.assertEqual(mock_stalwart_pkid, task_results.get('stalwart_pkid'))
 
@@ -369,8 +369,7 @@ class CreateStalwartAccountTestCase(TaskTestCase):
                 [username_and_email, email_alias], username_and_email, None, None, quota
             )
 
-            self.assertEqual(username_and_email, task_results.get('email'))
-            self.assertEqual(username_and_email, task_results.get('username'))
+            self.assertEqual(user.uuid, task_results.get('user_uuid'))
             self.assertEqual(oidc_id, task_results.get('oidc_id'))
             self.assertEqual(mock_stalwart_pkid, task_results.get('stalwart_pkid'))
 
@@ -386,7 +385,7 @@ class CreateStalwartAccountTestCase(TaskTestCase):
             self.assertEqual(Email.EmailType.PRIMARY.value, email.type)
             self.assertEqual(Email.EmailType.ALIAS.value, alias.type)
 
-    def test_success_account_already_exists_on_stalwart(self):
+    def test_fail_if_account_already_exists_on_stalwart(self):
         with patch('thunderbird_accounts.mail.tasks.MailClient', Mock()) as mail_client_mock:
             mock_stalwart_pkid = 1
 
@@ -401,24 +400,21 @@ class CreateStalwartAccountTestCase(TaskTestCase):
             instance_mock.create_account.side_effect = AccountNotFoundError(username_and_email)
             mail_client_mock.return_value = instance_mock
 
-            User.objects.create(oidc_id=oidc_id, username=username_and_email, email=username_and_email)
+            user = User.objects.create(oidc_id=oidc_id, username=username_and_email, email=username_and_email)
 
             # Run sync so can look at the task results
-            task_results = tasks.create_stalwart_account.run(
-                oidc_id=oidc_id, username=username_and_email, email=username_and_email, quota=quota
-            )
-
-            self.assertEqual(
-                'success', task_results.get('task_status'), msg=f'Failed due to {task_results.get("reason")}'
-            )
+            with self.assertRaises(TaskFailed) as ex:
+                tasks.create_stalwart_account.run(
+                    oidc_id=oidc_id, username=username_and_email, email=username_and_email, quota=quota
+                )
+            task_results = ex.exception.other
 
             mail_client_mock.assert_called_once()
             instance_mock.get_account.assert_called_with(username_and_email)
-            instance_mock.save_email_addresses.assert_called_once()
-            instance_mock.delete_email_addresses.assert_called_once()
+            instance_mock.save_email_addresses.assert_not_called()
+            instance_mock.delete_email_addresses.assert_not_called()
 
-            self.assertEqual(username_and_email, task_results.get('email'))
-            self.assertEqual(username_and_email, task_results.get('username'))
+            self.assertEqual(user.uuid, task_results.get('user_uuid'))
             self.assertEqual(oidc_id, task_results.get('oidc_id'))
             self.assertEqual(mock_stalwart_pkid, task_results.get('stalwart_pkid'))
 
@@ -429,6 +425,8 @@ class CreateStalwartAccountTestCase(TaskTestCase):
             username_and_email = f'test_user@{domain}'
             oidc_id = '1234'
             quota = settings.ONE_GIGABYTE_IN_BYTES * 100
+
+            user = User.objects.create(oidc_id=oidc_id, username=username_and_email, email=username_and_email)
 
             instance_mock = Mock()
             mail_client_mock.return_value = instance_mock
@@ -450,6 +448,5 @@ class CreateStalwartAccountTestCase(TaskTestCase):
             instance_mock.save_email_addresses.assert_not_called()
             instance_mock.delete_email_addresses.assert_not_called()
 
-            self.assertEqual(username_and_email, task_results.get('email'))
-            self.assertEqual(username_and_email, task_results.get('username'))
+            self.assertEqual(user.uuid, task_results.get('user_uuid'))
             self.assertEqual(oidc_id, task_results.get('oidc_id'))

--- a/src/thunderbird_accounts/mail/tests/test_tasks.py
+++ b/src/thunderbird_accounts/mail/tests/test_tasks.py
@@ -418,6 +418,32 @@ class CreateStalwartAccountTestCase(TaskTestCase):
             self.assertEqual(oidc_id, task_results.get('oidc_id'))
             self.assertEqual(mock_stalwart_pkid, task_results.get('stalwart_pkid'))
 
+    def test_fail_if_account_lookup_raises_unexpected_error(self):
+        """If get_account blows up with something other than AccountNotFoundError we should fail the
+        task rather than continuing on and risk creating a duplicate account."""
+        with patch('thunderbird_accounts.mail.tasks.MailClient', Mock()) as mail_client_mock:
+            username_and_email = f'test_user@{settings.PRIMARY_EMAIL_DOMAIN}'
+            oidc_id = '1234'
+            quota = settings.ONE_GIGABYTE_IN_BYTES * 100
+
+            instance_mock = Mock()
+            instance_mock.get_account.side_effect = RuntimeError('stalwart is on fire')
+            mail_client_mock.return_value = instance_mock
+
+            user = User.objects.create(oidc_id=oidc_id, username=username_and_email, email=username_and_email)
+
+            with self.assertRaises(TaskFailed) as ex:
+                tasks.create_stalwart_account.run(
+                    oidc_id=oidc_id, username=username_and_email, email=username_and_email, quota=quota
+                )
+            task_results = ex.exception.other
+
+            instance_mock.get_account.assert_called_with(username_and_email)
+            instance_mock.create_account.assert_not_called()
+
+            self.assertEqual(user.uuid, task_results.get('user_uuid'))
+            self.assertEqual(oidc_id, task_results.get('oidc_id'))
+
     def test_creating_with_not_primary_domain(self):
         with patch('thunderbird_accounts.mail.tasks.MailClient', Mock()) as mail_client_mock:
             # Username is the app password login, and email is the primary email address

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -1,11 +1,13 @@
-from unittest.mock import patch
-
+import uuid
 from django.conf import settings
 from django.test import TestCase
+from unittest.mock import Mock, patch
+from thunderbird_accounts.mail.models import Email
+from waffle.testutils import override_switch
 
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.exceptions import EmailNotValidError
-from thunderbird_accounts.mail.utils import create_stalwart_account, validate_email
+from thunderbird_accounts.mail.utils import create_stalwart_account, validate_email, is_address_taken
 
 
 class ValidateEmailTestCase(TestCase):
@@ -129,3 +131,64 @@ class CreateStalwartAccountTestCase(TestCase):
         create_stalwart_account(user)
 
         self.assertIsNone(mock_task.delay.call_args.kwargs['full_name'])
+
+
+class IsAddressTakenTestCase(TestCase):
+    def _form_email(self, local_part: str) -> str:
+        return f'{local_part}@{settings.PRIMARY_EMAIL_DOMAIN}'
+
+    @override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, False)
+    def test_success(self):
+        """If no one is using the address then it's not 'taken'."""
+        thundermail_address = self._form_email(str(uuid.uuid4()))
+
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.get(username=thundermail_address)
+
+        self.assertFalse(is_address_taken(thundermail_address))
+
+    @override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, False)
+    def test_fail_due_to_user(self):
+        """Ensure that if a user is using that address, that it will be 'taken'."""
+        thundermail_address = self._form_email(str(uuid.uuid4()))
+
+        self.assertFalse(is_address_taken(thundermail_address))
+
+        # Now the address cannot be reused
+        User.objects.create(username=thundermail_address)
+        self.assertTrue(is_address_taken(thundermail_address))
+
+    @override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, False)
+    def test_fail_due_to_email_alias(self):
+        """Ensure that if an email alias exists of that address, that it will be 'taken'."""
+        thundermail_address = self._form_email(str(uuid.uuid4()))
+
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.get(username=thundermail_address)
+
+        self.assertFalse(is_address_taken(thundermail_address))
+
+        # Create an email alias
+        Email.objects.create(address=thundermail_address)
+
+        self.assertTrue(is_address_taken(thundermail_address))
+
+    def test_fail_due_to_stalwart(self):
+        """Same as the other fail tests but we test both with the
+        waffle switch off (return false) and switch on (return true)"""
+        with patch('thunderbird_accounts.mail.utils.MailClient', Mock()) as mail_client_mock:
+            instance_mock = Mock()
+            instance_mock.get_account.return_value = {'id': 1}
+            mail_client_mock.return_value = instance_mock
+
+            thundermail_address = self._form_email(str(uuid.uuid4()))
+
+            with self.assertRaises(User.DoesNotExist):
+                User.objects.get(username=thundermail_address)
+            with self.assertRaises(Email.DoesNotExist):
+                Email.objects.get(address=thundermail_address)
+
+            with override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, False):
+                self.assertFalse(is_address_taken(thundermail_address))
+            with override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, True):
+                self.assertTrue(is_address_taken(thundermail_address))

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -2,12 +2,16 @@ import uuid
 from django.conf import settings
 from django.test import TestCase
 from unittest.mock import Mock, patch
-from thunderbird_accounts.mail.models import Email
 from waffle.testutils import override_switch
 
 from thunderbird_accounts.authentication.models import User
-from thunderbird_accounts.mail.exceptions import EmailNotValidError
+from thunderbird_accounts.mail.models import Email
 from thunderbird_accounts.mail.utils import create_stalwart_account, validate_email, is_address_taken
+from thunderbird_accounts.mail.exceptions import (
+    EmailNotValidError,
+    AccountNotFoundError,
+    InvalidJMapResponseError,
+)
 
 
 class ValidateEmailTestCase(TestCase):
@@ -192,3 +196,40 @@ class IsAddressTakenTestCase(TestCase):
                 self.assertFalse(is_address_taken(thundermail_address))
             with override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, True):
                 self.assertTrue(is_address_taken(thundermail_address))
+
+    @override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, True)
+    def test_check_remote_false_skips_stalwart_lookup(self):
+        """Even with the switch on, ``check_remote=False`` must not hit Stalwart."""
+        with patch('thunderbird_accounts.mail.utils.MailClient', Mock()) as mail_client_mock:
+            instance_mock = Mock()
+            instance_mock.get_account.return_value = {'id': 1}
+            mail_client_mock.return_value = instance_mock
+
+            thundermail_address = self._form_email(str(uuid.uuid4()))
+
+            self.assertFalse(is_address_taken(thundermail_address, check_remote=False))
+            instance_mock.get_account.assert_not_called()
+
+    @override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, True)
+    def test_stalwart_account_not_found_is_not_taken(self):
+        """A clean AccountNotFoundError from Stalwart means the address is free."""
+        with patch('thunderbird_accounts.mail.utils.MailClient', Mock()) as mail_client_mock:
+            instance_mock = Mock()
+            instance_mock.get_account.side_effect = AccountNotFoundError('nope')
+            mail_client_mock.return_value = instance_mock
+
+            thundermail_address = self._form_email(str(uuid.uuid4()))
+
+            self.assertFalse(is_address_taken(thundermail_address))
+
+    @override_switch(settings.WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART, True)
+    def test_stalwart_invalid_jmap_response_is_treated_as_taken(self):
+        """If we can't parse Stalwart's response we can't prove the address is free, so treat it as taken."""
+        with patch('thunderbird_accounts.mail.utils.MailClient', Mock()) as mail_client_mock:
+            instance_mock = Mock()
+            instance_mock.get_account.side_effect = InvalidJMapResponseError(None)
+            mail_client_mock.return_value = instance_mock
+
+            thundermail_address = self._form_email(str(uuid.uuid4()))
+
+            self.assertTrue(is_address_taken(thundermail_address))

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -267,7 +267,7 @@ def is_address_taken(email_address: str) -> bool:
             # It exists? That's a problem.
             return True
         except (AccountNotFoundError, InvalidJMapResponseError):
-            pass # all okay
+            pass  # all okay
 
     return False
 

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -242,9 +242,13 @@ def is_allowed_domain(email_address: str) -> bool:
     return any([email_address.endswith(f'@{domain}') for domain in settings.ALLOWED_EMAIL_DOMAINS])
 
 
-def is_address_taken(email_address: str) -> bool:
+def is_address_taken(email_address: str, check_remote: bool = True) -> bool:
     """Checks an email address (thundermail address or custom alias, not recovery email!) against known
-    user's recovery email, thundermail address or custom aliases."""
+    user's recovery email, thundermail address or custom aliases.
+
+    If ``check_remote`` is True (and the ``is-address-taken-lookup-stalwart`` switch is active) this also
+    queries Stalwart for the address."""
+
     from thunderbird_accounts.authentication.models import User
     from thunderbird_accounts.mail.models import Email
     from django.db.models import Q
@@ -260,7 +264,7 @@ def is_address_taken(email_address: str) -> bool:
         return True
 
     # If this switch is enabled then check stalwart if this address is taken as well
-    if waffle.switch_is_active(WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART):
+    if check_remote and waffle.switch_is_active(WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART):
         stalwart = MailClient()
         try:
             stalwart.get_account(email_address)

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -270,8 +270,11 @@ def is_address_taken(email_address: str, check_remote: bool = True) -> bool:
             stalwart.get_account(email_address)
             # It exists? That's a problem.
             return True
-        except (AccountNotFoundError, InvalidJMapResponseError):
+        except AccountNotFoundError:
             pass  # all okay
+        except InvalidJMapResponseError:
+            # We couldn't parse Stalwart's response, so we can't say the address is free so treat as taken.
+            return True
 
     return False
 

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -1,3 +1,6 @@
+from thunderbird_accounts.mail.clients import MailClient
+from thunderbird_accounts.settings import WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART
+import waffle
 import logging
 import uuid
 import sentry_sdk
@@ -9,7 +12,7 @@ from django.contrib.auth.hashers import make_password, identify_hasher
 from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
-from thunderbird_accounts.mail.exceptions import EmailNotValidError
+from thunderbird_accounts.mail.exceptions import EmailNotValidError, AccountNotFoundError, InvalidJMapResponseError
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.models import Account
 from thunderbird_accounts.mail import tasks
@@ -255,6 +258,16 @@ def is_address_taken(email_address: str) -> bool:
     aliases = Email.objects.filter(address__iexact=email_address).exists()
     if aliases:
         return True
+
+    # If this switch is enabled then check stalwart if this address is taken as well
+    if waffle.switch_is_active(WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART):
+        stalwart = MailClient()
+        try:
+            stalwart.get_account(email_address)
+            # It exists? That's a problem.
+            return True
+        except (AccountNotFoundError, InvalidJMapResponseError):
+            pass # all okay
 
     return False
 

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -723,3 +723,7 @@ WAFFLE_FLAG_ALLOW_POST_REAUTH = 'auth-allow-post-reauth'
 
 # Show the sitewide "we're under increased traffic" banner
 WAFFLE_SWITCH_INCREASED_TRAFFIC_BANNER = 'increased-traffic-banner'
+
+# During the is_address_taken function lastly check Stalwart for the address that is being requested,
+# and error if that address exists in Stalwart.
+WAFFLE_FLAG_IS_ADDRESS_TAKEN_LOOKUP_STALWART = 'is-address-taken-lookup-stalwart'


### PR DESCRIPTION
Fixes [Ensure that orphaned/existing Stalwart principals cannot be linked to new user creations #1239](https://github.com/thunderbird/thunderbird-accounts/issues/1239) and also related to [User deletion fails to ensure related records in other apps are removed  #1238](https://github.com/thunderbird/thunderbird-accounts/issues/1238)

I don't think it fully completes #1238, but it's a good step in the right direction. I'm still thinking over some good actions to do if Stalwart (or Keycloak) fail to delete besides notify. (See [Add a monitoring script that diffs between stalwart / keycloak / accounts #1240](https://github.com/thunderbird/thunderbird-accounts/issues/1240) ).

This is mostly for Mark and Davi to review, I've added sancus for sanity check here. 

## Changes

### Adds `is-address-taken-lookup-stalwart` waffle switch

As documented when enabled it'll add a Stalwart get_account lookup on is_address_taken. This function is used in the sign-up debounced username check, before the actual sign-up occurs, and during alias creation.

### create_stalwart_account no longer succeeds after account lookup

This code should have never left the initial prototype, and is directly the cause of this issue. Before if there was a Stalwart account we purposefully tied the new user with the account. This is the opposite of what we want, so now it'll error out. 

This could get tricky since this occurs during the Paddle webhook processing, but it'll error to Sentry and we take action as needed (like remove the old Stalwart account if needed, and re-run the 'activate subscription features' admin action.)

### Unindent delete stalwart account during delete_user_data

This made it look like it was reliant on delete keycloak to succeed. It used to be but not anymore, so make it more readable.

### Add is_address_taken tests

This should have been tested, and now it is.
