### PR TITLE
Add scheduled task base classes for easy automatic retries (#1246)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ SENTRY_TRACES_SAMPLE_RATE=0.0
 CELERY_BROKER=redis://redis:6379
 CELERY_BACKEND=redis://redis:6379
 CELERY_EAGER=False
+# Maximum delay in seconds between automatic database task retries.
+CELERY_DATABASE_TASK_RETRY_BACKOFF_MAX=300
+# Patient background tasks tolerate external-service outages for much longer.
+CELERY_PATIENT_TASK_RETRY_BACKOFF_MAX=3600
+CELERY_PATIENT_TASK_MAX_RETRIES=24
 
 # Zendesk (contact support form)
 ZENDESK_SUBDOMAIN=

--- a/src/thunderbird_accounts/authentication/tasks.py
+++ b/src/thunderbird_accounts/authentication/tasks.py
@@ -6,13 +6,14 @@ import sentry_sdk
 import waffle
 from celery import shared_task
 from django.conf import settings
-from django.db import transaction
+from django.db import OperationalError, transaction
 from django.db.models import Exists, OuterRef, QuerySet
 from django.utils import timezone
 
 from thunderbird_accounts.authentication.models import User, AllowListEntry
 from thunderbird_accounts.authentication.utils import delete_user_data
-from thunderbird_accounts.celery.exceptions import TaskFailed
+from thunderbird_accounts.celery.base import DatabaseTask, PatientExternalServiceTask
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError, TaskFailed
 from thunderbird_accounts.subscription.mailchimp import MailchimpClient
 from thunderbird_accounts.subscription.models import Subscription
 
@@ -58,7 +59,7 @@ def get_stale_incomplete_signup_users(cutoff_hours: int) -> QuerySet[User]:
     )
 
 
-@shared_task(bind=True)
+@shared_task(base=PatientExternalServiceTask, bind=True)
 def tag_abandoned_cart_in_mailchimp(self):
     """Tag abandoned sign-up users with abandoned_cart in Mailchimp."""
     if not settings.USE_MAILCHIMP:
@@ -118,6 +119,8 @@ def tag_abandoned_cart_in_mailchimp(self):
                 language=language,
                 error_context={'user_uuid': str(user.uuid)},
             )
+        except (OperationalError, RetryableExternalServiceError):
+            raise
         except TaskFailed as ex:
             errors += 1
             if is_permanent_recovery_email_rejection(ex):
@@ -160,7 +163,7 @@ def tag_abandoned_cart_in_mailchimp(self):
     return result
 
 
-@shared_task(bind=True)
+@shared_task(base=DatabaseTask, bind=True)
 def purge_incomplete_signups(self):
     """Delete abandoned sign-up users older than INCOMPLETE_SIGNUP_PURGE_HOURS.
 
@@ -215,6 +218,8 @@ def purge_incomplete_signups(self):
         except User.DoesNotExist:
             skipped += 1
             continue
+        except OperationalError:
+            raise
         except Exception as ex:
             errors += 1
             sentry_sdk.capture_exception(ex)
@@ -256,7 +261,7 @@ def purge_incomplete_signups(self):
     return result
 
 
-@shared_task(bind=True)
+@shared_task(base=DatabaseTask, bind=True)
 def purge_stale_test_allow_list_entries(self):
     entries = AllowListEntry.objects.filter(
         is_test_entry=True,

--- a/src/thunderbird_accounts/authentication/tests/test_tasks.py
+++ b/src/thunderbird_accounts/authentication/tests/test_tasks.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import freezegun
+from celery.exceptions import Retry
 from waffle.testutils import override_switch
 
 from django.conf import settings
@@ -19,7 +20,7 @@ from thunderbird_accounts.authentication.tasks import (
     purge_stale_test_allow_list_entries,
     PURGE_INCOMPLETE_SIGNUPS_SWITCH,
 )
-from thunderbird_accounts.celery.exceptions import TaskFailed
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError, TaskFailed
 from thunderbird_accounts.subscription.models import Subscription
 
 
@@ -227,22 +228,19 @@ class TagAbandonedCartInMailchimpTaskTestCase(TestCase):
         self.assertEqual(self.user.recovery_email_rejected_at, FROZEN_NOW)
         self.assertEqual(self.user.recovery_email_rejection_reason, 'mailchimp error')
 
-    def test_does_not_mark_transient_mailchimp_error(self, mock_client_cls):
-        mock_client_cls.return_value.add_or_tag_member.side_effect = TaskFailed(
-            'mailchimp error',
-            {
-                'user_uuid': str(self.user.uuid),
-                'error_status_code': 500,
-                'error_msg_title': 'InternalServerError',
-                'error_msg_detail': 'A deep, internal error has occurred.',
-            },
+    def test_retries_transient_mailchimp_error(self, mock_client_cls):
+        mock_client_cls.return_value.add_or_tag_member.side_effect = RetryableExternalServiceError(
+            'mailchimp unavailable'
         )
 
-        tag_abandoned_cart_in_mailchimp.apply().get()
+        with patch.object(tag_abandoned_cart_in_mailchimp, 'retry', side_effect=Retry()) as retry:
+            with self.assertRaises(Retry):
+                tag_abandoned_cart_in_mailchimp.run()
 
         self.user.refresh_from_db()
         self.assertIsNone(self.user.recovery_email_rejected_at)
         self.assertIsNone(self.user.recovery_email_rejection_reason)
+        self.assertIsInstance(retry.call_args.kwargs['exc'], RetryableExternalServiceError)
 
     def test_clears_recovery_email_rejection_when_recovery_email_changes(self, mock_client_cls):
         self.user.recovery_email_rejected_at = timezone.now()

--- a/src/thunderbird_accounts/celery/base.py
+++ b/src/thunderbird_accounts/celery/base.py
@@ -1,0 +1,23 @@
+from celery.contrib.django.task import DjangoTask
+from django.conf import settings
+from django.db import OperationalError
+
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError
+
+
+class DatabaseTask(DjangoTask):
+    """Celery task base that retries transient database failures."""
+
+    autoretry_for = (OperationalError,)
+    retry_backoff = True
+    retry_backoff_max = settings.CELERY_DATABASE_TASK_RETRY_BACKOFF_MAX
+    retry_jitter = True
+    max_retries = 8
+
+
+class PatientExternalServiceTask(DatabaseTask):
+    """Task base for durable background work against external services."""
+
+    autoretry_for = DatabaseTask.autoretry_for + (RetryableExternalServiceError,)
+    retry_backoff_max = settings.CELERY_PATIENT_TASK_RETRY_BACKOFF_MAX
+    max_retries = settings.CELERY_PATIENT_TASK_MAX_RETRIES

--- a/src/thunderbird_accounts/celery/exceptions.py
+++ b/src/thunderbird_accounts/celery/exceptions.py
@@ -1,6 +1,10 @@
 from typing import Optional
 
 
+class RetryableExternalServiceError(Exception):
+    """Raised when an external service operation should be retried later."""
+
+
 class TaskFailed(Exception):
     """Raised when a needs to fail intentionally (an unrecoverable error for example.)
     Celery only seems to treat exceptions as failed tasks.

--- a/src/thunderbird_accounts/celery/retry.py
+++ b/src/thunderbird_accounts/celery/retry.py
@@ -1,0 +1,36 @@
+from functools import wraps
+
+import requests
+
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError
+
+TRANSIENT_EXTERNAL_SERVICE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def is_retryable_external_service_error(exc: requests.RequestException) -> bool:
+    """Return whether a request failure is likely to succeed later."""
+    response = getattr(exc, 'response', None)
+    if response is not None:
+        return response.status_code in TRANSIENT_EXTERNAL_SERVICE_STATUS_CODES
+
+    return isinstance(exc, (requests.ConnectionError, requests.Timeout))
+
+
+def raise_retryable_external_service_error(exc: requests.RequestException) -> None:
+    """Translate a transient request failure for patient Celery tasks."""
+    if is_retryable_external_service_error(exc):
+        raise RetryableExternalServiceError(str(exc)) from exc
+
+
+def retry_transient_external_service_errors(func):
+    """Translate transient request failures raised by a task body."""
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except requests.RequestException as exc:
+            raise_retryable_external_service_error(exc)
+            raise
+
+    return wrapped

--- a/src/thunderbird_accounts/celery/tests/test_base.py
+++ b/src/thunderbird_accounts/celery/tests/test_base.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from celery.exceptions import Retry
+from django.conf import settings
+from django.db import OperationalError
+from django.test import SimpleTestCase
+
+from thunderbird_accounts.celery import app
+from thunderbird_accounts.celery.base import DatabaseTask, PatientExternalServiceTask
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError
+
+
+@app.task(base=DatabaseTask)
+def database_failure():
+    raise OperationalError('database unavailable')
+
+
+@app.task(base=DatabaseTask)
+def non_database_failure():
+    raise ValueError('invalid input')
+
+
+@app.task(base=PatientExternalServiceTask)
+def external_service_failure():
+    raise RetryableExternalServiceError('service unavailable')
+
+
+class DatabaseTaskTestCase(SimpleTestCase):
+    def test_uses_configured_backoff_max(self):
+        self.assertEqual(DatabaseTask.retry_backoff_max, settings.CELERY_DATABASE_TASK_RETRY_BACKOFF_MAX)
+
+    def test_retries_operational_errors(self):
+        with patch.object(database_failure, 'retry', side_effect=Retry()) as retry:
+            with self.assertRaises(Retry):
+                database_failure.run()
+
+        self.assertIsInstance(retry.call_args.kwargs['exc'], OperationalError)
+
+    def test_does_not_retry_other_errors(self):
+        with self.assertRaises(ValueError):
+            non_database_failure.run()
+
+    def test_patiently_retries_external_service_errors(self):
+        with patch.object(external_service_failure, 'retry', side_effect=Retry()) as retry:
+            with self.assertRaises(Retry):
+                external_service_failure.run()
+
+        self.assertIsInstance(retry.call_args.kwargs['exc'], RetryableExternalServiceError)

--- a/src/thunderbird_accounts/celery/tests/test_retry.py
+++ b/src/thunderbird_accounts/celery/tests/test_retry.py
@@ -1,0 +1,23 @@
+import requests
+from django.test import SimpleTestCase
+
+from thunderbird_accounts.celery.retry import is_retryable_external_service_error
+
+
+class RetryableExternalServiceErrorTestCase(SimpleTestCase):
+    def test_retries_transient_responses(self):
+        for status_code in (429, 500, 502, 503, 504):
+            response = requests.Response()
+            response.status_code = status_code
+
+            with self.subTest(status_code=status_code):
+                self.assertTrue(is_retryable_external_service_error(requests.HTTPError(response=response)))
+
+        self.assertTrue(is_retryable_external_service_error(requests.ConnectionError()))
+        self.assertTrue(is_retryable_external_service_error(requests.Timeout()))
+
+    def test_does_not_retry_permanent_responses(self):
+        response = requests.Response()
+        response.status_code = 400
+
+        self.assertFalse(is_retryable_external_service_error(requests.HTTPError(response=response)))

--- a/src/thunderbird_accounts/mail/exceptions.py
+++ b/src/thunderbird_accounts/mail/exceptions.py
@@ -1,6 +1,8 @@
 from pydantic import ValidationError
 from typing import Optional
 
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError
+
 
 class StalwartError(RuntimeError):
     """Generic error"""
@@ -126,7 +128,7 @@ class FailedToReloadStalwart(StalwartError):
         return f'FailedToReloadStalwart: {self.domain}{context}'
 
 
-class HostedDkimPublishRetry(Exception):
+class HostedDkimPublishRetry(RetryableExternalServiceError):
     """Raise when hosted DKIM publication should be retried."""
 
     domain: str
@@ -146,7 +148,7 @@ class HostedDkimPublishRetry(Exception):
         return f'HostedDkimPublishRetry: {self.phase} failed for {self.domain}: {self.reason}'
 
 
-class HostedDkimDeleteRetry(Exception):
+class HostedDkimDeleteRetry(RetryableExternalServiceError):
     """Raise when hosted DKIM deletion should be retried."""
 
     domain: str

--- a/src/thunderbird_accounts/mail/tasks.py
+++ b/src/thunderbird_accounts/mail/tasks.py
@@ -8,6 +8,9 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.celery.base import PatientExternalServiceTask
+from thunderbird_accounts.celery.exceptions import TaskFailed
+from thunderbird_accounts.celery.retry import retry_transient_external_service_errors
 from thunderbird_accounts.mail.clients import MailClient
 from thunderbird_accounts.mail.dkim import (
     CloudflareDNSClient,
@@ -23,7 +26,6 @@ from thunderbird_accounts.mail.exceptions import (
     HostedDkimPublishRetry,
 )
 from thunderbird_accounts.mail.models import Account, Email
-from thunderbird_accounts.celery.exceptions import TaskFailed
 from thunderbird_accounts.core.types import TaskReturnStatus
 
 # Allow self-healing from problems accessing our DNS provider with generous retry policy.
@@ -93,7 +95,8 @@ def _base_email_address_to_stalwart_account(fn_name, username, emails):
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
+@retry_transient_external_service_errors
 def add_email_addresses_to_stalwart_account(self, username: str, emails: list[str]):
     try:
         return _base_email_address_to_stalwart_account('save_email_addresses', username, emails)
@@ -109,7 +112,8 @@ def add_email_addresses_to_stalwart_account(self, username: str, emails: list[st
     )
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
+@retry_transient_external_service_errors
 def replace_email_addresses_on_stalwart_account(self, username: str, emails: list[tuple[str, str]]):
     try:
         return _base_email_address_to_stalwart_account('replace_email_addresses', username, emails)
@@ -127,7 +131,8 @@ def replace_email_addresses_on_stalwart_account(self, username: str, emails: lis
     )
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
+@retry_transient_external_service_errors
 def delete_email_addresses_from_stalwart_account(self, username: str, emails: list[str]):
     try:
         return _base_email_address_to_stalwart_account('delete_email_addresses', username, emails)
@@ -145,7 +150,8 @@ def delete_email_addresses_from_stalwart_account(self, username: str, emails: li
     )
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
+@retry_transient_external_service_errors
 def update_quota_on_stalwart_account(self, username: str, quota: Optional[int]):
     """Updates the quota value on a stalwart account.
     This will cause the account's storage to be tracked by stalwart."""
@@ -174,11 +180,8 @@ def update_quota_on_stalwart_account(self, username: str, quota: Optional[int]):
 
 
 @shared_task(
+    base=PatientExternalServiceTask,
     bind=True,
-    autoretry_for=(HostedDkimPublishRetry,),
-    retry_backoff=True,
-    retry_backoff_max=60 * 60,  # 1 hour
-    retry_jitter=True,
     max_retries=HOSTED_DKIM_PUBLISH_MAX_RETRIES,
 )
 def publish_hosted_dkim_dns_records(self, domain_name: str):
@@ -247,14 +250,7 @@ def publish_hosted_dkim_dns_records(self, domain_name: str):
     }
 
 
-@shared_task(
-    bind=True,
-    autoretry_for=(HostedDkimDeleteRetry,),
-    retry_backoff=True,
-    retry_backoff_max=60 * 60,  # 1 hour
-    retry_jitter=True,
-    max_retries=24,
-)
+@shared_task(base=PatientExternalServiceTask, bind=True)
 def delete_hosted_dkim_dns_records(self, domain_name: str):
     phase = 'initialize'
     hosted_records = []
@@ -304,7 +300,8 @@ def delete_hosted_dkim_dns_records(self, domain_name: str):
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
+@retry_transient_external_service_errors
 def create_stalwart_account(
     self,
     oidc_id: str,

--- a/src/thunderbird_accounts/mail/tests/test_tasks.py
+++ b/src/thunderbird_accounts/mail/tests/test_tasks.py
@@ -1,10 +1,12 @@
-from thunderbird_accounts.celery.exceptions import TaskFailed
 from unittest.mock import patch, Mock, call
 
+import requests
+from celery.exceptions import Retry
 from django.conf import settings
 from django.test import TestCase, override_settings
 
 from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.celery.exceptions import RetryableExternalServiceError, TaskFailed
 from thunderbird_accounts.mail import tasks
 from thunderbird_accounts.mail.exceptions import AccountNotFoundError, HostedDkimDeleteRetry, HostedDkimPublishRetry
 from thunderbird_accounts.mail.models import Account, Email
@@ -59,6 +61,19 @@ class UpdateQuotaOnStalwartAccountTestCase(TaskTestCase):
 
             self.assertEqual(results['task_status'], 'success')
             self.assertEqual(results['quota'], 0)
+
+    @patch('thunderbird_accounts.mail.tasks.MailClient')
+    def test_retries_connection_errors(self, mail_client_mock):
+        mail_client_mock.return_value.update_quota.side_effect = requests.ConnectionError('stalwart unavailable')
+
+        with patch.object(tasks.update_quota_on_stalwart_account, 'retry', side_effect=Retry()) as retry:
+            with self.assertRaises(Retry):
+                tasks.update_quota_on_stalwart_account.run(
+                    username=f'test_user@{settings.PRIMARY_EMAIL_DOMAIN}',
+                    quota=settings.ONE_GIGABYTE_IN_BYTES,
+                )
+
+        self.assertIsInstance(retry.call_args.kwargs['exc'], RetryableExternalServiceError)
 
 
 class PublishHostedDkimDNSRecordsTestCase(TaskTestCase):

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -568,6 +568,9 @@ if CELERY_RESULT_BACKEND.startswith('rediss://'):
 CELERY_RESULT_EXPIRES = 3600
 # If true, immediately run tasks instead of queueing them
 CELERY_TASK_ALWAYS_EAGER = os.getenv('CELERY_EAGER', False) == 'True'
+CELERY_DATABASE_TASK_RETRY_BACKOFF_MAX = int(os.getenv('CELERY_DATABASE_TASK_RETRY_BACKOFF_MAX', '300'))
+CELERY_PATIENT_TASK_RETRY_BACKOFF_MAX = int(os.getenv('CELERY_PATIENT_TASK_RETRY_BACKOFF_MAX', '3600'))
+CELERY_PATIENT_TASK_MAX_RETRIES = int(os.getenv('CELERY_PATIENT_TASK_MAX_RETRIES', '24'))
 
 # Celery Beat — use redbeat for distributed locking across multiple workers.
 CELERY_BEAT_SCHEDULER = 'redbeat.RedBeatScheduler'

--- a/src/thunderbird_accounts/subscription/mailchimp.py
+++ b/src/thunderbird_accounts/subscription/mailchimp.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from requests.exceptions import JSONDecodeError
 
 from thunderbird_accounts.celery.exceptions import TaskFailed
+from thunderbird_accounts.celery.retry import raise_retryable_external_service_error
 
 
 def _get_response_error_details(ex: requests.exceptions.RequestException) -> dict:
@@ -101,6 +102,8 @@ class MailchimpClient:
             # Error details reference: https://mailchimp.com/developer/marketing/docs/errors/#error-glossary
             error_details = _get_response_error_details(ex)
             sentry_sdk.set_context('mailchimp_error', error_details)
+
+            raise_retryable_external_service_error(ex)
             sentry_sdk.capture_exception(ex)
 
             raise TaskFailed(

--- a/src/thunderbird_accounts/subscription/tasks.py
+++ b/src/thunderbird_accounts/subscription/tasks.py
@@ -3,19 +3,26 @@ import json
 import datetime
 import logging
 
+import requests
 import sentry_sdk
 from celery import shared_task
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.signing import Signer, BadSignature
+from django.db import OperationalError
 
 from thunderbird_accounts.authentication.models import User
+from thunderbird_accounts.celery.base import DatabaseTask, PatientExternalServiceTask
+from thunderbird_accounts.celery.exceptions import TaskFailed
+from thunderbird_accounts.celery.retry import (
+    raise_retryable_external_service_error,
+    retry_transient_external_service_errors,
+)
 from thunderbird_accounts.subscription.mailchimp import MailchimpClient
 from thunderbird_accounts.subscription.models import Transaction, Subscription, SubscriptionItem, Price, Product, Plan
 from thunderbird_accounts.subscription.utils import activate_subscription_features
 from thunderbird_accounts.subscription.decorators import inject_paddle, init_paddle
 from thunderbird_accounts.core.types import TaskReturnStatus
-from thunderbird_accounts.celery.exceptions import TaskFailed
 
 try:
     from paddle_billing import Client
@@ -24,7 +31,8 @@ except ImportError:
     Client = None
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
+@retry_transient_external_service_errors
 def dev_only_paddle_fake_webhook(self, transaction_id: str, user_uuid: str):
     """A task that only runs in dev mode. This will simulate the paddle webhook after a checkout has been completed."""
     if not settings.IS_DEV:
@@ -80,7 +88,7 @@ def dev_only_paddle_fake_webhook(self, transaction_id: str, user_uuid: str):
                 break
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=DatabaseTask, bind=True)
 def paddle_transaction_event(self, event_data: dict, occurred_at: datetime.datetime, is_create_event: bool):
     """Handles transaction.created and transaction.updated events.
     Docs: https://developer.paddle.com/webhooks/transactions/transaction-created
@@ -186,7 +194,7 @@ def paddle_transaction_event(self, event_data: dict, occurred_at: datetime.datet
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=DatabaseTask, bind=True)
 def paddle_subscription_event(self, event_data: dict, occurred_at: datetime.datetime, is_create_event: bool):
     """Handles subscription.created events.
     Docs: https://developer.paddle.com/webhooks/subscriptions/subscription-created
@@ -382,7 +390,7 @@ def paddle_subscription_event(self, event_data: dict, occurred_at: datetime.date
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=DatabaseTask, bind=True)
 def paddle_product_event(self, event_data: dict, occurred_at: datetime.datetime, is_create_event: bool):
     """Handles product.created and product.updated events.
     Docs: https://developer.paddle.com/webhooks/products/product-created
@@ -447,7 +455,7 @@ def paddle_product_event(self, event_data: dict, occurred_at: datetime.datetime,
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=DatabaseTask, bind=True)
 def update_thundermail_quota(self, plan_uuid):
     """Since Stalwart only checks the db we have to manually propagate a plan change across the user's accounts."""
     try:
@@ -489,7 +497,7 @@ def update_thundermail_quota(self, plan_uuid):
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
 def add_subscriber_to_mailchimp_list(self, user_uuid):
     """Adds a user's thundermail address to the primary tbpro mailing list.
     This mailing list contains automations to trigger welcome emails and such."""
@@ -543,7 +551,7 @@ def add_subscriber_to_mailchimp_list(self, user_uuid):
     }
 
 
-@shared_task(bind=True, retry_backoff=True, retry_backoff_max=60 * 60, max_retries=10)
+@shared_task(base=PatientExternalServiceTask, bind=True)
 @inject_paddle
 def retrieve_and_update_localized_subscription_price(self, subscription_uuid, paddle: Client):
     """Since Stalwart only checks the db we have to manually propagate a plan change across the user's accounts."""
@@ -609,6 +617,18 @@ def retrieve_and_update_localized_subscription_price(self, subscription_uuid, pa
         if paddle_discount_type:
             subscription.discount_type = paddle_discount_type
         subscription.save()
+    except requests.RequestException as ex:
+        raise_retryable_external_service_error(ex)
+        sentry_sdk.capture_exception(ex)
+        logging.exception(ex)
+
+        return {
+            'subscription_uuid': subscription_uuid,
+            'task_status': TaskReturnStatus.FAILED,
+            'reason': 'Failed to retrieve and store discount / localized prices.',
+        }
+    except OperationalError:
+        raise
     except Exception as ex:
         sentry_sdk.capture_exception(ex)
         logging.exception(ex)

--- a/src/thunderbird_accounts/telemetry/tasks.py
+++ b/src/thunderbird_accounts/telemetry/tasks.py
@@ -6,8 +6,10 @@ import sentry_sdk
 from celery import shared_task
 from django.conf import settings
 from django.core.cache import cache
+from django.db import OperationalError
 
 from thunderbird_accounts.authentication.clients import KeycloakClient
+from thunderbird_accounts.celery.base import DatabaseTask
 from thunderbird_accounts.telemetry.client import capture, hash_id, shutdown, submit_event
 
 logger = logging.getLogger(__name__)
@@ -108,7 +110,7 @@ def _process_stalwart_event(event):
     return True
 
 
-@shared_task(**settings.POSTHOG_TASK_KWARGS)
+@shared_task(base=DatabaseTask, **settings.POSTHOG_TASK_KWARGS)
 def process_stalwart_events(self, events):
     """Process a batch of Stalwart webhook events: resolve users and forward to PostHog."""
     if not settings.POSTHOG_API_KEY:
@@ -127,6 +129,8 @@ def process_stalwart_events(self, events):
 
         if submitted:
             shutdown()
+    except OperationalError:
+        raise
     except Exception as exc:
         _retry_or_report(self, exc, 'Failed to process Stalwart events')
 
@@ -191,7 +195,7 @@ def _fetch_keycloak_events(client, date_from):
     return all_events
 
 
-@shared_task(**settings.POSTHOG_TASK_KWARGS)
+@shared_task(base=DatabaseTask, **settings.POSTHOG_TASK_KWARGS)
 def poll_keycloak_events(self):
     """Poll the Keycloak Admin API for recent user events and submit them to PostHog.
 


### PR DESCRIPTION
## What changed?

Adds two new base classes for Celery tasks. Both have automatic retries
for recoverable conditions enabled by default.

 * **DatabaseTask**: Typically for database access that we expect to complete within five minutes. Retries on OperationalError
 * **PatientExternalServiceTask**: For connections with third parties where we can tolerate more downtime or flakines son their end. Automatically retries a number of recoverable conditions
  up to an hour.

Tasks are updated to use one or the other base class as appropriate.

## Why?

The base class pattern is used to make retrying on recoverable errors easy and consistent.

As to why some of the classification choices were made:

The tasks moved to `DatabaseTask` are local event-processing jobs:

    - paddle_transaction_event
    - paddle_subscription_event
    - paddle_product_event
    - update_thundermail_quota

The Paddle event tasks consume webhook data that has already arrived and primarily update local models. `update_thundermail_quota` is also somewhat misleadingly named: it updates local Account.quota fields; it doesn’t call Stalwart directly. For these, the relevant transient failure is the local database, so the "database" policy was applied.

## Limitations and Notes

Some tasks that /intended/ to have automatic retries before weren't completely configured because they didn't have `autoretry_for` set. So this work /actually/ enables some retry logic that we intended to work before.

## Applicable Issues

 * #1246

