### PR TITLE
Adjust celery's scaling boundaries

### DIFF
--- a/pulumi/config.prod.yaml
+++ b/pulumi/config.prod.yaml
@@ -648,8 +648,8 @@ resources:
 
       autoscalers:
         celery-prod:
-          min_capacity: 10
-          max_capacity: 20
+          min_capacity: 2
+          max_capacity: 40
         flower-prod:
           min_capacity: 1
           max_capacity: 1


### PR DESCRIPTION
Earlier we wanted to guarantee at least 10 containers coming online to deal with a queue backlog. We're done with that, and this PR now widens the scaling parameters to go as low as 2 containers or as high as 40, depending on container resource demand.

Pulumi diff: https://app.pulumi.com/thunderbird/accounts/prod/previews/bba7068a-5c5a-4480-aaca-b31f42009e1a?view=diff