### PR TITLE
Downgrade log-level when when account does not exist during account removal. (#1302)

### DIFF
--- a/src/thunderbird_accounts/mail/views.py
+++ b/src/thunderbird_accounts/mail/views.py
@@ -402,7 +402,7 @@ def remove_custom_domain(request: AuthenticatedHttpRequest):
     try:
         account = Account.objects.get(user=request.user)
     except Account.DoesNotExist:
-        logging.error(f'Account not found for user {request.user.uuid}')
+        logging.info(f'remove_custom_domain: Account not found for user {request.user.uuid}')
         return JsonResponse(
             {'success': False, 'error': _('There was an error retrieving your mail account.')},
             status=404,


### PR DESCRIPTION
## What changed and why

This is state is expected to happen sometimes if users double-click "remove domain".
The first request deletes the domain the second one hits this state. In that case,
a log info level if sufficient (and will stop creating a Sentry exception).

Logging string was also updated to help differiate it from similar "account not found"
log signatures.

## Applicable Issues

* [Downgrade logging for expected Account.DoesNotExist case in custom-domains/remove · Issue #1302 · thunderbird/thunderbird-accounts](https://github.com/thunderbird/thunderbird-accounts/issues/1302)

## QA Log

 * Recently dealt with very similar cases in the same way
 * Reviewed other places where we handle Account.DoesNotExist to see if others made sense to update
   their log levels as well. In the other cases, it seemed more like the case /might/ represent a real issue. As we are only getting Sentry'ed about this, I left the others alone.
