### PR TITLE
Add aria-hidden to decorative icons and labels to icon-only buttons

### DIFF
--- a/assets/app/vue/components/CardContainer.vue
+++ b/assets/app/vue/components/CardContainer.vue
@@ -37,8 +37,8 @@ defineEmits<{
         :title="isPinned ? t('components.cardContainer.unpin') : t('components.cardContainer.pin')"
         @click="$emit('togglePinned')"
       >
-        <ph-push-pin v-if="isPinned" size="20" />
-        <ph-push-pin-simple v-else size="20" />
+        <ph-push-pin v-if="isPinned" size="20" aria-hidden="true" />
+        <ph-push-pin-simple v-else size="20" aria-hidden="true" />
       </button>
     </header>
 

--- a/assets/app/vue/components/GenericModal.vue
+++ b/assets/app/vue/components/GenericModal.vue
@@ -27,8 +27,8 @@ defineExpose({
 
 <template>
   <dialog ref="modal">
-    <button class="close-button" @click="handleClose">
-      <ph-x size="24" />
+    <button class="close-button" @click="handleClose" :aria-label="$t('components.genericModal.close')">
+      <ph-x size="24" aria-hidden="true" />
     </button>
 
     <div class="modal-scroll-area">

--- a/assets/app/vue/components/ServerSettingsCard.vue
+++ b/assets/app/vue/components/ServerSettingsCard.vue
@@ -88,7 +88,7 @@ const incomingServerDetails = computed(() =>
         <template #footer v-if="showFooter">
           <template v-if="incomingServerSelectedTab === INCOMING_SERVER_TABS.IMAP">
             <div class="what-is-container">
-              <ph-info size="24" weight="fill" />
+              <ph-info size="24" weight="fill" aria-hidden="true" />
               <span>{{ t('views.mail.sections.dashboard.whatIsImap') }}</span>
   
               <tool-tip :alt="t('views.mail.sections.dashboard.whatIsImap')">
@@ -102,7 +102,7 @@ const incomingServerDetails = computed(() =>
           </template>
           <template v-else>
             <div class="what-is-container">
-              <ph-info size="24" weight="fill" />
+              <ph-info size="24" weight="fill" aria-hidden="true" />
               <span>{{ t('views.mail.sections.dashboard.whatIsJmap') }}</span>
   
               <tool-tip :alt="t('views.mail.sections.dashboard.whatIsJmap')">
@@ -135,7 +135,7 @@ const incomingServerDetails = computed(() =>
   
         <template #footer v-if="showFooter">
           <div class="what-is-container">
-            <ph-info size="24" weight="fill" />
+            <ph-info size="24" weight="fill" aria-hidden="true" />
             <span>{{ t('views.mail.sections.dashboard.whatIsSmtp') }}</span>
   
             <tool-tip :alt="t('views.mail.sections.dashboard.whatIsSmtp')">

--- a/assets/app/vue/components/ServerSettingsCardItem.vue
+++ b/assets/app/vue/components/ServerSettingsCardItem.vue
@@ -42,26 +42,26 @@ const copyValue = async (value: string | number) => {
 
     <div class="server-detail-item">
       <div class="server-detail-item-label">
-        <ph-database size="16" />
+        <ph-database size="16" aria-hidden="true" />
         <strong>{{ t('views.mail.sections.dashboard.server') }}</strong>
       </div>
       <div class="server-detail-item-value">
         <span>{{ details.server }}</span>
         <button type="button" class="copy-btn" @click="copyValue(details.server)" :aria-label="t('views.mail.sections.dashboard.copyServer')">
-          <ph-copy-simple size="12" />
+          <ph-copy-simple size="12" aria-hidden="true" />
         </button>
       </div>
     </div>
 
     <div class="server-detail-item">
       <div class="server-detail-item-label">
-        <ph-shield-check size="16" />
+        <ph-shield-check size="16" aria-hidden="true" />
         <strong>{{ t('views.mail.sections.dashboard.port') }}</strong>
       </div>
       <div class="server-detail-item-value">
         <span>{{ details.port }}</span>
         <button type="button" class="copy-btn" @click="copyValue(details.port)" :aria-label="t('views.mail.sections.dashboard.copyPort')">
-          <ph-copy-simple size="12" />
+          <ph-copy-simple size="12" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/assets/app/vue/components/TourCard.vue
+++ b/assets/app/vue/components/TourCard.vue
@@ -38,7 +38,7 @@ const isWelcome = computed(() => props.variant === 'welcome');
     <header v-if="!isWelcome">
       <p>{{ t('views.mail.ftue.step', { step: currentStep, total: totalSteps }) }}</p>
       <button class="close-button" :aria-label="t('views.mail.ftue.close')" @click="emit('close')">
-        <ph-x-circle size="24" />
+        <ph-x-circle size="24" aria-hidden="true" />
       </button>
     </header>
 

--- a/assets/app/vue/locales/en.json
+++ b/assets/app/vue/locales/en.json
@@ -37,6 +37,9 @@
     },
     "trafficBanner": {
       "message": "We're currently experiencing high demand. Pages may load slowly, and some features may not work. Thank you for your patience."
+    },
+    "genericModal": {
+      "close": "Close dialog"
     }
   },
   "views": {
@@ -223,7 +226,8 @@
           "displayNameRequired": "Display name is required",
           "emailAliasesArticleTitle": "Setting Up Email Aliases",
           "emailAliasesCatchAllArticleTitle": "Setting Up a Catch-All Alias",
-          "emailAliasSupportText": "For help with aliases, see {emailAliasesSupportLink}. For catch-all aliases, see {emailAliasesCatchAllSupportLink}."
+          "emailAliasSupportText": "For help with aliases, see {emailAliasesSupportLink}. For catch-all aliases, see {emailAliasesCatchAllSupportLink}.",
+          "aliasActions": "Alias actions"
         },
         "customDomains": {
           "customDomains": "Custom Domains",
@@ -288,7 +292,9 @@
             "readGreetingError": "We could not verify that the domain records connect to Thundermail",
             "autodiscoverRecordFound": "The autodiscover DNS record must be removed.",
             "autodiscoverSrvRecordFound": "The _autodiscover._tcp DNS record must be removed."
-          }
+          },
+          "dismissNotice": "Dismiss",
+          "domainActions": "Domain actions"
         },
         "securitySettings": {
           "securitySettings": "Security Settings",
@@ -322,7 +328,8 @@
           "addToAllowList": "Add to allow list",
           "save": "Save",
           "removedSuccessfully": "Removed {email} from allow list",
-          "undo": "Undo"
+          "undo": "Undo",
+          "removeFromAllowList": "Remove from allow list"
         },
         "signUp": {
           "continue": "Continue",

--- a/assets/app/vue/views/CustomDomainsView/CustomDomainsSection/components/ActionsMenu.vue
+++ b/assets/app/vue/views/CustomDomainsView/CustomDomainsSection/components/ActionsMenu.vue
@@ -108,8 +108,8 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="actions-menu" ref="menuRef">
-    <button class="kebab-menu-button" @click="toggleMenu">
-      <ph-dots-three-vertical size="20" />
+    <button class="kebab-menu-button" @click="toggleMenu" :aria-label="t('views.mail.sections.customDomains.domainActions')">
+      <ph-dots-three-vertical size="20" aria-hidden="true" />
     </button>
 
     <div v-if="showMenu" class="dropdown">

--- a/assets/app/vue/views/CustomDomainsView/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/CustomDomainsView/CustomDomainsSection/components/CustomDomainForm.vue
@@ -663,8 +663,8 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
       <p>{{ t('views.mail.sections.customDomains.verifyStepInfoDescription') }}</p>
 
       <template #cta>
-        <button class="close-button" @click="showNoticeBar = false">
-          <ph-x size="24" />
+        <button class="close-button" @click="showNoticeBar = false" :aria-label="t('views.mail.sections.customDomains.dismissNotice')">
+          <ph-x size="24" aria-hidden="true" />
         </button>
       </template>
     </notice-bar> -->

--- a/assets/app/vue/views/CustomDomainsView/CustomDomainsSection/index.vue
+++ b/assets/app/vue/views/CustomDomainsView/CustomDomainsSection/index.vue
@@ -87,13 +87,13 @@ export default {
 
       <div class="custom-domains-list" v-if="customDomains.length > 0">
         <div class="custom-domain-item" v-for="domain in customDomains" :key="domain.name">
-          <ph-globe size="20" />
+          <ph-globe size="20" aria-hidden="true" />
           <p>{{ domain.name }}</p>
 
           <template v-if="domain.status === DOMAIN_STATUS.VERIFIED">
             <base-badge :type="BaseBadgeTypes.Verified">
               <template #icon>
-                <ph-check-circle size="16" weight="fill" />
+                <ph-check-circle size="16" weight="fill" aria-hidden="true" />
               </template>
               {{ t('views.mail.sections.customDomains.verified') }}
             </base-badge>
@@ -124,8 +124,8 @@ export default {
         <p>{{ errorMessage }}</p>
 
         <template #cta>
-          <button @click="errorMessage = null">
-            <ph-x size="24" />
+          <button @click="errorMessage = null" :aria-label="t('views.mail.sections.customDomains.dismissNotice')">
+            <ph-x size="24" aria-hidden="true" />
           </button>
         </template>
       </notice-bar>

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/ActionsMenu.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/ActionsMenu.vue
@@ -108,8 +108,8 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="actions-menu" ref="menuRef">
-    <button class="kebab-menu-button" @click="toggleMenu">
-      <ph-dots-three-vertical size="20" />
+    <button class="kebab-menu-button" @click="toggleMenu" :aria-label="t('views.mail.sections.customDomains.domainActions')">
+      <ph-dots-three-vertical size="20" aria-hidden="true" />
     </button>
 
     <div v-if="showMenu" class="dropdown">

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/components/CustomDomainForm.vue
@@ -663,8 +663,8 @@ watch(() => props.lastDomainRemoved, (newLastDomainRemoved) => {
       <p>{{ t('views.mail.sections.customDomains.verifyStepInfoDescription') }}</p>
 
       <template #cta>
-        <button class="close-button" @click="showNoticeBar = false">
-          <ph-x size="24" />
+        <button class="close-button" @click="showNoticeBar = false" :aria-label="t('views.mail.sections.customDomains.dismissNotice')">
+          <ph-x size="24" aria-hidden="true" />
         </button>
       </template>
     </notice-bar> -->

--- a/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/CustomDomainsSection/index.vue
@@ -87,13 +87,13 @@ export default {
 
       <div class="custom-domains-list" v-if="customDomains.length > 0">
         <div class="custom-domain-item" v-for="domain in customDomains" :key="domain.name">
-          <ph-globe size="20" />
+          <ph-globe size="20" aria-hidden="true" />
           <p>{{ domain.name }}</p>
 
           <template v-if="domain.status === DOMAIN_STATUS.VERIFIED">
             <base-badge :type="BaseBadgeTypes.Verified">
               <template #icon>
-                <ph-check-circle size="16" weight="fill" />
+                <ph-check-circle size="16" weight="fill" aria-hidden="true" />
               </template>
               {{ t('views.mail.sections.customDomains.verified') }}
             </base-badge>
@@ -124,8 +124,8 @@ export default {
         <p>{{ errorMessage }}</p>
 
         <template #cta>
-          <button @click="errorMessage = null">
-            <ph-x size="24" />
+          <button @click="errorMessage = null" :aria-label="t('views.mail.sections.customDomains.dismissNotice')">
+            <ph-x size="24" aria-hidden="true" />
           </button>
         </template>
       </notice-bar>

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailDesktop.vue
@@ -72,7 +72,7 @@ export default {
         <p class="error-message" v-if="error">{{ error }}</p>
 
         <template #icon>
-          <ph-arrow-square-out :size="20" />
+          <ph-arrow-square-out :size="20" aria-hidden="true" />
         </template>
         <template #action>
           <div class="connect-action" ref="connectAction">
@@ -116,7 +116,7 @@ export default {
       :description="t('views.mail.sections.dashboard.getStartedWithThundermail.desktopPanel.downloadDescription')"
     >
       <template #icon>
-        <ph-download-simple :size="20" />
+        <ph-download-simple :size="20" aria-hidden="true" />
       </template>
       <template #action>
         <primary-button

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailMobile.vue
@@ -64,7 +64,7 @@ export default {
         class="qr-code-details-summary"
       >
         <template #icon>
-          <ph-qr-code :size="20" />
+          <ph-qr-code :size="20" aria-hidden="true" />
         </template>
         <img
           class="qr-code"
@@ -79,7 +79,7 @@ export default {
       :description="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.downloadDescription')"
     >
       <template #icon>
-        <ph-download-simple :size="20" />
+        <ph-download-simple :size="20" aria-hidden="true" />
       </template>
       <template #action>
         <primary-button
@@ -100,14 +100,14 @@ export default {
       :description="t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.iosDescription')"
     >
       <template #icon>
-        <ph-lifebuoy :size="20" />
+        <ph-lifebuoy :size="20" aria-hidden="true" />
       </template>
       <template #action>
         <link-button size="small" :href="IOS_SUPPORT_URL" target="_blank" class="ios-help-button">
           {{ t('views.mail.sections.dashboard.getStartedWithThundermail.mobilePanel.iosSupportButtonLabel') }}
 
           <template #iconRight>
-            <ph-arrow-right :size="16" />
+            <ph-arrow-right :size="16" aria-hidden="true" />
           </template>
         </link-button>
       </template>

--- a/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
+++ b/assets/app/vue/views/MailView/sections/DashboardSection/components/GetStartedWithThundermailOtherApps.vue
@@ -23,7 +23,7 @@ const { t } = useI18n();
     <!-- Manual Configuration -->
     <action-card :title="t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.manualConfigurationTitle')">
       <template #icon>
-        <ph-gear :size="20" />
+        <ph-gear :size="20" aria-hidden="true" />
       </template>
 
       <server-settings-card is-manual-configuration-section :show-footer=false />
@@ -35,14 +35,14 @@ const { t } = useI18n();
       :description="t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.needHelpDescription')"
     >
       <template #icon>
-        <ph-lifebuoy :size="20" />
+        <ph-lifebuoy :size="20" aria-hidden="true" />
       </template>
       <template #action>
         <link-button size="small" :href="OTHER_APPS_SUPPORT_URL" target="_blank" class="need-help-button">
           {{ t('views.mail.sections.dashboard.getStartedWithThundermail.otherAppsPanel.needHelpButtonLabel') }}
 
           <template #iconRight>
-            <ph-arrow-right :size="16" />
+            <ph-arrow-right :size="16" aria-hidden="true" />
           </template>
         </link-button>
       </template>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/AppPasswordSide.vue
@@ -98,7 +98,7 @@ const onCancelSetPassword = () => {
       <p>
         {{ t('views.mail.sections.emailSettings.changePasswordDescriptionTwo') }}
         <span class="info-tooltip-trigger">
-          <ph-info size="16" />
+          <ph-info size="16" aria-hidden="true" />
           <tool-tip :alt="t('views.mail.sections.emailSettings.changePasswordTooltip')">
             <span>{{ t('views.mail.sections.emailSettings.changePasswordTooltip') }}</span>
           </tool-tip>
@@ -109,7 +109,7 @@ const onCancelSetPassword = () => {
       <p>
         {{ t('views.mail.sections.emailSettings.createPasswordDescriptionTwo') }}
         <span class="info-tooltip-trigger">
-          <ph-info size="16" />
+          <ph-info size="16" aria-hidden="true" />
           <tool-tip :alt="t('views.mail.sections.emailSettings.createPasswordTooltip')">
             <i18n-t keypath="views.mail.sections.emailSettings.createPasswordTooltip" tag="span">
               <template #supportUrl>
@@ -126,7 +126,7 @@ const onCancelSetPassword = () => {
       <template v-slot:cta>
         <button class="close-button" @click="successMessage = null"
           :aria-label="$t('views.mail.sections.emailSettings.close')">
-          <ph-x size="24" />
+          <ph-x size="24" aria-hidden="true" />
         </button>
       </template>
     </notice-bar>
@@ -150,7 +150,7 @@ const onCancelSetPassword = () => {
           <template v-slot:cta>
             <button class="close-button" @click="errorMessage = null"
               :aria-label="$t('views.mail.sections.emailSettings.close')">
-              <ph-x size="24" />
+              <ph-x size="24" aria-hidden="true" />
             </button>
           </template>
         </notice-bar>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliasActionsMenu.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliasActionsMenu.vue
@@ -60,8 +60,8 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="actions-menu" ref="menuRef">
-    <button class="kebab-menu-button" @click="toggleMenu">
-      <ph-dots-three-vertical size="20" />
+    <button class="kebab-menu-button" @click="toggleMenu" :aria-label="t('views.mail.sections.emailSettings.aliasActions')">
+      <ph-dots-three-vertical size="20" aria-hidden="true" />
     </button>
 
     <div v-if="showMenu" class="dropdown">

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/EmailAliases.vue
@@ -109,7 +109,7 @@ const onDeleteAliasError = (error: string) => {
           }) }}
           <aside aria-labelledby="catch-all-tooltip" class="info-tooltip-trigger" tabindex="0"
             v-if="catchAlls.length >= customDomains.length">
-            <ph-info size="13" />
+            <ph-info size="13" aria-hidden="true" />
             <tool-tip id="catch-all-tooltip" :alt="t('views.mail.sections.emailSettings.catchAllTooltip')">
               <i18n-t keypath="views.mail.sections.emailSettings.catchAllTooltip" tag="span">
                 <template #supportUrl>
@@ -158,8 +158,8 @@ const onDeleteAliasError = (error: string) => {
       <p>{{ errorMessage }}</p>
 
       <template #cta>
-        <button @click="errorMessage = null">
-          <ph-x size="16" />
+        <button @click="errorMessage = null" :aria-label="t('views.mail.sections.emailSettings.close')">
+          <ph-x size="16" aria-hidden="true" />
         </button>
       </template>
     </notice-bar>

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/ViewServerSettings.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/components/ViewServerSettings.vue
@@ -10,7 +10,7 @@ const { t } = useI18n();
 <template>
   <details-summary :title="t('views.mail.sections.dashboard.viewServerSettings')">
     <template #icon>
-      <ph-sliders size="24" />
+      <ph-sliders size="24" aria-hidden="true" />
     </template>
 
     <server-settings-card

--- a/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
+++ b/assets/app/vue/views/MailView/sections/EmailSettingsSection/index.vue
@@ -38,7 +38,7 @@ export default {
         default-open
       >
         <template #icon>
-          <ph-sliders size="24" />
+          <ph-sliders size="24" aria-hidden="true" />
         </template>
 
         <email-aliases />

--- a/assets/app/vue/views/MailView/views/SecuritySettingsView/components/AccountActivity.vue
+++ b/assets/app/vue/views/MailView/views/SecuritySettingsView/components/AccountActivity.vue
@@ -42,7 +42,7 @@ const signOut = (id: number) => {
 <template>
   <details-summary :title="t('views.mail.views.securitySettings.accountActivity')" :expandable="false" default-open>
     <template #icon>
-      <ph-devices size="24" />
+      <ph-devices size="24" aria-hidden="true" />
     </template>
 
     <template v-if="accountActivityRecords.length > 0">

--- a/assets/app/vue/views/MailView/views/SecuritySettingsView/components/AllowList.vue
+++ b/assets/app/vue/views/MailView/views/SecuritySettingsView/components/AllowList.vue
@@ -47,7 +47,7 @@ const onShowMore = () => {
 <template>
   <details-summary :title="t('views.mail.views.securitySettings.allowList')" :expandable="false" default-open>
     <template #icon>
-      <ph-shield-check size="24" />
+      <ph-shield-check size="24" aria-hidden="true" />
     </template>
 
     <p>{{ t('views.mail.views.securitySettings.allowListDescription') }}</p>
@@ -66,8 +66,8 @@ const onShowMore = () => {
       <div class="allow-list-item" v-for="item in allowListItems" :key="item.id">
         <p>{{ item.email }}</p>
 
-        <button class="remove-from-allow-list-button" @click="onRemoveFromAllowList(item.id)" v-show="isManagingAllowList">
-          <ph-x size="16" />
+        <button class="remove-from-allow-list-button" @click="onRemoveFromAllowList(item.id)" v-show="isManagingAllowList" :aria-label="t('views.mail.views.securitySettings.removeFromAllowList')">
+          <ph-x size="16" aria-hidden="true" />
         </button>
       </div>
 

--- a/assets/app/vue/views/ManageMfaView/components/AuthenticationMethods.vue
+++ b/assets/app/vue/views/ManageMfaView/components/AuthenticationMethods.vue
@@ -101,7 +101,7 @@ onMounted(loadMfaMethods);
                   {{ methodData.set ? t('views.manageMfa.states.set') : t('views.manageMfa.states.notSet') }}
 
                   <template #icon v-if="methodData.set">
-                    <ph-check-circle size="16" weight="fill" />
+                    <ph-check-circle size="16" weight="fill" aria-hidden="true" />
                   </template>
                 </base-badge>
               </loading-skeleton>

--- a/assets/app/vue/views/ManageMfaView/components/VerifyYourIdentityModal.vue
+++ b/assets/app/vue/views/ManageMfaView/components/VerifyYourIdentityModal.vue
@@ -41,7 +41,7 @@ defineExpose({
 
     <div class="verify-your-identity-options">
       <div class="verify-option">
-        <span class="icon"><ph-key size="24" /></span>
+        <span class="icon"><ph-key size="24" aria-hidden="true" /></span>
         <span class="content">
           <span class="title">
             {{ t('views.manageMfa.modals.verifyYourIdentity.secondFactor') }}

--- a/assets/app/vue/views/SignUpView/components/SignUpLayout.vue
+++ b/assets/app/vue/views/SignUpView/components/SignUpLayout.vue
@@ -68,7 +68,7 @@ export default {
         <brand-button form-action="submit" data-testid="submit-button" class="submit" :disabled="submitDisabled"
           @click.prevent="onSubmit()">
           <template #iconRight>
-            <ph-arrow-right size="20" />
+            <ph-arrow-right size="20" aria-hidden="true" />
           </template>
           {{ submitTitle || $t('views.mail.views.signUp.continue') }}
         </brand-button>

--- a/assets/app/vue/views/SignUpView/index.vue
+++ b/assets/app/vue/views/SignUpView/index.vue
@@ -78,7 +78,7 @@ export default {
 
             <template #cta>
               <button :title="t('views.error.dismiss')" class="close-button" @click="errorMessage = null">
-                <ph-x size="16" />
+                <ph-x size="16" aria-hidden="true" />
               </button>
             </template>
           </notice-bar>


### PR DESCRIPTION
Fixes #1304.

Hides 46 decorative Phosphor icons from screen readers and gives 10 icon-only buttons accessible names.

What changed
- `aria-hidden="true"` on every decorative `ph-*` icon: status/info icons next to visible text, card/section header icons beside titles, copy-button icons (buttons already labeled), badge icons beside status text, and link/button trailing icons.
- `aria-label` on 10 icon-only buttons that previously exposed just an unlabeled icon: modal/notice dismiss buttons, both kebab menus, and the allow-list remove button. 4 new locale keys added (en is the only app locale); 2 cases reuse existing keys.

## QA Log
- Enumerated all 55 `ph-*` usages in `assets/app/vue` and checked each one's context: every tagged icon sits next to visible text, inside a titled card/section, or inside a button that now has (or already had) an accessible name.
- Skipped `DetailsSummary.vue`'s chevron on purpose: its parent span already carries `aria-hidden="true"", so it was covered.
- Verified no icon-only button is left without a name: searched all buttons whose only child is a `ph-*` icon and confirmed each has `aria-label` or `title`.
- Existing `aria-hidden` usages (warning icons in domain forms, accordion chevron, tab icons) left untouched.
- Gates: frontend vitest 17/17 pass, eslint clean on all touched files.