### PR TITLE
Fix email alias validation for custom domains

### DIFF
--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/emailAliasValidation.test.mjs
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/emailAliasValidation.test.mjs
@@ -29,3 +29,27 @@ test('email alias validation blocks catch-all aliases on domains with an existin
     })
   ).toBe(EMAIL_ALIAS_VALIDATION_MESSAGES.MIN_LENGTH);
 });
+
+test('shared domains enforce the minimum local-part length', () => {
+  expect(validateEmailAlias({ ...sharedDomainOptions, value: 'ab' })).toBe(
+    EMAIL_ALIAS_VALIDATION_MESSAGES.MIN_LENGTH
+  );
+  expect(validateEmailAlias({ ...sharedDomainOptions, value: 'abc' })).toBe(null);
+});
+
+test('custom domains allow short aliases regardless of catch-all state', () => {
+  const customDomainOptions = {
+    selectedDomain: 'my-domain.com',
+    allowedDomains: ['example.org'],
+  };
+
+  // No catch-all set
+  expect(
+    validateEmailAlias({ ...customDomainOptions, value: 'ab', existingCatchAlls: [] })
+  ).toBe(null);
+
+  // Catch-all already set for this domain
+  expect(
+    validateEmailAlias({ ...customDomainOptions, value: 'ab', existingCatchAlls: ['@my-domain.com'] })
+  ).toBe(null);
+});

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/emailAliasValidation.ts
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/emailAliasValidation.ts
@@ -25,19 +25,18 @@ export const validateEmailAlias = ({
 }: EmailAliasValidationOptions): EmailAliasValidationMessageKey | null => {
   const isSharedDomain = allowedDomains.includes(selectedDomain);
   const isUsedCatchAll = existingCatchAlls.some((catchAll) => catchAll.endsWith(`@${selectedDomain}`));
+  const isCatchAllRequest = !value || value === '*';
 
   if (EMAIL_ALIAS_FORBIDDEN_SYMBOLS.some((symbol) => value.includes(symbol))) {
     return EMAIL_ALIAS_VALIDATION_MESSAGES.PLUS_SYMBOL;
   }
 
-  // If we're a shared domain or a domain that already has a catch all we'll want to error out on min length.
-  if ((isUsedCatchAll || isSharedDomain) && (!value || value.length < EMAIL_ALIAS_MIN_LENGTH)) {
-    return EMAIL_ALIAS_VALIDATION_MESSAGES.MIN_LENGTH;
+  if (isCatchAllRequest) {
+    return isSharedDomain || isUsedCatchAll ? EMAIL_ALIAS_VALIDATION_MESSAGES.MIN_LENGTH : null;
   }
 
-  // Catch-all domain for #446
-  if (!isUsedCatchAll && (!value || value === '*')) {
-    return null;
+  if (isSharedDomain && value.length < EMAIL_ALIAS_MIN_LENGTH) {
+    return EMAIL_ALIAS_VALIDATION_MESSAGES.MIN_LENGTH;
   }
 
   if (value.length > EMAIL_ALIAS_MAX_LENGTH) {


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

A small frontend-only change to validate min length only for shared domains (e.g. thundermail.com / tb.pro) and not for custom-domains regardless of the existence of a catch-all. Also, split the validations a little bit for better readability.

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

We were preventing a user from having an alias for a custom domain that was less than the min length (e.g. me@mydomain.com).

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/1244

## Screenshots

<!--
  For UI changes, include screenshots or recordings.
  If there are many, consider using a details element:
  <details><summary>Screenshots</summary> ... shots here ... </details>
-->


https://github.com/user-attachments/assets/465a06e0-9c47-473d-a9dc-d75eb88c15eb


