### PR TITLE
Fix MFA modal being unusable in mobile Safari

### DIFF
--- a/assets/app/vue/components/GenericModal.vue
+++ b/assets/app/vue/components/GenericModal.vue
@@ -43,9 +43,7 @@ defineExpose({
 
 <style scoped>
 dialog {
-  /* Distance between the top of the viewport and the top of the modal. */
   --modal-inset-block-start: 1rem;
-
   position: fixed;
   top: var(--modal-inset-block-start);
   left: 50%;
@@ -58,29 +56,10 @@ dialog {
   padding: 2rem 1rem 1.5rem;
   width: 640px;
   max-width: 90vw;
-
-  /*
-   * The modal is offset from the top of the viewport, so its height budget is
-   * whatever is left below that offset (minus a matching gap at the bottom).
-   * Sizing it against the full viewport instead let the modal extend past the
-   * bottom of the screen without ever overflowing, so its content could not be
-   * scrolled to and the page behind it stays scroll-locked while it is open.
-   * `dvh` accounts for the dynamic browser chrome on mobile Safari; the `vh`
-   * declaration above it is the fallback for browsers without `dvh`.
-   */
   max-height: calc(100vh - var(--modal-inset-block-start) * 2);
   max-height: calc(100dvh - var(--modal-inset-block-start) * 2);
-
   overflow: hidden;
 
-  /*
-   * Scrolling lives on .modal-scroll-area rather than the dialog so that the
-   * close button, which is positioned against the dialog, stays put instead of
-   * scrolling out of view along with the content.
-   *
-   * Scoped to [open] so it does not override the user-agent
-   * `dialog:not([open]) { display: none }` rule and render closed modals.
-   */
   &[open] {
     display: flex;
     flex-direction: column;

--- a/assets/app/vue/components/GenericModal.vue
+++ b/assets/app/vue/components/GenericModal.vue
@@ -71,14 +71,20 @@ dialog {
   max-height: calc(100vh - var(--modal-inset-block-start) * 2);
   max-height: calc(100dvh - var(--modal-inset-block-start) * 2);
 
+  overflow: hidden;
+
   /*
    * Scrolling lives on .modal-scroll-area rather than the dialog so that the
    * close button, which is positioned against the dialog, stays put instead of
    * scrolling out of view along with the content.
+   *
+   * Scoped to [open] so it does not override the user-agent
+   * `dialog:not([open]) { display: none }` rule and render closed modals.
    */
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  &[open] {
+    display: flex;
+    flex-direction: column;
+  }
 
   &::backdrop {
     background-color: var(--colour-neutral-900);

--- a/assets/app/vue/components/GenericModal.vue
+++ b/assets/app/vue/components/GenericModal.vue
@@ -41,8 +41,11 @@ defineExpose({
 
 <style scoped>
 dialog {
+  /* Distance between the top of the viewport and the top of the modal. */
+  --modal-inset-block-start: 1rem;
+
   position: fixed;
-  top: 144px;
+  top: var(--modal-inset-block-start);
   left: 50%;
   transform: translate(-50%, 0);
   margin: 0;
@@ -53,8 +56,20 @@ dialog {
   padding: 2rem 1rem 1.5rem;
   width: 640px;
   max-width: 90vw;
-  max-height: 90vh;
-  overflow: auto;
+
+  /*
+   * The modal is offset from the top of the viewport, so its height budget is
+   * whatever is left below that offset (minus a matching gap at the bottom).
+   * Sizing it against the full viewport instead let the modal extend past the
+   * bottom of the screen without ever overflowing, so its content could not be
+   * scrolled to and the page behind it stays scroll-locked while it is open.
+   * `dvh` accounts for the dynamic browser chrome on mobile Safari; the `vh`
+   * declaration above it is the fallback for browsers without `dvh`.
+   */
+  max-height: calc(100vh - var(--modal-inset-block-start) * 2);
+  max-height: calc(100dvh - var(--modal-inset-block-start) * 2);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 
   &::backdrop {
     background-color: var(--colour-neutral-900);
@@ -97,6 +112,12 @@ dialog {
       margin-block: 1.5rem 1.75rem;
       text-align: center;
     }
+  }
+}
+
+@media (min-width: 768px) {
+  dialog {
+    --modal-inset-block-start: 144px;
   }
 }
 </style>

--- a/assets/app/vue/components/GenericModal.vue
+++ b/assets/app/vue/components/GenericModal.vue
@@ -31,10 +31,12 @@ defineExpose({
       <ph-x size="24" />
     </button>
 
-    <div class="modal-content">
-      <h2>{{ title }}</h2>
+    <div class="modal-scroll-area">
+      <div class="modal-content">
+        <h2>{{ title }}</h2>
 
-      <slot />
+        <slot />
+      </div>
     </div>
   </dialog>
 </template>
@@ -68,18 +70,32 @@ dialog {
    */
   max-height: calc(100vh - var(--modal-inset-block-start) * 2);
   max-height: calc(100dvh - var(--modal-inset-block-start) * 2);
-  overflow-y: auto;
-  overscroll-behavior: contain;
+
+  /*
+   * Scrolling lives on .modal-scroll-area rather than the dialog so that the
+   * close button, which is positioned against the dialog, stays put instead of
+   * scrolling out of view along with the content.
+   */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 
   &::backdrop {
     background-color: var(--colour-neutral-900);
     opacity: 0.5;
   }
 
+  .modal-scroll-area {
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
   .close-button {
     position: absolute;
     top: 1rem;
     right: 1rem;
+    z-index: 1;
     background-color: rgba(0, 0, 0, 0.05);
     color: rgba(0, 0, 0, 0.5);
     box-shadow: inset 2px 2px 4px 0 rgba(0, 0, 0, 0.05);

--- a/assets/app/vue/views/ManageMfaView/components/ManageAuthenticatorAppModal.vue
+++ b/assets/app/vue/views/ManageMfaView/components/ManageAuthenticatorAppModal.vue
@@ -199,14 +199,17 @@ p {
 
 .actions-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
   width: 100%;
   margin-block-start: 0.5rem;
 }
 
 .left-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
 


### PR DESCRIPTION
Fixes #1261

## Problem

`GenericModal` pins the dialog `144px` from the top of the viewport but sizes it with `max-height: 90vh`, so its bottom edge lands well below the bottom of the screen. Because the dialog never actually overflows its own box, `overflow: auto` produces nothing to scroll, and `showModal()` scroll-locks the page behind it (`body:has(dialog[open]) { overflow: hidden }` in `assets/css/main.css`).

Net effect on a phone: the **Continue** button in the authenticator-app setup step is unreachable, and MFA setup is completely blocked.

This shows up on iOS specifically because `vh` resolves against the *largest* viewport (browser chrome hidden), so the overshoot exceeds 144px. Chrome and DuckDuckGo on iOS handle the chrome differently, which matches the reporter seeing it only in Safari.

## Changes

**`assets/app/vue/components/GenericModal.vue`**

- Derive the height budget from the top offset — `max-height: calc(100dvh - offset * 2)` — instead of sizing against the full viewport. The modal now genuinely overflows and scrolls its own content. `100vh` is declared first as the fallback for browsers without `dvh`.
- Top offset is `1rem` by default, `144px` at `min-width: 768px`, following the repo's mobile-first `min-width` breakpoint convention. Desktop appearance is unchanged.
- Added `overscroll-behavior: contain` so the modal's scroll doesn't chain to the locked page behind it.
- Moved scrolling onto an inner `.modal-scroll-area` wrapper. The close button is absolutely positioned against the dialog, so once the dialog actually scrolled it would have scrolled out of view; the dialog now stays a fixed non-scrolling box and the button stays anchored.
- The flex layout is scoped to `&[open]` — see the note below.

**`assets/app/vue/views/ManageMfaView/components/ManageAuthenticatorAppModal.vue`**

- Let the QR step's action row wrap. "Enter code manually" + "Can't scan?" + "Continue" don't fit on one line at phone widths.

## Verification

Tested with the **compiled CSS extracted verbatim from the `npm run build` output** (not hand-copied rules), rendered in Safari 26.4 on an iPhone SE (3rd gen) simulator — a 549pt viewport, short enough to exercise the overflow path this bug depends on.

| | before (`main`) | after |
|---|---|---|
| dialog top → bottom | 144 → **627** | 16 → **533** |
| fits on screen (549pt) | **false** (78px off-screen) | **true** |
| modal can scroll | **false** | **true** |
| Continue reachable | **false** | **true** |
| close button stays put | — | **true** |

The "before" run reproduces #1261 exactly. Full numbers and screenshots in [this comment](https://github.com/thunderbird/thunderbird-accounts/pull/1269#issuecomment-5514599596).

Also checked:
- iPhone 17 Pro (714pt): content fits outright, Continue visible without scrolling.
- Desktop 1280x900: dialog still at `top: 144px`, 640px wide, fully on screen.
- `npm run build`, `npm run test:frontend`, and eslint all pass.

## Note: the regression on `0617efa`

Worth recording, since the e2e failure mid-PR was real and not flaky. Putting `display: flex` on the bare `dialog` selector overrode the user-agent `dialog:not([open]) { display: none }` rule, so **every closed modal in the page rendered**. The suite caught it as a strict-mode violation — "Continue" matched both the authenticator-app and recovery-codes modals at once.

Fixed in `5458403` by scoping the flex layout to `&[open]`, and re-verified in the simulator that closed dialogs stay hidden. Good catch by the existing e2e assertion.

## Reviewer notes

- **No automated coverage for the viewport half of this fix.** The e2e suite guards the `[open]` regression (it caught it), but nothing asserts the modal fits the viewport or that Continue is reachable on a small screen. The mobile Playwright project (`Google-Pixel-7-View`) exists but has no MFA coverage. Happy to add a mobile-viewport regression test if wanted — say so and I'll push it here.
- A check on real iOS hardware would be a good belt-and-braces confirmation. The simulator is faithful for layout and viewport units but not for scroll momentum/rubber-banding.
- `GenericModal` is shared, so the sizing change affects every modal in the app, not just MFA. That's intended — the same overshoot applied to all of them — but worth a look if any other modal has unusual height assumptions.