### PR TITLE
Slow down the payment processing page refresh

### DIFF
--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -556,6 +556,7 @@
       "verification": {
         "title": "Your payment is being processed.",
         "text": "This step can take up to 48 hours to complete.",
+        "refreshNote": "This page will refresh automatically in 15 seconds.",
         "help": "Need help? Contact {0}.",
         "support": "support"
       }

--- a/assets/app/vue/views/SubscribeView/components/PaymentPendingStep.vue
+++ b/assets/app/vue/views/SubscribeView/components/PaymentPendingStep.vue
@@ -4,11 +4,11 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
 onMounted(() => {
-  // After 5 seconds reload the page, if the payment came through they'll see the Mail view.
+  // After 15 seconds reload the page, if the payment came through they'll see the Mail view.
   // This is controlled by a beforeEach hook in router.ts.
   window.setTimeout(() => {
     window.location.reload();
-  }, 5000);
+  }, 15000);
 });
 </script>
 
@@ -16,6 +16,7 @@ onMounted(() => {
   <section class="pending-container">
     <h1 class="title">{{ t('views.subscribe.verification.title') }}</h1>
     <h3>{{ t('views.subscribe.verification.text') }}</h3>
+    <p>{{ t('views.subscribe.verification.refreshNote') }}</p>
     <i18n-t keypath="views.subscribe.verification.help" tag="p">
       <a href="/contact/">{{ t('views.subscribe.verification.support') }}</a>
     </i18n-t>


### PR DESCRIPTION
## What this changes

The "Payment processing" page automatically refreshes itself while it waits for a payment to go through. Right now it refreshes every 5 seconds. When things are busy and the page takes a little longer to load, that quick refresh makes the screen flash harshly, which isn't a great experience.

This updates the page to refresh every 15 seconds instead, giving it more breathing room. It also adds a short line on the page letting people know that the page will refresh automatically in 15 seconds, so the refresh doesn't feel unexpected.

## What you'll see

- The waiting page now refreshes every 15 seconds rather than every 5.
- A new message on the page: "This page will refresh automatically in 15 seconds."

Fixes #1253