### PR TITLE
Install amazon-ssm-agent on future bastion rebuilds via cloud-init

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -75,8 +75,14 @@ for service, sg in resources['tb:network:SecurityGroupWithRules']['containers'].
     )
 
 instances = {}
+# Our bastions run AL2023's minimal AMI, which doesn't ship with amazon-ssm-agent preinstalled.
+# This installs it so future rebuilds/replacements are reachable via SSM Session Manager.
+with open('bastion_user_data.sh') as user_data_fh:
+    bastion_user_data = user_data_fh.read()
+
 for instance in resources['tb:ec2:SshableInstance'].keys():
     instance_opts = resources['tb:ec2:SshableInstance'][instance]
+    instance_opts.setdefault('user_data', bastion_user_data)
     instances[instance] = tb_pulumi.ec2.SshableInstance(
         f'{project.name_prefix}-{instance}',
         project=project,

--- a/pulumi/bastion_user_data.sh
+++ b/pulumi/bastion_user_data.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#
+# Cloud-init script for SshableInstance (bastion) instances.
+#
+# Our bastions run AL2023's "minimal" AMI variant, which does not ship with amazon-ssm-agent
+# preinstalled like the standard AL2023 AMI does. Without this, the instance can't be reached
+# via AWS Systems Manager Session Manager, only direct SSH.
+#
+# Install command per AWS docs:
+# https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-al2.html
+#
+
+set -eux
+
+dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent


### PR DESCRIPTION
Adds cloud-init user_data to the bastion's SshableInstance so it installs, enables, and starts amazon-ssm-agent on boot. Our bastions run AL2023's minimal AMI, which doesn't ship the agent the way the standard AL2023 AMI does, so it has to be installed by hand or at launch.

This only takes effect on a future rebuild, replacement, or new environment. It does not touch the bastion running right now, since Pulumi applies user_data changes as an in-place instance attribute update rather than triggering a replace. The currently-running bastion is getting the agent installed manually in a separate step.

Verified with `pulumi preview` against the prod stack: the instance shows as an update, not a replace, with the only change being the new userData field.

Refs thunderbird/platform-infrastructure#1099
