### PR TITLE
feat(accounts): tell users to enable cookies when storage is blocked

### DIFF
--- a/assets/app/vue/App.test.ts
+++ b/assets/app/vue/App.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import i18n from '@/composables/i18n';
+import App from './App.vue';
+
+const mockIsStorageBlocked = vi.fn();
+
+vi.mock('@/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils')>();
+  return { ...actual, isStorageBlocked: () => mockIsStorageBlocked() };
+});
+
+// The app template pulls in HeaderBar/FooterBar/TrafficBanner, which read
+// window._page and waffle; stub them so this test focuses on the cookie notice.
+vi.mock('@/components/HeaderBar.vue', () => ({ default: { template: '<div />' } }));
+vi.mock('@/components/FooterBar.vue', () => ({ default: { template: '<div />' } }));
+vi.mock('@/components/TrafficBanner.vue', () => ({ default: { template: '<div />' } }));
+
+// Stub the services-ui NoticeBar to a plain slot wrapper: the real component's
+// internals are out of scope here, we only assert our own notice is rendered.
+vi.mock('@thunderbirdops/services-ui', () => ({
+  NoticeBar: {
+    props: ['type'],
+    template: '<div><slot /></div>',
+  },
+  NoticeBarTypes: { Critical: 'critical', Success: 'success', Warning: 'warning', Info: 'info' },
+}));
+
+const mountApp = async () => {
+  window._page = {
+    isAuthenticated: false,
+    userDisplayName: '',
+    needsTosAcceptance: false,
+    isAwaitingPaymentVerification: false,
+    hasActiveSubscription: false,
+    serverMessages: [],
+  } as Window['_page'];
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', name: 'home', component: { template: '<div />' } }],
+  });
+  router.push('/');
+  await router.isReady();
+
+  const wrapper = mount(App, { global: { plugins: [router, i18n] } });
+  await wrapper.vm.$nextTick();
+  return wrapper;
+};
+
+describe('App.vue cookies-disabled notice', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the enable-cookies notice when storage is blocked', async () => {
+    mockIsStorageBlocked.mockReturnValue(true);
+    const wrapper = await mountApp();
+
+    const notice = wrapper.find('[data-testid="cookies-disabled-notice"]');
+    expect(notice.exists()).toBe(true);
+    // Assert the localized message renders without coupling to exact wording.
+    expect(notice.text()).toBe(i18n.global.t('cookiesDisabled.message'));
+    expect(notice.text().length).toBeGreaterThan(0);
+  });
+
+  it('does not show the notice when storage is available', async () => {
+    mockIsStorageBlocked.mockReturnValue(false);
+    const wrapper = await mountApp();
+
+    expect(
+      wrapper.find('[data-testid="cookies-disabled-notice"]').exists()
+    ).toBe(false);
+  });
+});

--- a/assets/app/vue/App.vue
+++ b/assets/app/vue/App.vue
@@ -4,10 +4,18 @@ import TrafficBanner from '@/components/TrafficBanner.vue';
 import FooterBar from '@/components/FooterBar.vue';
 import { NoticeBar, NoticeBarTypes } from '@thunderbirdops/services-ui';
 import { SERVER_MESSAGE_LEVEL } from '@/types';
+import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { onMounted, ref } from 'vue';
+import { isStorageBlocked } from '@/utils';
 
+const { t } = useI18n();
 const serverMessages = ref(window._page?.serverMessages ?? []);
+
+// When the browser blocks cookies/storage the user cannot authenticate, so
+// tell them to enable cookies instead of leaving the app quietly broken.
+// Checked once at setup; no reactivity needed.
+const cookiesBlocked = isStorageBlocked();
 const serverLevelToNoticeBarType = (level: SERVER_MESSAGE_LEVEL) => {
   switch (level) {
     case SERVER_MESSAGE_LEVEL.ERROR:
@@ -41,11 +49,24 @@ onMounted(() => {
 </script>
 
 <template>
+  <!-- Rendered outside the app-template branch so a cookie-blocked user sees it
+       everywhere, including unauthenticated routes (sign-up, error, 404) that
+       use the bare router-view below. -->
+  <section class="server-messages cookies-blocked" v-if="cookiesBlocked">
+    <notice-bar
+      class="server-message"
+      data-testid="cookies-disabled-notice"
+      :type="NoticeBarTypes.Critical"
+    >
+      {{ t('cookiesDisabled.message') }}
+    </notice-bar>
+  </section>
+
   <div class="page-container" v-if="route?.meta?.useAppTemplate ?? true">
     <traffic-banner />
     <header-bar />
 
-    <section class="server-messages" v-if="serverMessages !== null">
+    <section class="server-messages" v-if="serverMessages.length">
       <template v-for="message in serverMessages" :key="message.message">
         <notice-bar
           class="server-message"

--- a/assets/app/vue/composables/useTour.ts
+++ b/assets/app/vue/composables/useTour.ts
@@ -1,4 +1,5 @@
 import { ref, computed, watch, nextTick } from 'vue';
+import { safeGetStorageItem, safeSetStorageItem } from '@/utils';
 
 export const FTUE_STEPS = {
   INITIAL: 0,
@@ -25,13 +26,12 @@ interface StepConfig {
 const FTUE_STORAGE_KEY = 'tb_accounts_ftue_completed';
 const TOUR_CARD_SELECTOR = '[data-tour-card]';
 
-// Get the initial state of the FTUE from localStorage or return true if not available
+// Get the initial state of the FTUE from localStorage or return true if not
+// available. safeGetStorageItem never throws: when the browser blocks storage
+// the localStorage getter itself raises a SecurityError, and this runs at
+// bundle-boot module scope, so an unguarded read would crash the whole app.
 const getInitialState = () => {
-  if (typeof localStorage !== 'undefined') {
-    return localStorage.getItem(FTUE_STORAGE_KEY) !== 'true';
-  }
-
-  return true;
+  return safeGetStorageItem(FTUE_STORAGE_KEY) !== 'true';
 };
 
 const currentStep = ref<FtueStepId>(FTUE_STEPS.INITIAL);
@@ -58,9 +58,7 @@ watch(showFTUE, (value) => {
 
   document.removeEventListener('keydown', onEscapeKey);
 
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem(FTUE_STORAGE_KEY, 'true');
-  }
+  safeSetStorageItem(FTUE_STORAGE_KEY, 'true');
 }, { immediate: true });
 
 export const useTour = () => {

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "cookiesDisabled": {
+    "message": "Thundermail requires essential cookies in order to authenticate your session across our services. Please enable cookies to continue."
+  },
   "navigationLinks": {
     "account": "Account",
     "dashboard": "Dashboard",

--- a/assets/app/vue/utils.test.ts
+++ b/assets/app/vue/utils.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  defaultLocale,
+  isStorageBlocked,
+  safeGetStorageItem,
+  safeRemoveStorageItem,
+  safeSetStorageItem,
+} from './utils';
+
+/**
+ * When the browser blocks cookies/storage (e.g. Thunderbird's "block all
+ * cookies"), Firefox makes localStorage access *throw* a SecurityError
+ * DOMException rather than return an empty store. defaultLocale() read storage
+ * unguarded, so it threw and broke app boot with no explanation. These tests
+ * pin the guarded behavior and the detection helper the UI uses to show the
+ * "enable cookies" message.
+ */
+describe('utils storage handling', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'localStorage'
+  );
+
+  /** Installs a localStorage whose getItem returns the given value. */
+  function stubStorage(value: string | null) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: { getItem: vi.fn(() => value) } as Partial<Storage>,
+    });
+  }
+
+  /**
+   * Installs a localStorage whose access throws, like a blocked-storage
+   * browser. Firefox with "block all cookies" raises a SecurityError
+   * DOMException even for a read.
+   */
+  function blockStorage() {
+    const throwing = new DOMException(
+      'The operation is insecure.',
+      'SecurityError'
+    );
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw throwing;
+      },
+    });
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis.navigator, 'language', {
+      configurable: true,
+      value: 'fr-FR',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', originalDescriptor);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  });
+
+  describe('isStorageBlocked', () => {
+    it('is false when storage is available', () => {
+      stubStorage(null);
+      expect(isStorageBlocked()).toBe(false);
+    });
+
+    it('is true when reading storage throws a DOMException', () => {
+      blockStorage();
+      expect(isStorageBlocked()).toBe(true);
+    });
+  });
+
+  describe('safe storage accessors', () => {
+    it('safeGetStorageItem returns the value when storage works', () => {
+      stubStorage('value');
+      expect(safeGetStorageItem('any')).toBe('value');
+    });
+
+    it('safeGetStorageItem returns null instead of throwing when blocked', () => {
+      blockStorage();
+      expect(() => safeGetStorageItem('any')).not.toThrow();
+      expect(safeGetStorageItem('any')).toBeNull();
+    });
+
+    it('safeSetStorageItem does not throw when storage is blocked', () => {
+      blockStorage();
+      expect(() => safeSetStorageItem('k', 'v')).not.toThrow();
+    });
+
+    it('safeRemoveStorageItem does not throw when storage is blocked', () => {
+      blockStorage();
+      expect(() => safeRemoveStorageItem('k')).not.toThrow();
+    });
+  });
+
+  describe('defaultLocale', () => {
+    it('returns the stored user language when present', () => {
+      stubStorage(JSON.stringify({ settings: { language: 'de' } }));
+      expect(defaultLocale()).toBe('de');
+    });
+
+    it('falls back to the navigator language when no user is stored', () => {
+      stubStorage(null);
+      expect(defaultLocale()).toBe('fr');
+    });
+
+    it('does not throw and falls back when storage is blocked', () => {
+      blockStorage();
+      expect(() => defaultLocale()).not.toThrow();
+      expect(defaultLocale()).toBe('fr');
+    });
+
+    it('falls back gracefully when the stored value is malformed JSON', () => {
+      stubStorage('{not valid json');
+      expect(() => defaultLocale()).not.toThrow();
+      expect(defaultLocale()).toBe('fr');
+    });
+  });
+});

--- a/assets/app/vue/utils.ts
+++ b/assets/app/vue/utils.ts
@@ -1,9 +1,69 @@
 import { WAFFLE_FLAG, WAFFLE_SWITCH } from '@/types';
 
+/**
+ * Accessing localStorage/sessionStorage throws (rather than returning an empty
+ * store) when the browser is set to block cookies/storage — e.g. Thunderbird's
+ * "block all cookies". Firefox raises a SecurityError DOMException
+ * ("The operation is insecure.") even for a read. Thundermail keeps the session
+ * in a cookie, so a user in this state cannot authenticate; we detect it here so
+ * the UI can tell them to enable cookies instead of failing silently.
+ */
+export const isStorageBlocked = (): boolean => {
+  try {
+    // A read is enough to trigger the DOMException when storage is blocked.
+    // The key is arbitrary and never written; we only care whether access
+    // throws.
+    void localStorage?.getItem('tba/storage-probe');
+    return false;
+  } catch {
+    return true;
+  }
+};
+
+/**
+ * Read from localStorage without ever throwing. When storage is blocked, even
+ * `typeof localStorage` and optional chaining do not help: the `window
+ * .localStorage` *getter itself* throws SecurityError, so every access must be
+ * wrapped. Returns null when storage is unavailable or the key is missing.
+ */
+export const safeGetStorageItem = (key: string): string | null => {
+  try {
+    return localStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/** Write to localStorage without ever throwing (no-op when storage is blocked). */
+export const safeSetStorageItem = (key: string, value: string): void => {
+  try {
+    localStorage?.setItem(key, value);
+  } catch {
+    // Storage blocked: nothing we can do, and this must never break the caller.
+  }
+};
+
+/** Remove from localStorage without ever throwing (no-op when storage is blocked). */
+export const safeRemoveStorageItem = (key: string): void => {
+  try {
+    localStorage?.removeItem(key);
+  } catch {
+    // Storage blocked: nothing we can do, and this must never break the caller.
+  }
+};
+
 // Check if we already have a local user preferred language
 // Otherwise just use the navigators language.
 export const defaultLocale = () => {
-  const user = JSON.parse(localStorage?.getItem('tba/user') ?? '{}');
+  let user: { settings?: { language?: string } } = {};
+  try {
+    user = JSON.parse(safeGetStorageItem('tba/user') ?? '{}');
+  } catch {
+    // Malformed value: fall back to the navigator language. Storage-blocked
+    // reads are already swallowed by safeGetStorageItem; isStorageBlocked()
+    // surfaces the cookies-disabled message separately, so we must not let this
+    // throw and break app boot.
+  }
   return user?.settings?.language ?? navigator.language.split('-')[0];
 };
 
@@ -12,4 +72,3 @@ export const isWaffleFlagActive = (flag: WAFFLE_FLAG): boolean =>
 
 export const isWaffleSwitchActive = (switchName: WAFFLE_SWITCH): boolean =>
   Boolean((window as any).waffle?.switch_is_active?.(switchName));
-

--- a/assets/app/vue/views/DashboardView/index.vue
+++ b/assets/app/vue/views/DashboardView/index.vue
@@ -5,9 +5,12 @@ import AccountCard from './components/AccountCard.vue';
 import PrivacyAndDataCard from './components/PrivacyAndDataCard.vue';
 import YourCurrentSubscription from './components/YourCurrentSubscription.vue';
 import { PADDLE_TRANSACTION_STORAGE_KEY } from '@/defines';
+import { safeRemoveStorageItem } from '@/utils';
 
 // Just in case, attempt to empty the stored Paddle transaction id here too.
-window.localStorage?.removeItem(PADDLE_TRANSACTION_STORAGE_KEY);
+// safeRemoveStorageItem never throws: optional chaining does not help when the
+// browser blocks storage, because the window.localStorage getter itself throws.
+safeRemoveStorageItem(PADDLE_TRANSACTION_STORAGE_KEY);
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## What changed?

When the browser is set to block cookies, Thundermail now shows a clear message telling the user to enable them, instead of failing to load with no explanation.

Blocking cookies in the browser (for example Thunderbird's "block all cookies") makes reading browser storage *throw an error* rather than come back empty. A few pieces of the app read storage the moment it starts up, so the whole page broke before anything could be shown. This change makes those storage reads safe and adds a prominent notice, shown on every page, asking the user to enable cookies so they can sign in.

AI disclosure: agent-written, human-directed. A human set the scope (detect the blocked state and show a message, matching the earlier Send fix) and reviewed the change; the investigation, code, and tests were written by the agent and reviewed step by step.

## Why?

Thundermail keeps you signed in with a cookie. When the browser refuses cookies, that cookie never reaches the server and the app quietly stops working. On top of that, the startup code read browser storage without guarding it, so on Firefox the read threw and the app crashed before it could render anything — meaning even a warning had nowhere to appear. This makes the startup path resilient and gives the user an actionable message.

## Limitations and Notes

- The message is shown in the accounts app. The Keycloak sign-in theme does not read browser storage at boot, so there is nothing to guard there; a fully cookieless user is stopped by Keycloak's own flow before reaching us.
- This detects and explains the blocked state; it does not remove the app's dependence on cookies for sign-in (that is separate, larger work).

## Applicable Issues

Closes #1279.

## Screenshots

_No screenshot: this adds a standard critical NoticeBar (the same component already used for server messages) with the copy from the issue. It renders at the top of every route when storage is blocked._

## Manual testing

Prerequisites: run the accounts app locally (see the README for the docker-compose dev stack), and sign in first so you are testing the cookies-blocked case rather than being logged out.

1. **Reproduce the bug (before this change):** In your browser, block all cookies for the accounts site, then load the app. Expected on `main`: a blank/broken page (the bundle throws on startup).
2. **With this change — blocked cookies:** With cookies still blocked, load any accounts page (dashboard, sign-up, an error route, a 404). Expected: the app renders and a red notice appears at the top saying *"Thundermail requires essential cookies in order to authenticate your session across our services. Please enable cookies to continue."* No blank page and no crash.
3. **Fix it live:** Re-allow cookies for the site and reload. Expected: the notice is gone and the app behaves normally.
4. **Language fallback:** With cookies blocked, confirm the app still picks a sensible language (falls back to the browser language) rather than erroring.

### Automated tests

`./node_modules/.bin/vitest run --dir assets/app/vue` — 29 passing, including new unit tests for the storage guards/`defaultLocale()` fallback and a component test asserting the notice shows only when storage is blocked. (Automated tests are provided in addition to, not instead of, the manual steps above.)
