### PR TITLE
Add a sitewide "increased traffic" banner that admins can toggle

### DIFF
--- a/assets/app/vue/App.vue
+++ b/assets/app/vue/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import HeaderBar from '@/components/HeaderBar.vue';
+import TrafficBanner from '@/components/TrafficBanner.vue';
 import FooterBar from '@/components/FooterBar.vue';
 import { NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import { SERVER_MESSAGE_LEVEL } from '@/types';
@@ -40,6 +41,7 @@ onMounted(() => {
 </script>
 
 <template>
+  <traffic-banner />
   <div class="page-container" v-if="route?.meta?.useAppTemplate ?? true">
     <header-bar />
 

--- a/assets/app/vue/App.vue
+++ b/assets/app/vue/App.vue
@@ -41,8 +41,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <traffic-banner />
   <div class="page-container" v-if="route?.meta?.useAppTemplate ?? true">
+    <traffic-banner />
     <header-bar />
 
     <section class="server-messages" v-if="serverMessages !== null">

--- a/assets/app/vue/components/TrafficBanner.test.ts
+++ b/assets/app/vue/components/TrafficBanner.test.ts
@@ -24,7 +24,7 @@ describe('TrafficBanner', () => {
     const banner = wrapper.find('[data-testid="traffic-banner"]');
     expect(banner.exists()).toBe(true);
     expect(banner.text()).toBe(
-      "We're currently experiencing high demand. You may notice slower performance or occasional errors. Thank you for your patience.",
+      "We're currently experiencing high demand. Pages may load slowly, and some features may not work. Thank you for your patience.",
     );
   });
 

--- a/assets/app/vue/components/TrafficBanner.test.ts
+++ b/assets/app/vue/components/TrafficBanner.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import i18n from '@/composables/i18n';
+import { WAFFLE_SWITCH } from '@/types';
+import TrafficBanner from './TrafficBanner.vue';
+
+const mountTrafficBanner = (activeSwitches: WAFFLE_SWITCH[] = []) => {
+  (window as any).waffle = {
+    switch_is_active: (switchName: WAFFLE_SWITCH) => activeSwitches.includes(switchName),
+  };
+
+  return mount(TrafficBanner, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+};
+
+describe('TrafficBanner', () => {
+  it('shows the banner when the increased-traffic-banner switch is active', () => {
+    const wrapper = mountTrafficBanner([WAFFLE_SWITCH.INCREASED_TRAFFIC_BANNER]);
+
+    const banner = wrapper.find('[data-testid="traffic-banner"]');
+    expect(banner.exists()).toBe(true);
+    expect(banner.text()).toBe(
+      "We're currently experiencing an increase in application traffic. Thank you for your patience.",
+    );
+  });
+
+  it('hides the banner when the switch is inactive', () => {
+    const wrapper = mountTrafficBanner([]);
+
+    expect(wrapper.find('[data-testid="traffic-banner"]').exists()).toBe(false);
+  });
+
+  it('hides the banner when waffle is unavailable', () => {
+    delete (window as any).waffle;
+
+    const wrapper = mount(TrafficBanner, { global: { plugins: [i18n] } });
+
+    expect(wrapper.find('[data-testid="traffic-banner"]').exists()).toBe(false);
+  });
+});

--- a/assets/app/vue/components/TrafficBanner.test.ts
+++ b/assets/app/vue/components/TrafficBanner.test.ts
@@ -24,7 +24,7 @@ describe('TrafficBanner', () => {
     const banner = wrapper.find('[data-testid="traffic-banner"]');
     expect(banner.exists()).toBe(true);
     expect(banner.text()).toBe(
-      "We're currently experiencing an increase in application traffic. Thank you for your patience.",
+      "We're currently experiencing high demand. You may notice slower performance or occasional errors. Thank you for your patience.",
     );
   });
 

--- a/assets/app/vue/components/TrafficBanner.vue
+++ b/assets/app/vue/components/TrafficBanner.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { WAFFLE_SWITCH } from '@/types';
+import { isWaffleSwitchActive } from '@/utils';
+
+const { t } = useI18n();
+
+// Only shown while the increased-traffic-banner waffle switch is active
+const showBanner = computed(() => isWaffleSwitchActive(WAFFLE_SWITCH.INCREASED_TRAFFIC_BANNER));
+</script>
+
+<template>
+  <div v-if="showBanner" class="traffic-banner" data-testid="traffic-banner" role="status">
+    {{ t('components.trafficBanner.message') }}
+  </div>
+</template>
+
+<style scoped>
+/* Styled after the thunderbird.net top-of-page nav banner */
+.traffic-banner {
+  width: 100%;
+  padding: 0.625rem 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #fff;
+  background-image: linear-gradient(to right, #1373d9, #7f27ff);
+}
+</style>

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -36,7 +36,7 @@
       }
     },
     "trafficBanner": {
-      "message": "We're currently experiencing an increase in application traffic. Thank you for your patience."
+      "message": "We're currently experiencing high demand. You may notice slower performance or occasional errors. Thank you for your patience."
     }
   },
   "views": {

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -36,7 +36,7 @@
       }
     },
     "trafficBanner": {
-      "message": "We're currently experiencing high demand. You may notice slower performance or occasional errors. Thank you for your patience."
+      "message": "We're currently experiencing high demand. Pages may load slowly, and some features may not work. Thank you for your patience."
     }
   },
   "views": {

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -34,6 +34,9 @@
         "customDomains": "{count} Custom Domains",
         "sendStorage": "{size} of Send Storage"
       }
+    },
+    "trafficBanner": {
+      "message": "We're currently experiencing an increase in application traffic. Thank you for your patience."
     }
   },
   "views": {

--- a/assets/app/vue/types.ts
+++ b/assets/app/vue/types.ts
@@ -18,6 +18,10 @@ export enum WAFFLE_FLAG {
   CUSTOM_DOMAINS_REVAMP = 'custom-domains-revamp'
 };
 
+export enum WAFFLE_SWITCH {
+  INCREASED_TRAFFIC_BANNER = 'increased-traffic-banner'
+};
+
 export enum TELEMETRY_EVENTS {
   SIGN_UP_SUPPORT = 'accounts.sign-up.support', 
   SIGN_UP_ERROR = 'accounts.sign-up.error',

--- a/assets/app/vue/utils.ts
+++ b/assets/app/vue/utils.ts
@@ -8,8 +8,8 @@ export const defaultLocale = () => {
 };
 
 export const isWaffleFlagActive = (flag: WAFFLE_FLAG): boolean =>
-  Boolean((window as any).waffle?.flag_is_active(flag));
+  Boolean((window as any).waffle?.flag_is_active?.(flag));
 
 export const isWaffleSwitchActive = (switchName: WAFFLE_SWITCH): boolean =>
-  Boolean((window as any).waffle?.switch_is_active(switchName));
+  Boolean((window as any).waffle?.switch_is_active?.(switchName));
 

--- a/assets/app/vue/utils.ts
+++ b/assets/app/vue/utils.ts
@@ -1,4 +1,4 @@
-import { WAFFLE_FLAG } from '@/types';
+import { WAFFLE_FLAG, WAFFLE_SWITCH } from '@/types';
 
 // Check if we already have a local user preferred language
 // Otherwise just use the navigators language.
@@ -9,4 +9,7 @@ export const defaultLocale = () => {
 
 export const isWaffleFlagActive = (flag: WAFFLE_FLAG): boolean =>
   Boolean((window as any).waffle?.flag_is_active(flag));
+
+export const isWaffleSwitchActive = (switchName: WAFFLE_SWITCH): boolean =>
+  Boolean((window as any).waffle?.switch_is_active(switchName));
 

--- a/docs/feature-flags.rst
+++ b/docs/feature-flags.rst
@@ -17,3 +17,5 @@ Please use constants to avoid mistakes.
 +-----------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 | purge-incomplete-signups    | switch | When active, purge_incomplete_signups will delete stale users. When inactive (default) it will move stale users into the "Users to Purge" group. |
 +-----------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+
+| increased-traffic-banner    | switch | When active, displays a sitewide banner telling users the site is under heavy load. Hidden by default.                                           |
++-----------------------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/src/thunderbird_accounts/core/tests/test_traffic_banner.py
+++ b/src/thunderbird_accounts/core/tests/test_traffic_banner.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+from waffle.testutils import override_switch
+
+
+class IncreasedTrafficBannerSwitchTestCase(TestCase):
+    """The frontend's TrafficBanner component reads switch state from the wafflejs endpoint
+    (window.waffle.switch_is_active), so make sure the increased-traffic-banner switch is
+    reported correctly when toggled on and off."""
+
+    def setUp(self):
+        self.url = reverse('wafflejs')
+
+    @override_switch(settings.WAFFLE_SWITCH_INCREASED_TRAFFIC_BANNER, active=True)
+    def test_switch_reported_active(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn(f"'{settings.WAFFLE_SWITCH_INCREASED_TRAFFIC_BANNER}': true", content)
+
+    @override_switch(settings.WAFFLE_SWITCH_INCREASED_TRAFFIC_BANNER, active=False)
+    def test_switch_reported_inactive(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn(f"'{settings.WAFFLE_SWITCH_INCREASED_TRAFFIC_BANNER}': false", content)

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -717,3 +717,6 @@ WAFFLE_FLAG_INTROSPECT_TOKEN_PER_REQUEST = 'auth-introspect-token-per-request'
 
 # Allow auth middleware to try and refresh an inactive access token with an active refresh token during non-get requests
 WAFFLE_FLAG_ALLOW_POST_REAUTH = 'auth-allow-post-reauth'
+
+# Show the sitewide "we're under increased traffic" banner
+WAFFLE_SWITCH_INCREASED_TRAFFIC_BANNER = 'increased-traffic-banner'

--- a/test/e2e/utils/mfa.ts
+++ b/test/e2e/utils/mfa.ts
@@ -13,7 +13,7 @@ export const enableMfaFeatureFlag = async (page: Page) => {
   await page.route('**/wafflejs', (route) =>
     route.fulfill({
       contentType: 'application/javascript',
-      body: `window.waffle = { flag_is_active: (name) => name === '${MFA_WAFFLE_FLAG}' };`,
+      body: `window.waffle = { flag_is_active: (name) => name === '${MFA_WAFFLE_FLAG}', switch_is_active: () => false };`,
     }),
   );
 };


### PR DESCRIPTION
This adds a small banner across the top of every page that says:

> We're currently experiencing an increase in application traffic. Thank you for your patience.

The banner is hidden by default. When the site is under heavy load, an admin can turn it on (and later off again) from the admin area by flipping a switch called `increased-traffic-banner` — no code changes or deploys needed. The wording lives in one place, so it's easy to tweak later.

It's styled like the top-of-page notice banner on thunderbird.net, so it looks at home above the navigation.

Tests cover both cases: the banner appears when the switch is on and stays hidden when it's off.

## Screenshot

<img width="1814" height="131" alt="Screenshot 2026-09-01 at 1 18 40 PM" src="https://github.com/user-attachments/assets/60a57c6b-8778-4fe8-93c3-30e869b2a8aa" />


Fixes #1254