### PR TITLE
Workaround Stalwart v0.15 domain deletion bug (#1270)

### DIFF
--- a/src/thunderbird_accounts/mail/clients/mail_client_legacy.py
+++ b/src/thunderbird_accounts/mail/clients/mail_client_legacy.py
@@ -389,10 +389,20 @@ class MailClientLegacy(MailClientInterface):
         if not response_data or not response_data.get('total'):
             return None
 
-        # Dict comprehension to remove any duplicate _ids (there shouldn't be any, but I have trust issues.)
-        dkim_ids = {r.get('_id'): True for r in response_data.get('items', [])}
+        # Stalwart's filter is a substring match, and v0.15 may group a longer
+        # signer ID under an ID that is its prefix. Only delete the default
+        # signer IDs create_dkim() generates for this exact domain.
+        expected_dkim_ids = {f'{algorithm.lower()}-{domain}' for algorithm in settings.STALWART_DKIM_ALGOS}
+        dkim_ids = {
+            record.get('_id')
+            for record in response_data.get('items', [])
+            if record.get('domain') == domain and record.get('_id') in expected_dkim_ids
+        }
 
-        data = [{'type': 'clear', 'prefix': f'signature.{d}.'} for d in dkim_ids.keys()]
+        if not dkim_ids:
+            return None
+
+        data = [{'type': 'clear', 'prefix': f'signature.{dkim_id}.'} for dkim_id in sorted(dkim_ids)]
         response = requests.post(
             f'{self.api_url}/settings',
             json=data,

--- a/src/thunderbird_accounts/mail/tests/test_clients/test_legacy.py
+++ b/src/thunderbird_accounts/mail/tests/test_clients/test_legacy.py
@@ -478,7 +478,8 @@ class TestMailClientDeleteDkim(TestCase):
         success_get_response = requests.Response()
         success_get_response.status_code = 200
         success_get_response._content = bytes(
-            json.dumps({'data': {'total': 1, 'items': [{'_id': f'rsa-{self.domain}'}]}}), 'utf-8'
+            json.dumps({'data': {'total': 1, 'items': [{'_id': f'rsa-{self.domain}', 'domain': self.domain}]}}),
+            'utf-8',
         )
 
         requests_get_mock.return_value = success_get_response
@@ -496,6 +497,68 @@ class TestMailClientDeleteDkim(TestCase):
         self.assertEqual(self.domain, call_args[1].get('params', {}).get('filter'))
 
         requests_post_mock.assert_called_once()
+        self.assertEqual(
+            requests_post_mock.call_args.kwargs['json'],
+            [{'type': 'clear', 'prefix': f'signature.rsa-{self.domain}.'}],
+        )
+
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_only_deletes_signers_for_exact_domain(self, requests_post_mock: MagicMock, requests_get_mock: MagicMock):
+        """A substring/prefix collision in Stalwart must not delete another domain's signers."""
+        domain = 'example.com.au'
+        success_get_response = requests.Response()
+        success_get_response.status_code = 200
+        success_get_response._content = bytes(
+            json.dumps(
+                {
+                    'data': {
+                        'total': 4,
+                        'items': [
+                            {
+                                '_id': 'rsa-example.com',
+                                'domain': 'example.com',
+                                'au.domain': domain,
+                            },
+                            {'_id': 'ed25519-example.com', 'domain': 'example.com'},
+                            {'_id': f'rsa-{domain}', 'domain': domain},
+                            {'_id': f'ed25519-{domain}', 'domain': domain},
+                        ],
+                    }
+                }
+            ),
+            'utf-8',
+        )
+        requests_get_mock.return_value = success_get_response
+
+        success_post_response = requests.Response()
+        success_post_response.status_code = 200
+        requests_post_mock.return_value = success_post_response
+
+        response = self.mail_client.delete_dkim(domain)
+
+        self.assertIs(response, success_post_response)
+        self.assertEqual(
+            requests_post_mock.call_args.kwargs['json'],
+            [
+                {'type': 'clear', 'prefix': f'signature.ed25519-{domain}.'},
+                {'type': 'clear', 'prefix': f'signature.rsa-{domain}.'},
+            ],
+        )
+
+    @patch('requests.get')
+    @patch('requests.post')
+    def test_does_not_delete_unexpected_signer_id(self, requests_post_mock: MagicMock, requests_get_mock: MagicMock):
+        success_get_response = requests.Response()
+        success_get_response.status_code = 200
+        success_get_response._content = bytes(
+            json.dumps({'data': {'total': 1, 'items': [{'_id': 'rsa-other.com', 'domain': self.domain}]}}),
+            'utf-8',
+        )
+        requests_get_mock.return_value = success_get_response
+
+        self.assertIsNone(self.mail_client.delete_dkim(self.domain))
+        requests_post_mock.assert_not_called()
 
     @patch('requests.get')
     @patch('requests.post')
@@ -541,7 +604,8 @@ class TestMailClientDeleteDkim(TestCase):
         success_get_response = requests.Response()
         success_get_response.status_code = 200
         success_get_response._content = bytes(
-            json.dumps({'data': {'total': 1, 'items': [{'_id': f'rsa-{self.domain}'}]}}), 'utf-8'
+            json.dumps({'data': {'total': 1, 'items': [{'_id': f'rsa-{self.domain}', 'domain': self.domain}]}}),
+            'utf-8',
         )
 
         requests_get_mock.return_value = success_get_response


### PR DESCRIPTION
## What changed and why?

As explained in the linked issue, Stalwart could return more domains
then it should. We were trusting Stalwarts list and ending up deleting
too many domains.

Here we guard against that behavior by explicitly building a list of
domain records to delete instead of trusting Stalwart.

Stalwart 0.16+ doesn't have this bug.

## Limitations and Notes

- Although v0.15 is on the chopping block, this matters to customers impacted now and was an easy enough fix to justify a short-term fix.

- The scope here does not address restoring records which were previously deleted by this bug. That
scope can be addressed seperately.

## Related Issues

 * [delete_dkim clears unrelated signers via Stalwart substring filter · Issue #1270 · thunderbird/thunderbird-accounts](https://github.com/thunderbird/thunderbird-accounts/issues/1270#issuecomment-5590521193)
 * Follow-up issue for repairing impacted accounts: [Audit DKIM records for consistency after fixing DKIM deletion bug · Issue #1298 ](https://github.com/thunderbird/thunderbird-accounts/issues/1298)

## QA Log

 - With AI-assist, reviewed related Stalwart v0.15 and v0.16 source code to confirm bug in v0.15
   and fix in v0.16.
