### PR TITLE
Fix E2E tests for dashboard-page by scoping menu links to the user menu dropdown

### DIFF
--- a/test/e2e/pages/dashboard-page.ts
+++ b/test/e2e/pages/dashboard-page.ts
@@ -70,8 +70,11 @@ export class DashboardPage {
     this.sendLink = this.page.locator('.service-icon-link').filter({ hasText: 'Send' });
     this.manageSubscriptionButton = this.page.getByRole('button', { name: 'Manage Subscription' });
     this.userAvatar = this.page.getByRole('banner').locator('.avatar');
-    this.supportLink = this.page.getByRole('link', { name: 'Support' });
-    this.logoutLink = this.page.getByRole('link', { name: 'Logout' });
+
+    // Scope menu links to the user menu dropdown
+    const userMenuDropdown = this.page.getByRole('banner').locator('.user-menu .dropdown');
+    this.supportLink = userMenuDropdown.getByRole('link', { name: 'Support', exact: true });
+    this.logoutLink = userMenuDropdown.getByRole('link', { name: 'Logout', exact: true });
     this.contactHeader = this.page.getByRole('heading', { name: 'Submit a request' });
   }
 


### PR DESCRIPTION
Since we've added a new support link in the footer, I accidentally broke the E2E tests heh 🤦 

By scoping the selectors to the user menu, it should now correctly find only one link!

Ref: https://github.com/thunderbird/thunderbird-accounts/actions/runs/34250407372/job/102145799455