### PR TITLE
Keep /oidc/callback out of browser history (#1271)

### DIFF
--- a/src/thunderbird_accounts/authentication/templates/authentication/oidc_callback_success.html
+++ b/src/thunderbird_accounts/authentication/templates/authentication/oidc_callback_success.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Completing login</title>
+  </head>
+  <body>
+    {{ redirect_url|json_script:"oidc-callback-redirect-url" }}
+    <script>
+      const redirectUrl = JSON.parse(document.getElementById('oidc-callback-redirect-url').textContent);
+      window.location.replace(redirectUrl);
+    </script>
+  </body>
+</html>

--- a/src/thunderbird_accounts/authentication/templates/authentication/oidc_callback_success.html
+++ b/src/thunderbird_accounts/authentication/templates/authentication/oidc_callback_success.html
@@ -2,9 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Completing login</title>
+    <noscript>
+      <meta http-equiv="refresh" content="0; url={{ redirect_url }}">
+    </noscript>
+    <title>Logging you in</title>
   </head>
   <body>
+    <noscript>
+      <p><a href="{{ redirect_url }}">Continue to complete your login</a>.</p>
+    </noscript>
     {{ redirect_url|json_script:"oidc-callback-redirect-url" }}
     <script>
       const redirectUrl = JSON.parse(document.getElementById('oidc-callback-redirect-url').textContent);

--- a/src/thunderbird_accounts/authentication/tests/test_views.py
+++ b/src/thunderbird_accounts/authentication/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.messages import get_messages
@@ -10,6 +12,39 @@ from thunderbird_accounts.core.tests.utils import oidc_force_login
 
 
 class RecoverableOIDCAuthenticationCallbackViewTestCase(TestCase):
+    @patch('mozilla_django_oidc.views.auth.authenticate')
+    def test_success_replaces_callback_history_with_destination(self, authenticate_mock):
+        user = User.objects.create(
+            username='user@example.com',
+            email='user@example.com',
+            oidc_id='user-oidc-id',
+        )
+        oidc_force_login(self.client, user)
+        authenticate_mock.return_value = user
+
+        session = self.client.session
+        session['oidc_states'] = {
+            'expected-state': {
+                'nonce': 'expected-nonce',
+                'code_verifier': None,
+                'added_on': 0,
+            }
+        }
+        session['oidc_login_next'] = '/mail'
+        session.save()
+
+        response = self.client.get(
+            reverse('oidc_authentication_callback'),
+            {'code': 'unused-code', 'state': 'expected-state'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'authentication/oidc_callback_success.html')
+        self.assertEqual(response.context['redirect_url'], '/mail')
+        self.assertContains(response, 'window.location.replace(redirectUrl)')
+        self.assertIn('no-store', response.headers['Cache-Control'])
+        self.assertEqual(response.headers['Referrer-Policy'], 'no-referrer')
+
     def test_unknown_state_starts_a_fresh_login_flow(self):
         session = self.client.session
         session['oidc_states'] = {

--- a/src/thunderbird_accounts/authentication/views.py
+++ b/src/thunderbird_accounts/authentication/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.http import HttpRequest, HttpResponseRedirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from urllib.parse import quote
 from django.conf import settings
@@ -28,9 +29,25 @@ DISCOUNT_ID_PATTERN = re.compile(r'^dsc_[a-z0-9]{26}$')
 logger = logging.getLogger(__name__)
 
 
+@method_decorator(never_cache, name='dispatch')
 class RecoverableOIDCAuthenticationCallbackView(OIDCAuthenticationCallbackView):
-    """Restart login when a stale or already-used OIDC callback is revisited."""
+    """Keep successful or stale OIDC callbacks out of the user's browser history."""
 
+    # The parent's `.get()` will call this.
+    # Display a small HTML page that redirects via the frontend so
+    # we can remove /oidc/callback from the browser history.
+    def login_success(self):
+        redirect_response = super().login_success()
+        response = TemplateResponse(
+            self.request,
+            'authentication/oidc_callback_success.html',
+            {'redirect_url': redirect_response.url},
+        )
+        # For increased security/privacy, don't pass along the referrer when redirecting.
+        response.headers['Referrer-Policy'] = 'no-referrer'
+        return response
+
+    # The parent class will dispatch GET handling here.
     def get(self, request):
         state = request.GET.get('state')
         if (


### PR DESCRIPTION
## What changed and why

Here we have /oidc/callback redirect via the frontend so that we can call
location.replace(), which will edit /oidc/callback out of the browser history.

This provides a cleaner browser history for users and prevents them from going
"back" to a URL that doesn't make sense to revisit.

This is a follup up to [Recover from user going back to /oidc/callback after a successful login (#1271) by markstos · Pull Request #1291 · thunderbird/thunderbird-accounts](https://github.com/thunderbird/thunderbird-accounts/pull/1291) where Mel suggested keeping /oidc/callback out of the browser history.

## QA Log

 * Because this is part of an auth flow, particular car was given to consider security issues. It's safe from XSS, it's not an open redirect, and we don't forward on the referrer header. This is a safe redirection method
 * Checked that other places are using this method during OIDC flows. Okta's official SDK is one example that uses window.location.replace() the same way: https://github.com/okta/okta-auth-js#handleredirectoriginaluri
 * After coding, manually tested the entry appears gone from the browser history.

## Limitations

 * Like much of our app, this requires JavaScript to be enabled.

## Applicable Issues

 * [SuspiciousOperation: OIDC callback state not found in session `oidc_states`! · Issue #1271 · thunderbird/thunderbird-accounts](https://github.com/thunderbird/thunderbird-accounts/issues/1271)

->
