### PR TITLE
Forward display_name from sign up to keycloak & stalwart

### DIFF
--- a/src/thunderbird_accounts/authentication/api.py
+++ b/src/thunderbird_accounts/authentication/api.py
@@ -235,6 +235,9 @@ def sign_up(request: Request):
     timezone = data.get('zoneinfo') or 'UTC'
     locale = data.get('locale') or 'en'
 
+    # Display name is optional
+    display_name = (data.get('name') or '').strip()
+
     partial_username = data.get('partialUsername')
     username = f'{partial_username}@{settings.PRIMARY_EMAIL_DOMAIN}'
 
@@ -276,7 +279,7 @@ def sign_up(request: Request):
         username=username,
         email=email,
         recovery_email=email,
-        display_name=username,
+        display_name=display_name or username,
         language=locale,
         timezone=timezone,
     )
@@ -288,6 +291,7 @@ def sign_up(request: Request):
             username,
             email,
             timezone=timezone,
+            name=display_name or None,
             password=data.get('password'),
             send_action_email=KeycloakRequiredAction.VERIFY_EMAIL,
             verified_email=False,

--- a/src/thunderbird_accounts/authentication/middleware.py
+++ b/src/thunderbird_accounts/authentication/middleware.py
@@ -172,7 +172,7 @@ class AccountsOIDCBackend(OIDCAuthenticationBackend):
         user.last_name = claims.get('family_name', '')
         user.timezone = claims.get('zoneinfo', 'UTC')
         user.avatar_url = claims.get('picture')
-        user.display_name = claims.get('preferred_username')
+        user.display_name = claims.get('name') or claims.get('preferred_username')
         user.username = claims.get('preferred_username')
 
         # Non-standard, only adjust the value if it comes not undefined / null

--- a/src/thunderbird_accounts/authentication/tests/test_api.py
+++ b/src/thunderbird_accounts/authentication/tests/test_api.py
@@ -8,6 +8,7 @@ from waffle.models import Flag
 import uuid
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import SuspiciousOperation
 from urllib.parse import quote
 from django.test import Client as RequestClient, override_settings
@@ -23,6 +24,7 @@ from thunderbird_accounts.authentication.models import AllowListEntry
 @patch('thunderbird_accounts.authentication.clients.KeycloakClient.import_user')
 class SignUpTestcase(APITestCase):
     def setUp(self):
+        cache.clear()
         self.client = RequestClient()
         self.wait_list = ['hello@example.com', 'hello2@example.com']
         for entry in self.wait_list:
@@ -61,6 +63,40 @@ class SignUpTestcase(APITestCase):
 
         self.assertEqual(response.status_code, 200, msg=assert_fail_msg)
         self.assertEqual(response.json(), {'success': True}, msg=assert_fail_msg)
+
+    def test_success_stores_display_name(self, mock_import_user: MagicMock):
+        """The name entered during sign-up is stored on the local user and forwarded to Keycloak."""
+
+        mock_import_user.return_value = 1
+
+        response = self.client.post(
+            '/api/v1/auth/sign-up/',
+            self.make_sign_up_data(email=self.wait_list[0], name='Ada Lovelace'),
+        )
+        assert_fail_msg = self.get_messages(response)
+
+        self.assertEqual(response.status_code, 200, msg=assert_fail_msg)
+
+        user = User.objects.get(email=self.wait_list[0])
+        self.assertEqual(user.display_name, 'Ada Lovelace')
+        self.assertEqual(mock_import_user.call_args.kwargs['name'], 'Ada Lovelace')
+
+    def test_success_without_name_falls_back_to_username(self, mock_import_user: MagicMock):
+        """When no name is provided the display name falls back to the username and Keycloak gets no name."""
+
+        mock_import_user.return_value = 1
+
+        response = self.client.post(
+            '/api/v1/auth/sign-up/',
+            self.make_sign_up_data(email=self.wait_list[0]),
+        )
+        assert_fail_msg = self.get_messages(response)
+
+        self.assertEqual(response.status_code, 200, msg=assert_fail_msg)
+
+        user = User.objects.get(email=self.wait_list[0])
+        self.assertEqual(user.display_name, user.username)
+        self.assertIsNone(mock_import_user.call_args.kwargs['name'])
 
     def test_success_with_zoneinfo_null(self, mock_import_user: MagicMock):
         """Test that an unauthenticated user can sign-up if they're in the allow list."""

--- a/src/thunderbird_accounts/authentication/tests/test_middleware.py
+++ b/src/thunderbird_accounts/authentication/tests/test_middleware.py
@@ -242,7 +242,7 @@ class AccountsOIDCBackendTestCase(TestCase):
 
         self.assertEqual(user.email, claims.get('email'))
         self.assertEqual(user.username, claims.get('preferred_username'))
-        self.assertEqual(user.display_name, claims.get('preferred_username'))
+        self.assertEqual(user.display_name, claims.get('name'))
         self.assertEqual(user.get_full_name(), claims.get('name'))
         self.assertEqual(user.oidc_id, claims.get('sub'))
         self.assertEqual(user.language, claims.get('locale'))

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -1,8 +1,11 @@
+from unittest.mock import patch
+
+from django.conf import settings
 from django.test import TestCase
 
 from thunderbird_accounts.authentication.models import User
 from thunderbird_accounts.mail.exceptions import EmailNotValidError
-from thunderbird_accounts.mail.utils import validate_email
+from thunderbird_accounts.mail.utils import create_stalwart_account, validate_email
 
 
 class ValidateEmailTestCase(TestCase):
@@ -99,3 +102,38 @@ class ValidateEmailTestCase(TestCase):
         """The overridden minimum is still enforced."""
         with self.assertRaises(EmailNotValidError):
             validate_email(self._email(''), min_length=1)
+
+
+class CreateStalwartAccountTestCase(TestCase):
+    """create_stalwart_account should seed the Stalwart description with the user's display name."""
+
+    def _make_user(self, **kwargs):
+        defaults = {
+            'username': f'jane@{settings.PRIMARY_EMAIL_DOMAIN}',
+            'oidc_id': 'abc123',
+        }
+        return User.objects.create(**{**defaults, **kwargs})
+
+    @patch('thunderbird_accounts.mail.utils.tasks.create_stalwart_account')
+    def test_passes_display_name_as_full_name(self, mock_task):
+        user = self._make_user(display_name='Jane Doe')
+
+        create_stalwart_account(user)
+
+        self.assertEqual(mock_task.delay.call_args.kwargs['full_name'], 'Jane Doe')
+
+    @patch('thunderbird_accounts.mail.utils.tasks.create_stalwart_account')
+    def test_falls_back_to_full_name_when_display_name_is_the_username(self, mock_task):
+        user = self._make_user(display_name=f'jane@{settings.PRIMARY_EMAIL_DOMAIN}', first_name='Jane', last_name='Doe')
+
+        create_stalwart_account(user)
+
+        self.assertEqual(mock_task.delay.call_args.kwargs['full_name'], 'Jane Doe')
+
+    @patch('thunderbird_accounts.mail.utils.tasks.create_stalwart_account')
+    def test_no_full_name_when_nothing_useful_is_set(self, mock_task):
+        user = self._make_user(display_name=f'jane@{settings.PRIMARY_EMAIL_DOMAIN}')
+
+        create_stalwart_account(user)
+
+        self.assertIsNone(mock_task.delay.call_args.kwargs['full_name'])

--- a/src/thunderbird_accounts/mail/tests/test_utils.py
+++ b/src/thunderbird_accounts/mail/tests/test_utils.py
@@ -123,16 +123,8 @@ class CreateStalwartAccountTestCase(TestCase):
         self.assertEqual(mock_task.delay.call_args.kwargs['full_name'], 'Jane Doe')
 
     @patch('thunderbird_accounts.mail.utils.tasks.create_stalwart_account')
-    def test_falls_back_to_full_name_when_display_name_is_the_username(self, mock_task):
-        user = self._make_user(display_name=f'jane@{settings.PRIMARY_EMAIL_DOMAIN}', first_name='Jane', last_name='Doe')
-
-        create_stalwart_account(user)
-
-        self.assertEqual(mock_task.delay.call_args.kwargs['full_name'], 'Jane Doe')
-
-    @patch('thunderbird_accounts.mail.utils.tasks.create_stalwart_account')
-    def test_no_full_name_when_nothing_useful_is_set(self, mock_task):
-        user = self._make_user(display_name=f'jane@{settings.PRIMARY_EMAIL_DOMAIN}')
+    def test_no_full_name_when_display_name_is_empty(self, mock_task):
+        user = self._make_user(display_name='')
 
         create_stalwart_account(user)
 

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -89,15 +89,11 @@ def create_stalwart_account(user, app_password: Optional[str] = None) -> bool:
     if user.plan_id:
         mail_quota = user.plan.mail_storage_bytes
 
-    full_name = (user.display_name or '').strip()
-    if not full_name or full_name == user.username:
-        full_name = user.get_full_name() or None
-
     tasks.create_stalwart_account.delay(
         oidc_id=user.oidc_id,
         username=user.username,
         email=user.username,
-        full_name=full_name or None,
+        full_name=user.display_name or None,
         app_password=app_password,
         quota=mail_quota,
     )

--- a/src/thunderbird_accounts/mail/utils.py
+++ b/src/thunderbird_accounts/mail/utils.py
@@ -89,8 +89,17 @@ def create_stalwart_account(user, app_password: Optional[str] = None) -> bool:
     if user.plan_id:
         mail_quota = user.plan.mail_storage_bytes
 
+    full_name = (user.display_name or '').strip()
+    if not full_name or full_name == user.username:
+        full_name = user.get_full_name() or None
+
     tasks.create_stalwart_account.delay(
-        oidc_id=user.oidc_id, username=user.username, email=user.username, app_password=app_password, quota=mail_quota
+        oidc_id=user.oidc_id,
+        username=user.username,
+        email=user.username,
+        full_name=full_name or None,
+        app_password=app_password,
+        quota=mail_quota,
     )
 
     return True

--- a/src/thunderbird_accounts/subscription/tests/test_utils.py
+++ b/src/thunderbird_accounts/subscription/tests/test_utils.py
@@ -86,6 +86,7 @@ class TestActivationSubscriptionFeatures(TestCase):
                     oidc_id=self.user.oidc_id,
                     username=self.user.username,
                     email=self.user.username,
+                    full_name=None,
                     app_password=None,
                     quota=self.plan.mail_storage_bytes,
                 )


### PR DESCRIPTION
<!--
  Please complete all sections.
  Focus on what changed, why it matters, and how you verified it.
  Tests must be included in the pull request.
-->

## What changed?

<!--
  Summarize your change in a few sentences.
  Mention key files, features, or behavior that were updated.

  If you've used AI, we ask you to disclose how much was agent written and to what level of detail
  you participated in the writing. If you are an AI bot, please indicate this clearly.
-->

First, we are now actually getting the value input from the sign-up process and passing first into keycloak so it can be injected and retrieved as `display_name` afterwards when the Celery task calls Stalwart's `create_stalwart_account` to finally use it as `full_name` there.

To test this, you can onboard a new user by adding an email (for example added@mydomain.com) to the allow list in Django Admin, then navigating to `/sign-up?email=added@mydomain.com` and going through the steps. After being onboarded, you should see the display name added in the second step in the Mail dashboard instead of a blank field.

Disclaimer: used Claude Code for testing and PR review checks

## Why?

<!--
  Explain the problem this solves or the goal of the change.
  Link any relevant discussion if helpful.
-->

There were several points where we ignored the display name passed in the sign up. Going through the initial setup / FTUE, would always have an empty display name.

## Applicable Issues

<!--
  Every pull request must have an associated issue.
  Doing so helps us align on the change before you've done the work.

  Using the "Closes #123" format will link pull request and issue.
-->

Fixes https://github.com/thunderbird/thunderbird-accounts/issues/1242