### PR TITLE
Fix incorrect django templating for index.html in the noscript element.

### DIFF
--- a/src/thunderbird_accounts/core/templates/index.html
+++ b/src/thunderbird_accounts/core/templates/index.html
@@ -34,19 +34,18 @@
 </script>
 <noscript>
   {% block noscript %}
-  <style>
-    .center {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
-  </style>
-  <div class="center">
-    {% translate 'website' as link_text %}
-    {% set website = '<a href="https://tb.pro/">{{ link_text }}</a>'}
-    <h2>{% translate 'This site requires Javascript.' %}</h2>
-    <p>{% translate 'Please visit our {{ website }} for more information.' %}</p>
-  </div>
+    <style>
+      .center {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+    </style>
+    <div class="center">
+      {% translate 'website' as link_text %}
+      <h1>{% translate 'This site requires Javascript.' %}</h2>
+      <p>{% blocktranslate %}Please visit our <a href="https://tb.pro/">{{ link_text }}</a> for more information.{% endblocktranslate %}</p>
+    </div>
   {% endblock %}
 </noscript>
 {% block app_container %}


### PR DESCRIPTION
A minor thing I noticed while reviewing another PR. The set tag doesn't seem to exist, so I just inlined it. 

<img width="931" height="343" alt="image" src="https://github.com/user-attachments/assets/45f0e7ed-fc14-4cc7-8047-4e9c1c7c7cf0" />
