### PR TITLE
Recover from user going back to /oidc/callback after a successful login (#1271)

### DIFF
--- a/src/thunderbird_accounts/authentication/tests/test_views.py
+++ b/src/thunderbird_accounts/authentication/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
 from django.test import Client as RequestClient, TestCase
@@ -6,6 +7,30 @@ from django.utils.crypto import get_random_string
 
 from thunderbird_accounts.authentication.models import AllowListEntry, User
 from thunderbird_accounts.core.tests.utils import oidc_force_login
+
+
+class RecoverableOIDCAuthenticationCallbackViewTestCase(TestCase):
+    def test_unknown_state_starts_a_fresh_login_flow(self):
+        session = self.client.session
+        session['oidc_states'] = {
+            'expected-state': {
+                'nonce': 'expected-nonce',
+                'code_verifier': None,
+                'added_on': 0,
+            }
+        }
+        session.save()
+
+        with self.assertLogs('thunderbird_accounts.authentication.views', level='WARNING') as logs:
+            response = self.client.get(
+                reverse('oidc_authentication_callback'),
+                {'code': 'unused-code', 'state': 'unknown-state'},
+            )
+
+        self.assertRedirects(response, reverse(settings.LOGIN_URL), fetch_redirect_response=False)
+        self.assertIn('starting a fresh login flow', logs.output[0])
+        self.assertNotIn('unknown-state', logs.output[0])
+        self.assertEqual(list(get_messages(response.wsgi_request)), [])
 
 
 class BulkImportAllowListTestCase(TestCase):

--- a/src/thunderbird_accounts/authentication/views.py
+++ b/src/thunderbird_accounts/authentication/views.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 import re
 
 from django.contrib import messages
@@ -17,13 +18,31 @@ from django.utils.translation import ngettext
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_http_methods
 from django.views.generic import TemplateView
-from mozilla_django_oidc.views import OIDCAuthenticationRequestView
+from mozilla_django_oidc.views import OIDCAuthenticationCallbackView, OIDCAuthenticationRequestView
 
 from thunderbird_accounts.authentication.mfa import MFA_REAUTH_PENDING_SESSION_KEY
 from thunderbird_accounts.authentication.utils import create_aia_url, KeycloakRequiredAction
 from thunderbird_accounts.core.utils import get_absolute_url
 
 DISCOUNT_ID_PATTERN = re.compile(r'^dsc_[a-z0-9]{26}$')
+logger = logging.getLogger(__name__)
+
+
+class RecoverableOIDCAuthenticationCallbackView(OIDCAuthenticationCallbackView):
+    """Restart login when a stale or already-used OIDC callback is revisited."""
+
+    def get(self, request):
+        state = request.GET.get('state')
+        if (
+            request.GET.get('code')
+            and state
+            and 'oidc_states' in request.session
+            and state not in request.session['oidc_states']
+        ):
+            logger.warning('OIDC callback state was not found in the session; starting a fresh login flow')
+            return HttpResponseRedirect(reverse(settings.LOGIN_URL))
+
+        return super().get(request)
 
 
 @login_required

--- a/src/thunderbird_accounts/settings.py
+++ b/src/thunderbird_accounts/settings.py
@@ -380,6 +380,7 @@ AUTH_SCHEME = os.getenv('AUTH_SCHEME', 'password')
 
 if AUTH_SCHEME == 'oidc':
     AUTHENTICATION_BACKENDS = ['thunderbird_accounts.authentication.middleware.AccountsOIDCBackend']
+    OIDC_CALLBACK_CLASS = 'thunderbird_accounts.authentication.views.RecoverableOIDCAuthenticationCallbackView'
     OIDC_RP_CLIENT_ID = os.getenv('OIDC_CLIENT_ID')
     OIDC_RP_CLIENT_SECRET = os.getenv('OIDC_CLIENT_SECRET')
     OIDC_RP_SIGN_ALGO = os.getenv('OIDC_SIGN_ALGO')


### PR DESCRIPTION
## What changed and why?

If a user navigated back in history to /oidc/callback URL, this could
result in a generic "Bad Request (400)" response as well as a Sentry issue.

Now we recover from this state by navigating forward back to the successful
login state result.

Sentry Issue: THUNDERBIRD-ACCOUNTS-2J

## Limitations and Notes

Malicious visits to this URL will still fail. This changes only the failure
response and not the authentication decision.

## Applicable Issues

 * [SuspiciousOperation: OIDC callback state not found in session `oidc_states`! · Issue #1271 · thunderbird/thunderbird-accounts](https://github.com/thunderbird/thunderbird-accounts/issues/1271)

