### PR TITLE
Document recommended task base classes in docs/tasks.rst (#1246)

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -38,7 +38,18 @@ An example of this would be:
 
       return
 
-This task takes in a user email and sends them a 'Hello World' email sometime in the future. The timing of when this is sent out depends on what queue a task is in, how full that queue is, and if a worker is scheduled to work on that queue.
+This task takes in a user email and sends them a 'Hello World' email sometime in the future.
+The timing of when this is sent out depends on what queue a task is in, how full that queue is,
+and if a worker is scheduled to work on that queue.
+
+Consider having new tasks automatically retry failed operations by having it inherit from one of
+these base classes:
+
+ - **DatabaseTask**: Typically for database access that we expect to complete within five minutes.
+   Retries on OperationalError.
+
+ - **PatientExternalServiceTask**: For connections with third parties where we can tolerate more
+   downtime or flakines son their end. Automatically retries on ``OperationalError`` and ``RetryableExternalServiceError``.
 
 Using a task
 ===============

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -49,7 +49,7 @@ these base classes:
    Retries on OperationalError.
 
  - **PatientExternalServiceTask**: For connections with third parties where we can tolerate more
-   downtime or flakines son their end. Automatically retries on ``OperationalError`` and ``RetryableExternalServiceError``.
+   downtime or flakiness on their end. Automatically retries on ``OperationalError`` and ``RetryableExternalServiceError``.
 
 Using a task
 ===============


### PR DESCRIPTION
## What changed?

Improved Task docs to mention base classes

## Why?

Two useful base classes were added in #1260. This improves the docs for them.

## Applicable Issues

 * #1246

